### PR TITLE
Run black formatting and remove `get_pixels`

### DIFF
--- a/cloud_tests/conftest.py
+++ b/cloud_tests/conftest.py
@@ -27,7 +27,7 @@ def pytest_generate_tests(metafunc):
     # This is called for every test. Only get/set command line arguments
     # if the argument is specified in the list of test "fixturenames".
     option_value = metafunc.config.option.cloud
-    if 'cloud' in metafunc.fixturenames and option_value is not None:
+    if "cloud" in metafunc.fixturenames and option_value is not None:
         metafunc.parametrize("cloud", [option_value])
 
 
@@ -35,7 +35,7 @@ def pytest_generate_tests(metafunc):
 def example_cloud_path(cloud):
     if cloud == "abfs":
         return "abfs:///hipscat/pytests/"
-    
+
     else:
         raise NotImplementedError("Cloud format not implemented for lsdb tests!")
 
@@ -44,8 +44,8 @@ def example_cloud_path(cloud):
 def example_cloud_storage_options(cloud):
     if cloud == "abfs":
         storage_options = {
-            "account_key" : os.environ.get("ABFS_LINCCDATA_ACCOUNT_KEY"),
-            "account_name" : os.environ.get("ABFS_LINCCDATA_ACCOUNT_NAME")
+            "account_key": os.environ.get("ABFS_LINCCDATA_ACCOUNT_KEY"),
+            "account_name": os.environ.get("ABFS_LINCCDATA_ACCOUNT_NAME"),
         }
         return storage_options
 
@@ -83,6 +83,7 @@ def small_sky_hipscat_catalog_cloud(small_sky_dir_cloud, example_cloud_storage_o
         small_sky_dir_cloud, storage_options=example_cloud_storage_options
     )
 
+
 @pytest.fixture
 def small_sky_catalog_cloud(small_sky_dir_cloud, example_cloud_storage_options):
     return lsdb.read_hipscat(small_sky_dir_cloud, storage_options=example_cloud_storage_options)
@@ -95,7 +96,9 @@ def small_sky_xmatch_catalog_cloud(small_sky_xmatch_dir_cloud, example_cloud_sto
 
 @pytest.fixture
 def small_sky_order1_hipscat_catalog_cloud(small_sky_order1_dir_cloud, example_cloud_storage_options):
-    return hc.catalog.Catalog.read_from_hipscat(small_sky_order1_dir_cloud, storage_options=example_cloud_storage_options)
+    return hc.catalog.Catalog.read_from_hipscat(
+        small_sky_order1_dir_cloud, storage_options=example_cloud_storage_options
+    )
 
 
 @pytest.fixture
@@ -107,14 +110,14 @@ def small_sky_order1_catalog_cloud(small_sky_order1_dir_cloud, example_cloud_sto
 def xmatch_correct_cloud(small_sky_xmatch_dir_cloud, example_cloud_storage_options):
     pathway = os.path.join(small_sky_xmatch_dir_cloud, XMATCH_CORRECT_FILE)
     return file_io.load_csv_to_pandas(pathway, storage_options=example_cloud_storage_options)
-    #return pd.read_csv(os.path.join(small_sky_xmatch_dir_cloud, XMATCH_CORRECT_FILE), storage_options=example_cloud_storage_options)
+    # return pd.read_csv(os.path.join(small_sky_xmatch_dir_cloud, XMATCH_CORRECT_FILE), storage_options=example_cloud_storage_options)
 
 
 @pytest.fixture
 def xmatch_correct_005_cloud(small_sky_xmatch_dir_cloud, example_cloud_storage_options):
     pathway = os.path.join(small_sky_xmatch_dir_cloud, XMATCH_CORRECT_005_FILE)
     return file_io.load_csv_to_pandas(pathway, storage_options=example_cloud_storage_options)
-    #return pd.read_csv(os.path.join(small_sky_xmatch_dir, XMATCH_CORRECT_005_FILE))
+    # return pd.read_csv(os.path.join(small_sky_xmatch_dir, XMATCH_CORRECT_005_FILE))
 
 
 @pytest.fixture

--- a/cloud_tests/copy_data_to_fs.py
+++ b/cloud_tests/copy_data_to_fs.py
@@ -4,10 +4,12 @@ from hipscat.io.file_io.file_io import get_fs
 
 
 def copy_tree_fs_to_fs(
-        fs1_source: str, fs2_destination: str,
-        storage_options1: dict = None, storage_options2: dict = None,
-        verbose=False
-    ):
+    fs1_source: str,
+    fs2_destination: str,
+    storage_options1: dict = None,
+    storage_options2: dict = None,
+    verbose=False,
+):
     """Recursive Copies directory from one filesystem to the other.
 
     Args:
@@ -22,7 +24,7 @@ def copy_tree_fs_to_fs(
     copy_dir(source_fs, source_fp, destination_fs, desintation_fp, verbose=verbose)
 
 
-def copy_dir(source_fs, source_fp, destination_fs, desintation_fp, verbose=False, chunksize=1024*1024):
+def copy_dir(source_fs, source_fp, destination_fs, desintation_fp, verbose=False, chunksize=1024 * 1024):
     """Recursive method to copy directories and their contents.
 
     Args:
@@ -56,17 +58,18 @@ def copy_dir(source_fs, source_fp, destination_fs, desintation_fp, verbose=False
 
     dirs = [x for x in dir_contents if x["type"] == "directory"]
     for _dir in dirs:
-        copy_dir(source_fs, _dir["name"], destination_fs, destination_folder, chunksize=chunksize, verbose=verbose)
+        copy_dir(
+            source_fs, _dir["name"], destination_fs, destination_folder, chunksize=chunksize, verbose=verbose
+        )
+
 
 if __name__ == "__main__":
-    
+
     source_pw = f"{os.getcwd()}/../tests/data"
     target_pw = "new_protocol:///path/to/pytest/lsdb"
 
     target_so = {
-        "valid_storage_option_param1" : os.environ.get("NEW_PROTOCOL_PARAM1"),
-        "valid_storage_option_param1" : os.environ.get("NEW_PROTOCOL_PARAM2"),
+        "valid_storage_option_param1": os.environ.get("NEW_PROTOCOL_PARAM1"),
+        "valid_storage_option_param1": os.environ.get("NEW_PROTOCOL_PARAM2"),
     }
-    copy_tree_fs_to_fs(
-        source_pw, target_pw, {}, target_so, verbose=True
-    )
+    copy_tree_fs_to_fs(source_pw, target_pw, {}, target_so, verbose=True)

--- a/cloud_tests/lsdb/catalog/test_catalog.py
+++ b/cloud_tests/lsdb/catalog/test_catalog.py
@@ -12,13 +12,15 @@ def test_catalog_html_repr_equals_ddf_html_repr(small_sky_order1_catalog_cloud):
 
 
 def test_catalog_compute_equals_ddf_compute(small_sky_order1_catalog_cloud):
-    pd.testing.assert_frame_equal(small_sky_order1_catalog_cloud.compute(), small_sky_order1_catalog_cloud._ddf.compute())
+    pd.testing.assert_frame_equal(
+        small_sky_order1_catalog_cloud.compute(), small_sky_order1_catalog_cloud._ddf.compute()
+    )
 
 
 def test_get_catalog_partition_gets_correct_partition(small_sky_order1_catalog_cloud):
-    for _, row in small_sky_order1_catalog_cloud.hc_structure.get_pixels().iterrows():
-        hp_order = row["Norder"]
-        hp_pixel = row["Npix"]
+    for pixel in small_sky_order1_catalog_cloud.hc_structure.get_healpix_pixels:
+        hp_order = pixel.order
+        hp_pixel = pixel.pixel
         partition = small_sky_order1_catalog_cloud.get_partition(hp_order, hp_pixel)
         pixel = HealpixPixel(order=hp_order, pixel=hp_pixel)
         partition_index = small_sky_order1_catalog_cloud._ddf_pixel_map[pixel]

--- a/cloud_tests/lsdb/catalog/test_cone_search.py
+++ b/cloud_tests/lsdb/catalog/test_cone_search.py
@@ -6,13 +6,13 @@ def test_cone_search_filters_correct_points(small_sky_order1_catalog_cloud):
     ra = 0
     dec = -80
     radius = 20
-    center_coord = SkyCoord(ra, dec, unit='deg')
+    center_coord = SkyCoord(ra, dec, unit="deg")
     cone_search_catalog = small_sky_order1_catalog_cloud.cone_search(ra, dec, radius).compute()
     print(len(cone_search_catalog))
     for _, row in small_sky_order1_catalog_cloud.compute().iterrows():
         row_ra = row[small_sky_order1_catalog_cloud.hc_structure.catalog_info.ra_column]
         row_dec = row[small_sky_order1_catalog_cloud.hc_structure.catalog_info.dec_column]
-        sep = SkyCoord(row_ra, row_dec, unit='deg').separation(center_coord)
+        sep = SkyCoord(row_ra, row_dec, unit="deg").separation(center_coord)
         if sep.degree <= radius:
             assert len(cone_search_catalog.loc[cone_search_catalog["id"] == row["id"]]) == 1
         else:
@@ -25,7 +25,7 @@ def test_cone_search_filters_partitions(small_sky_order1_catalog_cloud):
     radius = 20
     hc_conesearch = small_sky_order1_catalog_cloud.hc_structure.filter_by_cone(ra, dec, radius)
     consearch_catalog = small_sky_order1_catalog_cloud.cone_search(ra, dec, radius)
-    assert len(hc_conesearch.get_healpix_pixels()) == len(consearch_catalog.hc_structure.get_pixels())
+    assert len(hc_conesearch.get_healpix_pixels()) == len(consearch_catalog.get_healpix_pixels())
     assert len(hc_conesearch.get_healpix_pixels()) == consearch_catalog._ddf.npartitions
     print(hc_conesearch.get_healpix_pixels())
     for pixel in hc_conesearch.get_healpix_pixels():

--- a/cloud_tests/lsdb/catalog/test_crossmatch.py
+++ b/cloud_tests/lsdb/catalog/test_crossmatch.py
@@ -14,7 +14,9 @@ def test_kdtree_crossmatch(small_sky_catalog_cloud, small_sky_xmatch_catalog_clo
         assert xmatch_row["_DIST"].values == pytest.approx(correct_row["dist"])
 
 
-def test_kdtree_crossmatch_thresh(small_sky_catalog_cloud, small_sky_xmatch_catalog_cloud, xmatch_correct_005_cloud):
+def test_kdtree_crossmatch_thresh(
+    small_sky_catalog_cloud, small_sky_xmatch_catalog_cloud, xmatch_correct_005_cloud
+):
     xmatched = small_sky_catalog_cloud.crossmatch(small_sky_xmatch_catalog_cloud, d_thresh=0.005).compute()
     assert len(xmatched) == len(xmatch_correct_005_cloud)
     for _, correct_row in xmatch_correct_005_cloud.iterrows():
@@ -27,7 +29,9 @@ def test_kdtree_crossmatch_thresh(small_sky_catalog_cloud, small_sky_xmatch_cata
 def test_kdtree_crossmatch_multiple_neighbors(
     small_sky_catalog_cloud, small_sky_xmatch_catalog_cloud, xmatch_correct_3n_2t_no_margin_cloud
 ):
-    xmatched = small_sky_catalog_cloud.crossmatch(small_sky_xmatch_catalog_cloud, n_neighbors=3, d_thresh=2).compute()
+    xmatched = small_sky_catalog_cloud.crossmatch(
+        small_sky_xmatch_catalog_cloud, n_neighbors=3, d_thresh=2
+    ).compute()
     assert len(xmatched) == len(xmatch_correct_3n_2t_no_margin_cloud)
     for _, correct_row in xmatch_correct_3n_2t_no_margin_cloud.iterrows():
         assert correct_row["ss_id"] in xmatched["id_small_sky"].values
@@ -39,7 +43,9 @@ def test_kdtree_crossmatch_multiple_neighbors(
         assert xmatch_row["_DIST"].values == pytest.approx(correct_row["dist"])
 
 
-def test_custom_crossmatch_algorithm(small_sky_catalog_cloud, small_sky_xmatch_catalog_cloud, xmatch_mock_cloud):
+def test_custom_crossmatch_algorithm(
+    small_sky_catalog_cloud, small_sky_xmatch_catalog_cloud, xmatch_mock_cloud
+):
     xmatched = small_sky_catalog_cloud.crossmatch(
         small_sky_xmatch_catalog_cloud, algorithm=MockCrossmatchAlgorithm, mock_results=xmatch_mock_cloud
     ).compute()

--- a/cloud_tests/lsdb/loaders/hipscat/test_read_hipscat.py
+++ b/cloud_tests/lsdb/loaders/hipscat/test_read_hipscat.py
@@ -5,21 +5,21 @@ import pytest
 import lsdb
 
 
-def test_read_hipscat(small_sky_order1_dir_cloud, small_sky_order1_hipscat_catalog_cloud, example_cloud_storage_options):
+def test_read_hipscat(
+    small_sky_order1_dir_cloud, small_sky_order1_hipscat_catalog_cloud, example_cloud_storage_options
+):
     catalog = lsdb.read_hipscat(small_sky_order1_dir_cloud, storage_options=example_cloud_storage_options)
     assert isinstance(catalog, lsdb.Catalog)
     assert catalog.hc_structure.catalog_base_dir == small_sky_order1_hipscat_catalog_cloud.catalog_base_dir
-    pd.testing.assert_frame_equal(
-        catalog.hc_structure.get_pixels(), small_sky_order1_hipscat_catalog_cloud.get_pixels()
-    )
+    assert catalog.get_healpix_pixels() == small_sky_order1_hipscat_catalog_cloud.get_healpix_pixels()
 
 
-def test_pixels_in_map_equal_catalog_pixels(small_sky_order1_dir_cloud, small_sky_order1_hipscat_catalog_cloud, example_cloud_storage_options):
+def test_pixels_in_map_equal_catalog_pixels(
+    small_sky_order1_dir_cloud, small_sky_order1_hipscat_catalog_cloud, example_cloud_storage_options
+):
     catalog = lsdb.read_hipscat(small_sky_order1_dir_cloud, storage_options=example_cloud_storage_options)
-    for _, row in small_sky_order1_hipscat_catalog_cloud.get_pixels().iterrows():
-        hp_order = row["Norder"]
-        hp_pixel = row["Npix"]
-        catalog.get_partition(hp_order, hp_pixel)
+    for healpix_pixel in small_sky_order1_hipscat_catalog_cloud.get_healpix_pixels():
+        catalog.get_partition(healpix_pixel.order, healpix_pixel.pixel)
 
 
 def test_wrong_pixel_raises_value_error(small_sky_order1_dir_cloud, example_cloud_storage_options):
@@ -28,11 +28,13 @@ def test_wrong_pixel_raises_value_error(small_sky_order1_dir_cloud, example_clou
         catalog.get_partition(-1, -1)
 
 
-def test_parquet_data_in_partitions_match_files(small_sky_order1_dir_cloud, small_sky_order1_hipscat_catalog_cloud, example_cloud_storage_options):
+def test_parquet_data_in_partitions_match_files(
+    small_sky_order1_dir_cloud, small_sky_order1_hipscat_catalog_cloud, example_cloud_storage_options
+):
     catalog = lsdb.read_hipscat(small_sky_order1_dir_cloud, storage_options=example_cloud_storage_options)
-    for _, row in small_sky_order1_hipscat_catalog_cloud.get_pixels().iterrows():
-        hp_order = row["Norder"]
-        hp_pixel = row["Npix"]
+    for healpix_pixel in small_sky_order1_hipscat_catalog_cloud.get_healpix_pixels():
+        hp_order = healpix_pixel.order
+        hp_pixel = healpix_pixel.pixel
         partition = catalog.get_partition(hp_order, hp_pixel)
         partition_df = partition.compute()
         parquet_path = hc.io.paths.pixel_catalog_file(
@@ -42,22 +44,26 @@ def test_parquet_data_in_partitions_match_files(small_sky_order1_dir_cloud, smal
         pd.testing.assert_frame_equal(partition_df, loaded_df)
 
 
-def test_read_hipscat_specify_catalog_type(small_sky_catalog_cloud, small_sky_dir_cloud, example_cloud_storage_options):
-    catalog = lsdb.read_hipscat(small_sky_dir_cloud, catalog_type=lsdb.Catalog, storage_options=example_cloud_storage_options)
+def test_read_hipscat_specify_catalog_type(
+    small_sky_catalog_cloud, small_sky_dir_cloud, example_cloud_storage_options
+):
+    catalog = lsdb.read_hipscat(
+        small_sky_dir_cloud, catalog_type=lsdb.Catalog, storage_options=example_cloud_storage_options
+    )
     assert isinstance(catalog, lsdb.Catalog)
     pd.testing.assert_frame_equal(catalog.compute(), small_sky_catalog_cloud.compute())
-    pd.testing.assert_frame_equal(
-        catalog.hc_structure.get_pixels(), small_sky_catalog_cloud.hc_structure.get_pixels()
-    )
+    assert catalog.hc_structure.get_healpix_pixels() == small_sky_catalog_cloud.get_healpix_pixels()
     assert catalog.hc_structure.catalog_info == small_sky_catalog_cloud.hc_structure.catalog_info
 
 
-def test_read_hipscat_no_parquet_metadata(small_sky_catalog_cloud, small_sky_no_metadata_dir_cloud, example_cloud_storage_options):
-    catalog = lsdb.read_hipscat(small_sky_no_metadata_dir_cloud, storage_options=example_cloud_storage_options)
-    pd.testing.assert_frame_equal(catalog.compute(), small_sky_catalog_cloud.compute())
-    pd.testing.assert_frame_equal(
-        catalog.hc_structure.get_pixels(), small_sky_catalog_cloud.hc_structure.get_pixels()
+def test_read_hipscat_no_parquet_metadata(
+    small_sky_catalog_cloud, small_sky_no_metadata_dir_cloud, example_cloud_storage_options
+):
+    catalog = lsdb.read_hipscat(
+        small_sky_no_metadata_dir_cloud, storage_options=example_cloud_storage_options
     )
+    pd.testing.assert_frame_equal(catalog.compute(), small_sky_catalog_cloud.compute())
+    assert catalog.hc_structure.get_healpix_pixels() == small_sky_catalog_cloud.get_healpix_pixels()
     assert catalog.hc_structure.catalog_info == small_sky_catalog_cloud.hc_structure.catalog_info
 
 

--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -27,13 +27,13 @@ class DataframeCatalogLoader:
     DEFAULT_THRESHOLD = 100_000
 
     def __init__(
-            self,
-            df: pd.DataFrame,
-            lowest_order: int = 0,
-            highest_order: int = 5,
-            partition_size: float | None = None,
-            threshold: int | None = None,
-            **kwargs,
+        self,
+        df: pd.DataFrame,
+        lowest_order: int = 0,
+        highest_order: int = 5,
+        partition_size: float | None = None,
+        threshold: int | None = None,
+        **kwargs,
     ) -> None:
         """Initializes a DataframeCatalogLoader
 

--- a/src/lsdb/loaders/dataframe/from_dataframe.py
+++ b/src/lsdb/loaders/dataframe/from_dataframe.py
@@ -7,7 +7,7 @@ from lsdb.loaders.dataframe.dataframe_catalog_loader import DataframeCatalogLoad
 
 
 def from_dataframe(
-    df: pd.DataFrame,
+    dataframe: pd.DataFrame,
     lowest_order: int = 0,
     highest_order: int = 5,
     partition_size: float | None = None,
@@ -17,7 +17,7 @@ def from_dataframe(
     """Load a catalog from a Pandas Dataframe in CSV format.
 
     Args:
-        df (pd.Dataframe): The catalog Pandas Dataframe
+        dataframe (pd.Dataframe): The catalog Pandas Dataframe
         lowest_order (int): The lowest partition order
         highest_order (int): The highest partition order
         partition_size (float): The desired partition size, in megabytes
@@ -27,5 +27,7 @@ def from_dataframe(
     Returns:
         Catalog object loaded from the given parameters
     """
-    loader = DataframeCatalogLoader(df, lowest_order, highest_order, partition_size, threshold, **kwargs)
+    loader = DataframeCatalogLoader(
+        dataframe, lowest_order, highest_order, partition_size, threshold, **kwargs
+    )
     return loader.load_catalog()

--- a/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
@@ -15,8 +15,8 @@ class HipscatCatalogLoader:
     """Loads a HiPSCat formatted Catalog"""
 
     def __init__(
-            self, path: str, config: HipscatLoadingConfig,
-            storage_options: Union[Dict[Any, Any], None] = None) -> None:
+        self, path: str, config: HipscatLoadingConfig, storage_options: Union[Dict[Any, Any], None] = None
+    ) -> None:
         """Initializes a HipscatCatalogLoader
 
         Args:
@@ -80,7 +80,7 @@ class HipscatCatalogLoader:
             file_io.read_parquet_file_to_pandas,
             paths,
             storage_options=self.storage_options,
-            meta=dask_meta_schema
+            meta=dask_meta_schema,
         )
         return ddf
 

--- a/src/lsdb/loaders/hipscat/hipscat_loader_factory.py
+++ b/src/lsdb/loaders/hipscat/hipscat_loader_factory.py
@@ -14,8 +14,10 @@ loader_class_for_catalog_type: Dict[Type[Dataset], Type[HipscatCatalogLoader]] =
 
 
 def get_loader_for_type(
-    catalog_type_to_use: Type[CatalogTypeVar], path: str, config: HipscatLoadingConfig,
-    storage_options: Union[Dict[Any, Any], None] = None
+    catalog_type_to_use: Type[CatalogTypeVar],
+    path: str,
+    config: HipscatLoadingConfig,
+    storage_options: Union[Dict[Any, Any], None] = None,
 ) -> HipscatCatalogLoader:
     """Constructs a CatalogLoader that loads a Dataset of the specified type
 

--- a/src/lsdb/loaders/hipscat/read_hipscat.py
+++ b/src/lsdb/loaders/hipscat/read_hipscat.py
@@ -54,7 +54,7 @@ def read_hipscat(
 
 
 def _get_dataset_class_from_catalog_info(
-    base_catalog_path: str, storage_options: dict = None
+    base_catalog_path: str, storage_options: Union[Dict[Any, Any], None] = None
 ) -> Type[Dataset]:
     base_catalog_dir = hc.io.get_file_pointer_from_path(base_catalog_path)
     catalog_info_path = hc.io.paths.get_catalog_info_pointer(base_catalog_dir)

--- a/src/lsdb/loaders/hipscat/read_hipscat.py
+++ b/src/lsdb/loaders/hipscat/read_hipscat.py
@@ -21,7 +21,7 @@ dataset_class_for_catalog_type: Dict[CatalogType, Type[Dataset]] = {
 def read_hipscat(
     path: str,
     catalog_type: Type[CatalogTypeVar] | None = None,
-    storage_options: Union[Dict[Any, Any], None] = None
+    storage_options: Union[Dict[Any, Any], None] = None,
 ) -> CatalogTypeVar | Dataset:
     """Load a catalog from a HiPSCat formatted catalog.
 
@@ -54,8 +54,8 @@ def read_hipscat(
 
 
 def _get_dataset_class_from_catalog_info(
-        base_catalog_path: str, storage_options: dict = None
-    ) -> Type[Dataset]:
+    base_catalog_path: str, storage_options: dict = None
+) -> Type[Dataset]:
     base_catalog_dir = hc.io.get_file_pointer_from_path(base_catalog_path)
     catalog_info_path = hc.io.paths.get_catalog_info_pointer(base_catalog_dir)
     catalog_info = BaseCatalogInfo.read_from_metadata_file(catalog_info_path, storage_options=storage_options)

--- a/src/lsdb/loaders/hipscat/read_hipscat.pyi
+++ b/src/lsdb/loaders/hipscat/read_hipscat.pyi
@@ -20,6 +20,5 @@ from lsdb.loaders.hipscat.hipscat_loader_factory import CatalogTypeVar
 def read_hipscat(path: str, storage_options: Union[Dict[Any, Any], None] = None) -> Dataset: ...
 @overload
 def read_hipscat(
-    path: str, catalog_type: Type[CatalogTypeVar],
-    storage_options: Union[Dict[Any, Any], None] = None
+    path: str, catalog_type: Type[CatalogTypeVar], storage_options: Union[Dict[Any, Any], None] = None
 ) -> CatalogTypeVar: ...

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -60,6 +60,7 @@ def test_wrong_suffixes(small_sky_catalog, small_sky_xmatch_catalog):
 # pylint: disable=too-few-public-methods
 class MockCrossmatchAlgorithm(AbstractCrossmatchAlgorithm):
     """Mock class used to test a crossmatch algorithm"""
+
     def crossmatch(self, mock_results: pd.DataFrame = None):
         left_reset = self.left.reset_index(drop=True)
         right_reset = self.right.reset_index(drop=True)

--- a/tests/lsdb/loaders/dataframe/test_from_dataframe.py
+++ b/tests/lsdb/loaders/dataframe/test_from_dataframe.py
@@ -79,8 +79,7 @@ def test_partitions_in_partition_info_equal_partitions_on_map(small_sky_order1_d
     """Tests that partitions in the partition info match those on the partition map"""
     kwargs = get_catalog_kwargs(small_sky_order1_catalog)
     catalog = lsdb.from_dataframe(small_sky_order1_df, **kwargs)
-    for _, row in catalog.hc_structure.get_pixels().iterrows():
-        hp_pixel = HealpixPixel(row["Norder"], row["Npix"])
+    for hp_pixel in catalog.hc_structure.get_healpix_pixels():
         partition_from_df = catalog.get_partition(hp_pixel.order, hp_pixel.pixel)
         partition_index = catalog._ddf_pixel_map[hp_pixel]
         partition_from_map = catalog._ddf.partitions[partition_index]

--- a/tests/lsdb/loaders/dataframe/test_from_dataframe.py
+++ b/tests/lsdb/loaders/dataframe/test_from_dataframe.py
@@ -2,7 +2,6 @@ import healpy as hp
 import pandas as pd
 import pytest
 from hipscat.catalog import CatalogType
-from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_tree.pixel_node_type import PixelNodeType
 
 import lsdb


### PR DESCRIPTION
Mechanical application of black. 

Meaningful changes are primarily in test files to remove assertions on `get_pixels` dataframe and replaces with checks against `get_healpix_pixels() -> List[HealpixPixel]`.