### PR TITLE
Fix access to "ra" and "dec" values in `from_dataframe`

### DIFF
--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -109,8 +109,8 @@ class DataframeCatalogLoader:
         """Generates the hipscat indices for each data point and assigns
         the hipscat index column as the Dataframe index."""
         self.dataframe[HIPSCAT_ID_COLUMN] = compute_hipscat_id(
-            ra_values=self.dataframe[self.catalog_info.ra_column],
-            dec_values=self.dataframe[self.catalog_info.dec_column],
+            ra_values=self.dataframe[self.catalog_info.ra_column].values,
+            dec_values=self.dataframe[self.catalog_info.dec_column].values,
         )
         self.dataframe.set_index(HIPSCAT_ID_COLUMN, inplace=True)
 


### PR DESCRIPTION
It fixes the access to the "ra" and "dec" column values when computing the `hipscat_id` in `from_dataframe()`.