### PR TITLE
Method to get HEALPix pixels from Catalog

### DIFF
--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -5,6 +5,7 @@ from typing import Dict, Tuple, Type, cast
 
 import dask.dataframe as dd
 import hipscat as hc
+import pandas as pd
 from hipscat.pixel_math import HealpixPixel
 
 from lsdb.catalog.dataset.dataset import Dataset
@@ -46,6 +47,14 @@ class Catalog(Dataset):
         """
         super().__init__(ddf, hc_structure)
         self._ddf_pixel_map = ddf_pixel_map
+
+    def get_pixels(self) -> pd.DataFrame:
+        """Get all HEALPix pixels that are contained in the catalog
+
+        Returns:
+            Data frame with per-pixel data.
+        """
+        return self.hc_structure.get_pixels()
 
     def get_partition(self, order: int, pixel: int) -> dd.DataFrame:
         """Get the dask partition for a given HEALPix pixel

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -3,6 +3,12 @@ import pandas as pd
 from hipscat.pixel_math import HealpixPixel
 
 
+def test_catalog_pixels_equals_hc_catalog_pixels(small_sky_order1_catalog, small_sky_order1_hipscat_catalog):
+    pd.testing.assert_frame_equal(
+        small_sky_order1_catalog.get_pixels(), small_sky_order1_hipscat_catalog.get_pixels()
+    )
+
+
 def test_catalog_repr_equals_ddf_repr(small_sky_order1_catalog):
     assert repr(small_sky_order1_catalog) == repr(small_sky_order1_catalog._ddf)
 

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -16,7 +16,7 @@ def test_catalog_compute_equals_ddf_compute(small_sky_order1_catalog):
 
 
 def test_get_catalog_partition_gets_correct_partition(small_sky_order1_catalog):
-    for _, row in small_sky_order1_catalog.hc_structure.get_pixels().iterrows():
+    for _, row in small_sky_order1_catalog.get_pixels().iterrows():
         hp_order = row["Norder"]
         hp_pixel = row["Npix"]
         partition = small_sky_order1_catalog.get_partition(hp_order, hp_pixel)

--- a/tests/lsdb/catalog/test_cone_search.py
+++ b/tests/lsdb/catalog/test_cone_search.py
@@ -25,7 +25,7 @@ def test_cone_search_filters_partitions(small_sky_order1_catalog):
     radius = 20
     hc_conesearch = small_sky_order1_catalog.hc_structure.filter_by_cone(ra, dec, radius)
     consearch_catalog = small_sky_order1_catalog.cone_search(ra, dec, radius)
-    assert len(hc_conesearch.get_healpix_pixels()) == len(consearch_catalog.hc_structure.get_pixels())
+    assert len(hc_conesearch.get_healpix_pixels()) == len(consearch_catalog.get_pixels())
     assert len(hc_conesearch.get_healpix_pixels()) == consearch_catalog._ddf.npartitions
     print(hc_conesearch.get_healpix_pixels())
     for pixel in hc_conesearch.get_healpix_pixels():

--- a/tests/lsdb/loaders/hipscat/test_read_hipscat.py
+++ b/tests/lsdb/loaders/hipscat/test_read_hipscat.py
@@ -9,9 +9,7 @@ def test_read_hipscat(small_sky_order1_dir, small_sky_order1_hipscat_catalog):
     catalog = lsdb.read_hipscat(small_sky_order1_dir)
     assert isinstance(catalog, lsdb.Catalog)
     assert catalog.hc_structure.catalog_base_dir == small_sky_order1_hipscat_catalog.catalog_base_dir
-    pd.testing.assert_frame_equal(
-        catalog.hc_structure.get_pixels(), small_sky_order1_hipscat_catalog.get_pixels()
-    )
+    pd.testing.assert_frame_equal(catalog.get_pixels(), small_sky_order1_hipscat_catalog.get_pixels())
 
 
 def test_pixels_in_map_equal_catalog_pixels(small_sky_order1_dir, small_sky_order1_hipscat_catalog):
@@ -46,18 +44,14 @@ def test_read_hipscat_specify_catalog_type(small_sky_catalog, small_sky_dir):
     catalog = lsdb.read_hipscat(small_sky_dir, catalog_type=lsdb.Catalog)
     assert isinstance(catalog, lsdb.Catalog)
     pd.testing.assert_frame_equal(catalog.compute(), small_sky_catalog.compute())
-    pd.testing.assert_frame_equal(
-        catalog.hc_structure.get_pixels(), small_sky_catalog.hc_structure.get_pixels()
-    )
+    pd.testing.assert_frame_equal(catalog.get_pixels(), small_sky_catalog.get_pixels())
     assert catalog.hc_structure.catalog_info == small_sky_catalog.hc_structure.catalog_info
 
 
 def test_read_hipscat_no_parquet_metadata(small_sky_catalog, small_sky_no_metadata_dir):
     catalog = lsdb.read_hipscat(small_sky_no_metadata_dir)
     pd.testing.assert_frame_equal(catalog.compute(), small_sky_catalog.compute())
-    pd.testing.assert_frame_equal(
-        catalog.hc_structure.get_pixels(), small_sky_catalog.hc_structure.get_pixels()
-    )
+    pd.testing.assert_frame_equal(catalog.get_pixels(), small_sky_catalog.get_pixels())
     assert catalog.hc_structure.catalog_info == small_sky_catalog.hc_structure.catalog_info
 
 


### PR DESCRIPTION
Adds utility method to the LSDB catalog to access HEALPix pixels from the underlying HiPSCat catalog. The method was named `get_pixels` instead of `get_healpix_pixels` to keep the convention already in use by HiPSCat. Closes #21.