### PR TITLE
Clean up some dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,6 @@ repos:
         name: Validate pyproject.toml
         description: Verify that pyproject.toml adheres to the established schema.
 
-
     # Automatically sort the imports used in .py files
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
@@ -52,8 +51,6 @@ repos:
         name: Run isort
         description: Sort and organize imports in .py and .pyi files.
         types_or: [python, pyi]
-
-
 
     # Analyze the src code style and report code that doesn't adhere.
   - repo: local
@@ -87,8 +84,6 @@ repos:
             "--rcfile=tests/.pylintrc",
           ]
 
-
-
     # Analyze type hints and report errors.
   - repo: local
     hooks:
@@ -100,11 +95,8 @@ repos:
         files: ^(src|tests)/
         args:
           [
-
             "--ignore-missing-imports", # Ignore imports without type hints
-
           ]
-
 
     # Run unit tests, verify that they pass. Note that coverage is run against
     # the ./src directory here because that is what will be committed. In the 
@@ -120,6 +112,7 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+
     # Make sure Sphinx can build the documentation while explicitly omitting 
     # notebooks from the docs, so users don't have to wait through the execution 
     # of each notebook or each commit. By default, these will be checked in the 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,5 +5,4 @@ nbsphinx
 ipython
 jupytext
 jupyter
-spherical_geometry
 git+https://github.com/astronomy-commons/hipscat.git@main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "lsdb"
 license = {file = "LICENSE"}
 readme = "README.md"
+description = "Spatial analysis for extremely large astronomical databases using dask"
 authors = [
     { name = "LINCC Frameworks", email = "lincc-frameworks-team@lists.lsst.org" }
 ]
@@ -16,16 +17,18 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "dask",
+    "dask[dataframe]",
+    "dask[distributed]",
     "hipscat",
     "pyarrow",
     "deprecated",
-    "ipykernel", # Support for Jupyter notebooks
     "scipy", # kdtree
     "lsst-sphgeom", # To handle spherical sky polygons
 ]
 
 [project.urls]
-"Source Code" = "https://github.com/astronomy-commons/lsdb"
+source = "https://github.com/astronomy-commons/lsdb"
+documentation = "https://lsdb.readthedocs.io/"
 
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)
 [project.optional-dependencies]
@@ -38,11 +41,9 @@ dev = [
     "sphinx", # Used to automatically generate documentation
     "sphinx-rtd-theme", # Used to render documentation
     "sphinx-autoapi", # Used to automatically generate api documentation
-    # if you add dependencies here while experimenting in a notebook and you
-    # want that notebook to render in your documentation, please add the
-    # dependencies to ./docs/requirements.txt as well.
     "nbconvert", # Needed for pre-commit check to clear output from Python notebooks
     "nbsphinx", # Used to integrate Python notebooks into Sphinx documentation
+    "ipykernel", # Support for Jupyter notebooks
     "ipython", # Also used in building notebooks into Sphinx
     "asv==0.6.1", # Used to compute performance benchmarks
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,8 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "dask",
-    "dask[dataframe]",
-    "dask[distributed]",
+    # dask distributed is included to ease creation of parallel dask clients.
+    "dask[dataframe,distributed]",
     "hipscat",
     "pyarrow",
     "deprecated",


### PR DESCRIPTION
This is related to #121 , but doesn't really close it.

- we're using `dask[distributed]` and `dask[dataframe]`, so let's explicitly depend on them.
- remove extra spherical geometry dep on docs
- maybe fix github being sad in `pyproject.toml` about `project.urls`?