### PR TITLE
Allow `to_hipscat` to overwrite catalogs

### DIFF
--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -349,6 +349,7 @@ class Catalog(Dataset):
         self,
         base_catalog_path: str,
         catalog_name: Union[str, None] = None,
+        overwrite: bool = False,
         storage_options: Union[Dict[Any, Any], None] = None,
         **kwargs,
     ):
@@ -360,7 +361,7 @@ class Catalog(Dataset):
             storage_options (dict): Dictionary that contains abstract filesystem credentials
             **kwargs: Arguments to pass to the parquet write operations
         """
-        io.to_hipscat(self, base_catalog_path, catalog_name, storage_options, **kwargs)
+        io.to_hipscat(self, base_catalog_path, catalog_name, overwrite, storage_options, **kwargs)
 
     def join(
         self,

--- a/src/lsdb/io/to_hipscat.py
+++ b/src/lsdb/io/to_hipscat.py
@@ -51,6 +51,7 @@ def to_hipscat(
     catalog: Catalog,
     base_catalog_path: str,
     catalog_name: Union[str, None] = None,
+    overwrite: bool = False,
     storage_options: Union[Dict[Any, Any], None] = None,
     **kwargs,
 ):
@@ -62,12 +63,13 @@ def to_hipscat(
         catalog (Catalog): A catalog to export
         base_catalog_path (str): Location where catalog is saved to
         catalog_name (str): The name of the output catalog
+        overwrite (bool): If True existing catalog is overwritten
         storage_options (dict): Dictionary that contains abstract filesystem credentials
         **kwargs: Arguments to pass to the parquet write operations
     """
     # Create base directory
     base_catalog_dir_fp = hc.io.get_file_pointer_from_path(base_catalog_path)
-    hc.io.file_io.make_directory(base_catalog_dir_fp)
+    hc.io.file_io.make_directory(base_catalog_dir_fp, overwrite, storage_options)
     # Save partition parquet files
     pixel_to_partition_size_map = write_partitions(catalog, base_catalog_dir_fp, storage_options, **kwargs)
     # Save parquet metadata

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -121,3 +121,11 @@ def test_save_catalog(small_sky_catalog, tmp_path):
     assert expected_catalog.hc_structure.catalog_info == small_sky_catalog.hc_structure.catalog_info
     assert expected_catalog.get_healpix_pixels() == small_sky_catalog.get_healpix_pixels()
     pd.testing.assert_frame_equal(expected_catalog.compute(), small_sky_catalog._ddf.compute())
+
+
+def test_save_catalog_overwrite(small_sky_catalog, tmp_path):
+    base_catalog_path = os.path.join(tmp_path, "small_sky")
+    small_sky_catalog.to_hipscat(base_catalog_path)
+    with pytest.raises(FileExistsError):
+        small_sky_catalog.to_hipscat(base_catalog_path)
+    small_sky_catalog.to_hipscat(base_catalog_path, overwrite=True)


### PR DESCRIPTION
Allows `to_hipscat` to overwrite existing catalogs. Closes #94. 