### PR TITLE
Update README.md - fix link to the LINCC logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://www.lsstcorporation.org/lincc/sites/default/files/PastedGraphic-8.png" width="300" height="100">
+<img src="https://github.com/lincc-frameworks/tape/blob/main/docs/DARK_Combo_sm.png?raw=true" width="300" height="100">
 <img src="https://user-images.githubusercontent.com/113376043/211332292-4705c34c-5e74-4f12-85e2-be4bacaa8700.jpg" width="300">
 
 # LSDB


### PR DESCRIPTION
The link to the logo in the readme.md file was broken. It was pointing to the LSST Corporation website, and the website got a complete remodel when moving to Discovery Alliance. The link is now pointing to the image hosted with repo of TAPE project. 