### PR TITLE
Add more thorough polygon validation

### DIFF
--- a/src/lsdb/core/search/polygon_search.py
+++ b/src/lsdb/core/search/polygon_search.py
@@ -11,7 +11,7 @@ from hipscat.pixel_math.polygon_filter import (
     SphericalCoordinates,
     filter_pixels_by_polygon,
 )
-from hipscat.pixel_math.validators import validate_declination_values
+from hipscat.pixel_math.validators import validate_declination_values, validate_polygon
 from hipscat.pixel_tree.pixel_tree_builder import PixelTreeBuilder
 from lsst.sphgeom import ConvexPolygon, UnitVector3d
 
@@ -77,5 +77,6 @@ def get_cartesian_polygon(
         list of cartesian coordinates of its vertices.
     """
     vertices_xyz = hp.ang2vec(*np.array(vertices).T, lonlat=True)
-    vertices_vectors = [UnitVector3d(x, y, z) for x, y, z in vertices_xyz]
-    return ConvexPolygon(vertices_vectors), vertices_xyz
+    validate_polygon(vertices_xyz)
+    edge_vectors = [UnitVector3d(x, y, z) for x, y, z in vertices_xyz]
+    return ConvexPolygon(edge_vectors), vertices_xyz

--- a/tests/lsdb/catalog/test_polygon_search.py
+++ b/tests/lsdb/catalog/test_polygon_search.py
@@ -48,8 +48,25 @@ def test_polygon_search_invalid_dec(small_sky_order1_catalog):
 
 def test_polygon_search_invalid_shape(small_sky_order1_catalog):
     """The polygon is not convex, so the shape is invalid"""
-    vertices = [(0, 1), (1, 0), (1, 1), (0, 0), (1, 1)]
     with pytest.raises(RuntimeError):
+        vertices = [(45, 30), (60, 60), (90, 45), (60, 50)]
+        small_sky_order1_catalog.polygon_search(vertices)
+
+
+def test_polygon_search_invalid_polygon(small_sky_order1_catalog):
+    with pytest.raises(ValueError, match=ValidatorsErrors.INVALID_NUM_VERTICES):
+        vertices = [(100.1, -20.3), (100.1, 40.3)]
+        small_sky_order1_catalog.polygon_search(vertices[:2])
+    # The vertices should not have duplicates
+    with pytest.raises(ValueError, match=ValidatorsErrors.DUPLICATE_VERTICES):
+        vertices = [(100.1, -20.3), (100.1, -20.3), (280.1, -20.3), (280.1, 40.3)]
+        small_sky_order1_catalog.polygon_search(vertices)
+    # The polygons should not be on a great circle
+    with pytest.raises(ValueError, match=ValidatorsErrors.DEGENERATE_POLYGON):
+        vertices = [(100.1, 40.3), (100.1, -20.3), (280.1, -20.3), (280.1, 40.3)]
+        small_sky_order1_catalog.polygon_search(vertices)
+    with pytest.raises(ValueError, match=ValidatorsErrors.DEGENERATE_POLYGON):
+        vertices = [(50.1, 0), (100.1, 0), (150.1, 0), (200.1, 0)]
         small_sky_order1_catalog.polygon_search(vertices)
 
 


### PR DESCRIPTION
Validates polygons used for catalog search. They must contain at least three vertices (without duplicates) and form a non-degenerate region (i.e., the vertices cannot be on a single great circle). Closes #120.