### PR TITLE
ask git to store version information in tarballs

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# For explanation of this file and uses see
+# https://git-scm.com/docs/gitattributes
+# https://developer.lsst.io/git/git-lfs.html#using-git-lfs-enabled-repositories
+#
+# Used by https://github.com/lsst/afwdata.git
+# *.boost filter=lfs diff=lfs merge=lfs -text
+# *.dat filter=lfs diff=lfs merge=lfs -text
+# *.fits filter=lfs diff=lfs merge=lfs -text
+# *.gz filter=lfs diff=lfs merge=lfs -text
+#
+# apache parquet files
+# *.parq	filter=lfs diff=lfs merge=lfs -text
+#
+# sqlite files
+# *.sqlite3	filter=lfs diff=lfs merge=lfs -text
+#
+# gzip files
+# *.gz	filter=lfs diff=lfs merge=lfs -text
+#
+# png image files
+# *.png	filter=lfs diff=lfs merge=lfs -text
+.git_archival.txt  export-subst


### PR DESCRIPTION
The added lines make git(hub) add a file named .git_archival.txt into tarballs it enerated for tags that have the following format:

    $ cat .git_archival.txt
    node: 3cd27f3
    node-date: 2023-10-04T12:53:16-07:00
    describe-name: v0.6.1
    ref-names: HEAD -> main, tag: v0.6.1

(the above is for v0.6.1 tag).

This allows setuptools-scm to deduce the version number, allowing us to build from exported tarballs (which is how conda packages fetch their source).

More information:

    https://setuptools-scm.readthedocs.io/en/latest/usage/#git-archives