### PR TITLE
Add kwargs to read_hipscat to filter columns

### DIFF
--- a/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
@@ -78,12 +78,14 @@ class HipscatCatalogLoader:
         dask_meta_schema = metadata_schema.empty_table().to_pandas()
         if self.config.columns:
             dask_meta_schema = dask_meta_schema[self.config.columns]
+        kwargs = self.config.kwargs if self.config.kwargs is not None else {}
         ddf = dd.from_map(
             file_io.read_parquet_file_to_pandas,
             paths,
             storage_options=self.storage_options,
             meta=dask_meta_schema,
-            **self.config.as_dict(),
+            columns=self.config.columns,
+            **kwargs,
         )
         return ddf
 

--- a/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
@@ -78,14 +78,13 @@ class HipscatCatalogLoader:
         dask_meta_schema = metadata_schema.empty_table().to_pandas()
         if self.config.columns:
             dask_meta_schema = dask_meta_schema[self.config.columns]
-        kwargs = self.config.kwargs if self.config.kwargs is not None else {}
         ddf = dd.from_map(
             file_io.read_parquet_file_to_pandas,
             paths,
             storage_options=self.storage_options,
             meta=dask_meta_schema,
             columns=self.config.columns,
-            **kwargs,
+            **self.config.get_kwargs_dict(),
         )
         return ddf
 

--- a/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
@@ -76,11 +76,14 @@ class HipscatCatalogLoader:
     ) -> dd.DataFrame:
         metadata_schema = self._load_parquet_metadata_schema(catalog)
         dask_meta_schema = metadata_schema.empty_table().to_pandas()
+        if self.config.columns:
+            dask_meta_schema = dask_meta_schema[self.config.columns]
         ddf = dd.from_map(
             file_io.read_parquet_file_to_pandas,
             paths,
             storage_options=self.storage_options,
             meta=dask_meta_schema,
+            **self.config.as_dict(),
         )
         return ddf
 

--- a/src/lsdb/loaders/hipscat/hipscat_loading_config.py
+++ b/src/lsdb/loaders/hipscat/hipscat_loading_config.py
@@ -12,20 +12,6 @@ class HipscatLoadingConfig:
     columns: Union[List[str],None] = None
     """Columns to load from the catalog - if not specified, all columns are loaded"""
 
-    required_fields: List[str] = dataclasses.field(default_factory=list)
-    """Required parameters for loading the catalog"""
-
-    def __post_init__(self):
-        self._check_required_fields()
-
-    def _check_required_fields(self):
-        fields_dict = dataclasses.asdict(self)
-        for field_name in self.required_fields:
-            if field_name not in fields_dict or fields_dict[field_name] is None:
-                raise ValueError(f"{field_name} is required to load the Catalog and a value must be provided")
-
     def as_dict(self) -> dict:
         """Returns the HipscatLoadingConfig as a dictionary"""
-        config = dataclasses.asdict(self)
-        del config["required_fields"]
-        return config
+        return dataclasses.asdict(self)

--- a/src/lsdb/loaders/hipscat/hipscat_loading_config.py
+++ b/src/lsdb/loaders/hipscat/hipscat_loading_config.py
@@ -1,6 +1,7 @@
-import dataclasses
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import List, Union
+from typing import List
 
 
 @dataclass
@@ -9,9 +10,8 @@ class HipscatLoadingConfig:
 
     Contains all parameters needed for a user to specify how to correctly read a hipscat catalog.
     """
-    columns: Union[List[str],None] = None
+    columns: List[str] | None = None
     """Columns to load from the catalog - if not specified, all columns are loaded"""
 
-    def as_dict(self) -> dict:
-        """Returns the HipscatLoadingConfig as a dictionary"""
-        return dataclasses.asdict(self)
+    kwargs: dict | None = None
+    """Extra kwargs"""

--- a/src/lsdb/loaders/hipscat/hipscat_loading_config.py
+++ b/src/lsdb/loaders/hipscat/hipscat_loading_config.py
@@ -15,3 +15,7 @@ class HipscatLoadingConfig:
 
     kwargs: dict | None = None
     """Extra kwargs"""
+
+    def get_kwargs_dict(self) -> dict:
+        """Returns a dictionary with the extra kwargs"""
+        return self.kwargs if self.kwargs is not None else {}

--- a/src/lsdb/loaders/hipscat/hipscat_loading_config.py
+++ b/src/lsdb/loaders/hipscat/hipscat_loading_config.py
@@ -1,4 +1,6 @@
+import dataclasses
 from dataclasses import dataclass
+from typing import List, Union
 
 
 @dataclass
@@ -7,5 +9,23 @@ class HipscatLoadingConfig:
 
     Contains all parameters needed for a user to specify how to correctly read a hipscat catalog.
     """
+    columns: Union[List[str],None] = None
+    """Columns to load from the catalog - if not specified, all columns are loaded"""
 
-    pass
+    required_fields: List[str] = dataclasses.field(default_factory=list)
+    """Required parameters for loading the catalog"""
+
+    def __post_init__(self):
+        self._check_required_fields()
+
+    def _check_required_fields(self):
+        fields_dict = dataclasses.asdict(self)
+        for field_name in self.required_fields:
+            if field_name not in fields_dict or fields_dict[field_name] is None:
+                raise ValueError(f"{field_name} is required to load the Catalog and a value must be provided")
+
+    def as_dict(self) -> dict:
+        """Returns the HipscatLoadingConfig as a dictionary"""
+        config = dataclasses.asdict(self)
+        del config["required_fields"]
+        return config

--- a/src/lsdb/loaders/hipscat/read_hipscat.py
+++ b/src/lsdb/loaders/hipscat/read_hipscat.py
@@ -46,11 +46,7 @@ def read_hipscat(
         Catalog object loaded from the given parameters
     """
 
-    # Creates a config object to store loading parameters from all keyword arguments. I
-    # originally had a few parameters in here, but after changing the file loading implementation
-    # they weren't needed, so this object is now empty. But I wanted to keep this here for future
-    # use
-    # all_kwd_args = locals().copy()
+    # Creates a config object to store loading parameters from all keyword arguments.
     kwd_args = locals().copy()
     config_args = {field.name: kwd_args[field.name] for field in dataclasses.fields(HipscatLoadingConfig)}
     config = HipscatLoadingConfig(**config_args)

--- a/src/lsdb/loaders/hipscat/read_hipscat.py
+++ b/src/lsdb/loaders/hipscat/read_hipscat.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import dataclasses
 from typing import Any, Dict, Type, Union
 
 import hipscat as hc
@@ -21,7 +20,8 @@ dataset_class_for_catalog_type: Dict[CatalogType, Type[Dataset]] = {
 def read_hipscat(
     path: str,
     catalog_type: Type[CatalogTypeVar] | None = None,
-    storage_options: Union[Dict[Any, Any], None] = None,
+    storage_options: dict | None = None,
+    **kwargs,
 ) -> CatalogTypeVar | Dataset:
     """Load a catalog from a HiPSCat formatted catalog.
 
@@ -32,6 +32,9 @@ def read_hipscat(
             cannot allow a return type specified by a loaded value, so to use the correct return
             type for type checking, the type of the catalog can be specified here. Use by specifying
             the lsdb class for that catalog.
+        storage_options (dict): Dictionary that contains abstract filesystem credentials
+        **kwargs: Arguments to pass to the parquet file readers
+
     Returns:
         Catalog object loaded from the given parameters
     """
@@ -40,9 +43,8 @@ def read_hipscat(
     # originally had a few parameters in here, but after changing the file loading implementation
     # they weren't needed, so this object is now empty. But I wanted to keep this here for future
     # use
-    kwd_args = locals().copy()
-    config_args = {field.name: kwd_args[field.name] for field in dataclasses.fields(HipscatLoadingConfig)}
-    config = HipscatLoadingConfig(**config_args)
+    # all_kwd_args = locals().copy()
+    config = HipscatLoadingConfig(**kwargs)
 
     catalog_type_to_use = _get_dataset_class_from_catalog_info(path, storage_options=storage_options)
 

--- a/src/lsdb/loaders/hipscat/read_hipscat.py
+++ b/src/lsdb/loaders/hipscat/read_hipscat.py
@@ -25,6 +25,9 @@ def read_hipscat(
 ) -> CatalogTypeVar | Dataset:
     """Load a catalog from a HiPSCat formatted catalog.
 
+    Typical usage example, where we load a catalog with a subset of columns:
+        lsdb.read_hipscat(path="./my_catalog_dir", catalog_type=lsdb.Catalog, columns=["ra","dec"])
+
     Args:
         path (str): The path that locates the root of the HiPSCat catalog
         catalog_type (Type[Dataset]): Default `None`. By default, the type of the catalog is loaded

--- a/src/lsdb/loaders/hipscat/read_hipscat.py
+++ b/src/lsdb/loaders/hipscat/read_hipscat.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Type, Union
+import dataclasses
+from typing import Any, Dict, List, Type, Union
 
 import hipscat as hc
 from hipscat.catalog import CatalogType
@@ -17,10 +18,12 @@ dataset_class_for_catalog_type: Dict[CatalogType, Type[Dataset]] = {
 }
 
 
+# pylint: disable=unused-argument
 def read_hipscat(
     path: str,
     catalog_type: Type[CatalogTypeVar] | None = None,
     storage_options: dict | None = None,
+    columns: List[str] | None = None,
     **kwargs,
 ) -> CatalogTypeVar | Dataset:
     """Load a catalog from a HiPSCat formatted catalog.
@@ -36,7 +39,8 @@ def read_hipscat(
             type for type checking, the type of the catalog can be specified here. Use by specifying
             the lsdb class for that catalog.
         storage_options (dict): Dictionary that contains abstract filesystem credentials
-        **kwargs: Arguments to pass to the parquet file readers
+        columns (List[str]): Default `None`. The set of columns to filter the catalog on.
+        **kwargs: Arguments to pass to the pandas parquet file reader
 
     Returns:
         Catalog object loaded from the given parameters
@@ -47,7 +51,9 @@ def read_hipscat(
     # they weren't needed, so this object is now empty. But I wanted to keep this here for future
     # use
     # all_kwd_args = locals().copy()
-    config = HipscatLoadingConfig(**kwargs)
+    kwd_args = locals().copy()
+    config_args = {field.name: kwd_args[field.name] for field in dataclasses.fields(HipscatLoadingConfig)}
+    config = HipscatLoadingConfig(**config_args)
 
     catalog_type_to_use = _get_dataset_class_from_catalog_info(path, storage_options=storage_options)
 

--- a/tests/lsdb/loaders/hipscat/test_read_hipscat.py
+++ b/tests/lsdb/loaders/hipscat/test_read_hipscat.py
@@ -1,4 +1,5 @@
 import hipscat as hc
+import numpy.testing as npt
 import pandas as pd
 import pytest
 
@@ -10,6 +11,14 @@ def test_read_hipscat(small_sky_order1_dir, small_sky_order1_hipscat_catalog):
     assert isinstance(catalog, lsdb.Catalog)
     assert catalog.hc_structure.catalog_base_dir == small_sky_order1_hipscat_catalog.catalog_base_dir
     assert catalog.get_healpix_pixels() == small_sky_order1_hipscat_catalog.get_healpix_pixels()
+    assert len(catalog.compute().columns) == 8
+
+
+def test_read_hipscat_with_columns(small_sky_order1_dir):
+    filter_columns = ["ra", "dec"]
+    catalog = lsdb.read_hipscat(small_sky_order1_dir, columns=filter_columns)
+    assert isinstance(catalog, lsdb.Catalog)
+    npt.assert_array_equal(catalog.compute().columns.values, filter_columns)
 
 
 def test_pixels_in_map_equal_catalog_pixels(small_sky_order1_dir, small_sky_order1_hipscat_catalog):

--- a/tests/lsdb/loaders/hipscat/test_read_hipscat.py
+++ b/tests/lsdb/loaders/hipscat/test_read_hipscat.py
@@ -1,4 +1,5 @@
 import hipscat as hc
+import numpy as np
 import numpy.testing as npt
 import pandas as pd
 import pytest
@@ -19,6 +20,11 @@ def test_read_hipscat_with_columns(small_sky_order1_dir):
     catalog = lsdb.read_hipscat(small_sky_order1_dir, columns=filter_columns)
     assert isinstance(catalog, lsdb.Catalog)
     npt.assert_array_equal(catalog.compute().columns.values, filter_columns)
+
+def test_read_hipscat_with_extra_kwargs(small_sky_order1_dir):
+    catalog = lsdb.read_hipscat(small_sky_order1_dir, filters=[("ra", ">", 300)], engine="pyarrow")
+    assert isinstance(catalog, lsdb.Catalog)
+    assert np.greater(catalog.compute()["ra"].values, 300).all()
 
 
 def test_pixels_in_map_equal_catalog_pixels(small_sky_order1_dir, small_sky_order1_hipscat_catalog):


### PR DESCRIPTION
Adds kwargs to `read_hipscat` and tests the loading of a HiPSCat catalog using a subset of columns. Closes #78. 