### PR TITLE
Refactor join and crossmatch partition alignment and applying code

### DIFF
--- a/src/lsdb/dask/crossmatch_catalog_data.py
+++ b/src/lsdb/dask/crossmatch_catalog_data.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Tuple, Type, cast
+from typing import TYPE_CHECKING, Tuple, Type
 
 import dask
 import dask.dataframe as dd

--- a/src/lsdb/dask/crossmatch_catalog_data.py
+++ b/src/lsdb/dask/crossmatch_catalog_data.py
@@ -4,19 +4,16 @@ from typing import TYPE_CHECKING, Tuple, Type, cast
 
 import dask
 import dask.dataframe as dd
-import numpy as np
 from hipscat.pixel_tree import PixelAlignment, PixelAlignmentType, align_trees
 
 from lsdb.core.crossmatch.abstract_crossmatch_algorithm import AbstractCrossmatchAlgorithm
 from lsdb.core.crossmatch.crossmatch_algorithms import BuiltInCrossmatchAlgorithm
 from lsdb.core.crossmatch.kdtree_match import KdTreeCrossmatch
-from lsdb.dask.divisions import get_pixels_divisions
 from lsdb.dask.merge_catalog_functions import (
-    align_catalogs_to_alignment_mapping,
     filter_by_hipscat_index_to_pixel,
     generate_meta_df_for_joined_tables,
     get_healpix_pixels_from_alignment,
-    get_partition_map_from_alignment_pixels,
+    align_and_apply, construct_catalog_args,
 )
 from lsdb.types import DaskDFPixelMap
 
@@ -29,15 +26,13 @@ builtin_crossmatch_algorithms = {BuiltInCrossmatchAlgorithm.KD_TREE: KdTreeCross
 # pylint: disable=too-many-arguments
 @dask.delayed
 def perform_crossmatch(
-    algorithm,
     left_df,
     right_df,
-    left_order,
-    left_pixel,
-    right_order,
-    right_pixel,
+    left_pix,
+    right_pix,
     left_hc_structure,
     right_hc_structure,
+    algorithm,
     suffixes,
     **kwargs,
 ):
@@ -46,15 +41,15 @@ def perform_crossmatch(
     Filters the left catalog before performing the cross-match to stop duplicate points appearing in
     the result.
     """
-    if right_order > left_order:
-        left_df = filter_by_hipscat_index_to_pixel(left_df, right_order, right_pixel)
+    if right_pix.order > left_pix.order:
+        left_df = filter_by_hipscat_index_to_pixel(left_df, right_pix.order, right_pix.pixel)
     return algorithm(
         left_df,
         right_df,
-        left_order,
-        left_pixel,
-        right_order,
-        right_pixel,
+        left_pix.order,
+        left_pix.pixel,
+        right_pix.order,
+        right_pix.pixel,
         left_hc_structure,
         right_hc_structure,
         suffixes,
@@ -95,54 +90,26 @@ def crossmatch_catalog_data(
         right.hc_structure.pixel_tree,
         alignment_type=PixelAlignmentType.INNER,
     )
-    join_pixels = alignment.pixel_mapping
-
-    # align partitions from the catalogs to match the pixel alignment
-    left_aligned_partitions, right_aligned_partitions = align_catalogs_to_alignment_mapping(
-        join_pixels, left, right
-    )
 
     # get lists of HEALPix pixels from alignment to pass to cross-match
-    left_pixels, right_pixels = get_healpix_pixels_from_alignment(join_pixels)
+    left_pixels, right_pixels = get_healpix_pixels_from_alignment(alignment)
 
     # perform the crossmatch on each partition pairing using dask delayed for lazy computation
-    apply_crossmatch = np.vectorize(
-        lambda left_df, right_df, left_pix, right_pix: perform_crossmatch(
-            crossmatch_algorithm,
-            left_df,
-            right_df,
-            left_pix.order,
-            left_pix.pixel,
-            right_pix.order,
-            right_pix.pixel,
-            left.hc_structure,
-            right.hc_structure,
-            suffixes,
-            **kwargs,
-        )
-    )
 
-    joined_partitions = apply_crossmatch(
-        left_aligned_partitions,
-        right_aligned_partitions,
-        left_pixels,
-        right_pixels,
+    joined_partitions = align_and_apply(
+        [(left, left_pixels), (right, right_pixels)],
+        perform_crossmatch,
+        crossmatch_algorithm,
+        suffixes,
+        **kwargs
     )
-
-    # generate dask df partition map from alignment
-    partition_map = get_partition_map_from_alignment_pixels(join_pixels)
 
     # generate meta table structure for dask df
     meta_df = generate_meta_df_for_joined_tables(
         [left, right], suffixes, extra_columns=crossmatch_algorithm.extra_columns
     )
 
-    # create dask df from delayed partitions
-    divisions = get_pixels_divisions(list(partition_map.keys()))
-    ddf = dd.from_delayed(joined_partitions, meta=meta_df, divisions=divisions)
-    ddf = cast(dd.DataFrame, ddf)
-
-    return ddf, partition_map, alignment
+    return construct_catalog_args(joined_partitions, meta_df, alignment)
 
 
 def get_crossmatch_algorithm(

--- a/src/lsdb/dask/crossmatch_catalog_data.py
+++ b/src/lsdb/dask/crossmatch_catalog_data.py
@@ -10,10 +10,11 @@ from lsdb.core.crossmatch.abstract_crossmatch_algorithm import AbstractCrossmatc
 from lsdb.core.crossmatch.crossmatch_algorithms import BuiltInCrossmatchAlgorithm
 from lsdb.core.crossmatch.kdtree_match import KdTreeCrossmatch
 from lsdb.dask.merge_catalog_functions import (
+    align_and_apply,
+    construct_catalog_args,
     filter_by_hipscat_index_to_pixel,
     generate_meta_df_for_joined_tables,
     get_healpix_pixels_from_alignment,
-    align_and_apply, construct_catalog_args,
 )
 from lsdb.types import DaskDFPixelMap
 
@@ -101,7 +102,7 @@ def crossmatch_catalog_data(
         perform_crossmatch,
         crossmatch_algorithm,
         suffixes,
-        **kwargs
+        **kwargs,
     )
 
     # generate meta table structure for dask df

--- a/src/lsdb/dask/join_catalog_data.py
+++ b/src/lsdb/dask/join_catalog_data.py
@@ -14,10 +14,11 @@ from hipscat.pixel_tree import PixelAlignment, PixelAlignmentType, align_trees
 
 from lsdb.catalog.association_catalog import AssociationCatalog
 from lsdb.dask.merge_catalog_functions import (
+    align_and_apply,
+    construct_catalog_args,
     filter_by_hipscat_index_to_pixel,
     generate_meta_df_for_joined_tables,
     get_healpix_pixels_from_alignment,
-    align_and_apply, construct_catalog_args,
 )
 from lsdb.types import DaskDFPixelMap
 
@@ -168,11 +169,7 @@ def join_catalog_data_on(
     left_pixels, right_pixels = get_healpix_pixels_from_alignment(alignment)
 
     joined_partitions = align_and_apply(
-        [(left, left_pixels), (right, right_pixels)],
-        perform_join_on,
-        left_on,
-        right_on,
-        suffixes
+        [(left, left_pixels), (right, right_pixels)], perform_join_on, left_on, right_on, suffixes
     )
 
     meta_df = generate_meta_df_for_joined_tables([left, right], suffixes)
@@ -220,7 +217,7 @@ def join_catalog_data_through(
     joined_partitions = align_and_apply(
         [(left, left_pixels), (right, right_pixels), (association, left_pixels)],
         perform_join_through,
-        suffixes
+        suffixes,
     )
 
     association_join_columns = [

--- a/src/lsdb/dask/join_catalog_data.py
+++ b/src/lsdb/dask/join_catalog_data.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Tuple, cast
+from typing import TYPE_CHECKING, Tuple
 
 import dask
 import dask.dataframe as dd
@@ -47,6 +47,7 @@ def rename_columns_with_suffixes(left: pd.DataFrame, right: pd.DataFrame, suffix
     return left, right
 
 
+# pylint: disable=unused-argument
 @dask.delayed
 def perform_join_on(
     left: pd.DataFrame,
@@ -83,6 +84,7 @@ def perform_join_on(
     return merged
 
 
+# pylint: disable=unused-argument
 @dask.delayed
 def perform_join_through(
     left: pd.DataFrame,

--- a/src/lsdb/dask/join_catalog_data.py
+++ b/src/lsdb/dask/join_catalog_data.py
@@ -7,21 +7,17 @@ from typing import TYPE_CHECKING, Tuple, cast
 import dask
 import dask.dataframe as dd
 import hipscat as hc
-import numpy as np
 import pandas as pd
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
 from hipscat.pixel_tree import PixelAlignment, PixelAlignmentType, align_trees
 
 from lsdb.catalog.association_catalog import AssociationCatalog
-from lsdb.dask.divisions import get_pixels_divisions
 from lsdb.dask.merge_catalog_functions import (
-    align_catalog_to_partitions,
-    align_catalogs_to_alignment_mapping,
     filter_by_hipscat_index_to_pixel,
     generate_meta_df_for_joined_tables,
     get_healpix_pixels_from_alignment,
-    get_partition_map_from_alignment_pixels,
+    align_and_apply, construct_catalog_args,
 )
 from lsdb.types import DaskDFPixelMap
 
@@ -54,10 +50,12 @@ def rename_columns_with_suffixes(left: pd.DataFrame, right: pd.DataFrame, suffix
 def perform_join_on(
     left: pd.DataFrame,
     right: pd.DataFrame,
-    left_on: str,
-    right_on: str,
     left_pixel: HealpixPixel,
     right_pixel: HealpixPixel,
+    left_structure: hc.catalog.Catalog,
+    right_structure: hc.catalog.Catalog,
+    left_on: str,
+    right_on: str,
     suffixes: Tuple[str, str],
 ):
     """Performs a join on two catalog partitions
@@ -65,10 +63,12 @@ def perform_join_on(
     Args:
         left (pd.DataFrame): the left partition to merge
         right (pd.DataFrame): the right partition to merge
-        left_on (str): the column to join on from the left partition
-        right_on (str): the column to join on from the right partition
         left_pixel (HealpixPixel): the HEALPix pixel of the left partition
         right_pixel (HealpixPixel): the HEALPix pixel of the right partition
+        left_structure (hc.Catalog): the hipscat structure of the left catalog
+        right_structure (hc.Catalog): the hipscat structure of the right catalog
+        left_on (str): the column to join on from the left partition
+        right_on (str): the column to join on from the right partition
         suffixes (Tuple[str,str]): the suffixes to apply to each partition's column names
 
     Returns:
@@ -89,7 +89,10 @@ def perform_join_through(
     through: pd.DataFrame,
     left_pixel: HealpixPixel,
     right_pixel: HealpixPixel,
-    catalog_info: hc.catalog.association_catalog.AssociationCatalogInfo,
+    through_pixel: HealpixPixel,
+    left_catalog: hc.catalog.Catalog,
+    right_catalog: hc.catalog.Catalog,
+    assoc_catalog: hc.catalog.AssociationCatalog,
     suffixes: Tuple[str, str],
 ):
     """Performs a join on two catalog partitions through an association catalog
@@ -100,12 +103,16 @@ def perform_join_through(
         through (pd.DataFrame): the association column partition to merge with
         left_pixel (HealpixPixel): the HEALPix pixel of the left partition
         right_pixel (HealpixPixel): the HEALPix pixel of the right partition
-        catalog_info (AssociationCatalogInfo): the catalog_info of the association catalog
+        through_pixel (HealpixPixel): the HEALPix pixel of the association partition
+        left_catalog (hc.Catalog): the hipscat structure of the left catalog
+        right_catalog (hc.Catalog): the hipscat structure of the right catalog
+        assoc_catalog (hc.AssociationCatalog): the hipscat structure of the association catalog
         suffixes (Tuple[str,str]): the suffixes to apply to each partition's column names
 
     Returns:
         A dataframe with the result of merging the left and right partitions on the specified columns
     """
+    catalog_info = assoc_catalog.catalog_info
     if catalog_info.primary_column is None or catalog_info.join_column is None:
         raise ValueError("Invalid catalog_info")
     if right_pixel.order > left_pixel.order:
@@ -157,35 +164,20 @@ def join_catalog_data_on(
     alignment = align_trees(
         left.hc_structure.pixel_tree, right.hc_structure.pixel_tree, alignment_type=PixelAlignmentType.INNER
     )
-    join_pixels = alignment.pixel_mapping
-    left_aligned_partitions, right_aligned_partitions = align_catalogs_to_alignment_mapping(
-        join_pixels, left, right
+
+    left_pixels, right_pixels = get_healpix_pixels_from_alignment(alignment)
+
+    joined_partitions = align_and_apply(
+        [(left, left_pixels), (right, right_pixels)],
+        perform_join_on,
+        left_on,
+        right_on,
+        suffixes
     )
 
-    left_pixels, right_pixels = get_healpix_pixels_from_alignment(join_pixels)
-
-    apply_join = np.vectorize(
-        lambda left_df, right_df, left_pix, right_pix: perform_join_on(
-            left_df,
-            right_df,
-            left_on,
-            right_on,
-            left_pix,
-            right_pix,
-            suffixes,
-        )
-    )
-
-    joined_partitions = apply_join(
-        left_aligned_partitions, right_aligned_partitions, left_pixels, right_pixels
-    )
-
-    partition_map = get_partition_map_from_alignment_pixels(join_pixels)
     meta_df = generate_meta_df_for_joined_tables([left, right], suffixes)
-    divisions = get_pixels_divisions(list(partition_map.keys()))
-    ddf = dd.from_delayed(joined_partitions, meta=meta_df, divisions=divisions)
-    ddf = cast(dd.DataFrame, ddf)
-    return ddf, partition_map, alignment
+
+    return construct_catalog_args(joined_partitions, meta_df, alignment)
 
 
 def join_catalog_data_through(
@@ -222,40 +214,15 @@ def join_catalog_data_through(
     alignment = align_trees(
         left.hc_structure.pixel_tree, right.hc_structure.pixel_tree, alignment_type=PixelAlignmentType.INNER
     )
-    join_pixels = alignment.pixel_mapping
-    left_aligned_partitions, right_aligned_partitions = align_catalogs_to_alignment_mapping(
-        join_pixels, left, right
-    )
-    association_aligned_to_join_partitions = align_catalog_to_partitions(
-        association,
-        join_pixels,
-        order_col=PixelAlignment.PRIMARY_ORDER_COLUMN_NAME,
-        pixel_col=PixelAlignment.PRIMARY_PIXEL_COLUMN_NAME,
+
+    left_pixels, right_pixels = get_healpix_pixels_from_alignment(alignment)
+
+    joined_partitions = align_and_apply(
+        [(left, left_pixels), (right, right_pixels), (association, left_pixels)],
+        perform_join_through,
+        suffixes
     )
 
-    left_pixels, right_pixels = get_healpix_pixels_from_alignment(join_pixels)
-
-    apply_join = np.vectorize(
-        lambda left_df, right_df, assoc_df, left_pix, right_pix: perform_join_through(
-            left_df,
-            right_df,
-            assoc_df,
-            left_pix,
-            right_pix,
-            association.hc_structure.catalog_info,
-            suffixes,
-        )
-    )
-
-    joined_partitions = apply_join(
-        left_aligned_partitions,
-        right_aligned_partitions,
-        association_aligned_to_join_partitions,
-        left_pixels,
-        right_pixels,
-    )
-
-    partition_map = get_partition_map_from_alignment_pixels(alignment.pixel_mapping)
     association_join_columns = [
         association.hc_structure.catalog_info.primary_column_association,
         association.hc_structure.catalog_info.join_column_association,
@@ -263,7 +230,5 @@ def join_catalog_data_through(
     # pylint: disable=protected-access
     extra_df = association._ddf._meta.drop(NON_JOINING_ASSOCIATION_COLUMNS + association_join_columns, axis=1)
     meta_df = generate_meta_df_for_joined_tables([left, extra_df, right], [suffixes[0], "", suffixes[1]])
-    divisions = get_pixels_divisions(list(partition_map.keys()))
-    ddf = dd.from_delayed(joined_partitions, meta=meta_df, divisions=divisions)
-    ddf = cast(dd.DataFrame, ddf)
-    return ddf, partition_map, alignment
+
+    return construct_catalog_args(joined_partitions, meta_df, alignment)

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -74,7 +74,8 @@ def construct_catalog_args(
         alignment (PixelAlignment): The alignment used to create the delayed partitions
 
     Returns:
-        A tuple of (ddf, partition_map, alignment) with the dask dataframe, the partition map, and the alignment needed to create the catalog
+        A tuple of (ddf, partition_map, alignment) with the dask dataframe, the partition map, and the
+        alignment needed to create the catalog
     """
     # generate dask df partition map from alignment
     partition_map = get_partition_map_from_alignment_pixels(alignment.pixel_mapping)

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -19,13 +19,13 @@ if TYPE_CHECKING:
 
 
 def align_and_apply(
-    catalog_mappings: List[Tuple[Catalog, List[HealpixPixel]]], func: Callable, *args, **kwargs
+    catalog_mappings: List[Tuple[HealpixDataset, List[HealpixPixel]]], func: Callable, *args, **kwargs
 ) -> List[Delayed]:
     """Aligns catalogs to a given ordering of pixels and applies a function to the aligned catalogs
 
     Args:
-        catalog_mappings (List[Tuple[Catalog, List[HealpixPixel]]]): The catalogs and their corresponding
-            order of pixels to align the partitions to. In the form of
+        catalog_mappings (List[Tuple[HealpixDataset, List[HealpixPixel]]]): The catalogs and their
+            corresponding order of pixels to align the partitions to. In the form of
             [(catalog, pixels), (catalog2, pixels2), ...]
         func (Callable): The function to apply to the aligned catalogs
         *args: Additional arguments to pass to the function

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Sequence, Tuple, cast, Callable
+from typing import TYPE_CHECKING, Callable, List, Sequence, Tuple, cast
 
+import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 from dask.delayed import Delayed
-import dask.dataframe as dd
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN, healpix_to_hipscat_id
 from hipscat.pixel_tree import PixelAlignment
@@ -19,9 +19,9 @@ if TYPE_CHECKING:
 
 
 def align_and_apply(
-        catalog_mappings: List[Tuple[Catalog, List[HealpixPixel]]], func: Callable, *args, **kwargs
+    catalog_mappings: List[Tuple[Catalog, List[HealpixPixel]]], func: Callable, *args, **kwargs
 ) -> List[Delayed]:
-    """ Aligns catalogs to a given ordering of pixels and applies a function to the aligned catalogs
+    """Aligns catalogs to a given ordering of pixels and applies a function to the aligned catalogs
 
     Args:
         catalog_mappings (List[Tuple[Catalog, List[HealpixPixel]]]): The catalogs and their corresponding
@@ -35,9 +35,7 @@ def align_and_apply(
         A list of delayed objects, each one representing the result of the function applied to the
         aligned partitions of the catalogs
     """
-    aligned_partitions = [
-        align_catalog_to_partitions(cat, pixels) for (cat, pixels) in catalog_mappings
-    ]
+    aligned_partitions = [align_catalog_to_partitions(cat, pixels) for (cat, pixels) in catalog_mappings]
     pixels = [pixels for (_, pixels) in catalog_mappings]
     hc_structures = [cat.hc_structure for (cat, _) in catalog_mappings]
 
@@ -66,7 +64,7 @@ def filter_by_hipscat_index_to_pixel(dataframe: pd.DataFrame, order: int, pixel:
 
 
 def construct_catalog_args(
-        partitions: List[Delayed], meta_df: pd.DataFrame, alignment: PixelAlignment
+    partitions: List[Delayed], meta_df: pd.DataFrame, alignment: PixelAlignment
 ) -> Tuple[dd.core.DataFrame, DaskDFPixelMap, PixelAlignment]:
     """Constructs the arguments needed to create a catalog from a list of delayed partitions
 
@@ -89,7 +87,7 @@ def construct_catalog_args(
 
 
 def get_healpix_pixels_from_alignment(
-        alignment: PixelAlignment,
+    alignment: PixelAlignment,
 ) -> Tuple[List[HealpixPixel], List[HealpixPixel]]:
     """Gets the list of primary and join pixels as the HealpixPixel class from a PixelAlignment
 
@@ -113,10 +111,10 @@ def get_healpix_pixels_from_alignment(
 
 
 def generate_meta_df_for_joined_tables(
-        catalogs: Sequence[Catalog],
-        suffixes: Sequence[str],
-        extra_columns: pd.DataFrame | None = None,
-        index_name: str = HIPSCAT_ID_COLUMN,
+    catalogs: Sequence[Catalog],
+    suffixes: Sequence[str],
+    extra_columns: pd.DataFrame | None = None,
+    index_name: str = HIPSCAT_ID_COLUMN,
 ) -> pd.DataFrame:
     """Generates a Dask meta DataFrame that would result from joining two catalogs
 
@@ -166,8 +164,7 @@ def get_partition_map_from_alignment_pixels(join_pixels: pd.DataFrame) -> DaskDF
 
 
 def align_catalog_to_partitions(
-        catalog: HealpixDataset,
-        pixels: List[HealpixPixel]
+    catalog: HealpixDataset, pixels: List[HealpixPixel]
 ) -> List[Tuple[Delayed, HealpixPixel]]:
     """Aligns the partitions of a Catalog to a dataframe with HEALPix pixels in each row
 

--- a/src/lsdb/loaders/hipscat/margin_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/margin_catalog_loader.py
@@ -14,6 +14,4 @@ class MarginCatalogLoader(AbstractCatalogLoader[MarginCatalog]):
 
     def load_hipscat_catalog(self) -> hc.catalog.MarginCatalog:
         """Load `hipscat` library catalog object with catalog metadata and partition data"""
-        return hc.catalog.MarginCatalog.read_from_hipscat(
-            self.path, storage_options=self.storage_options
-        )
+        return hc.catalog.MarginCatalog.read_from_hipscat(self.path, storage_options=self.storage_options)


### PR DESCRIPTION
The crossmatch and join methods all do pretty similar things, in that they align the left and right catalog partitions, then apply a function to the matching pairs of partitions. 

This PR refactors their methods to use a more general helper function `align_and_apply` that can perform this alignment and applying a function over them while allowing for differences like the association catalog needing to also be aligned for joining. This should also make it easier to add margins to each of these methods.