### PR TITLE
Documentation notebook with ZTF BTS vs NGC cross-match example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,20 @@
 Welcome to lsdb's documentation!
 ========================================================================================
 
+User Guide
+----------
+
+You can install LSDB with `conda` or `pip`:
+
+.. code-block:: bash
+
+   >> # Conda installation
+   >> conda install -c conda-forge install lsdb
+   >> # Pip installation
+   >> python3 -mpip install lsdb
+
+See `notebooks <notebooks>`_ for examples.
+
 Dev Guide - Getting Started
 ---------------------------
 

--- a/docs/notebooks.rst
+++ b/docs/notebooks.rst
@@ -4,4 +4,5 @@ Notebooks
 .. toctree::
     :maxdepth: 1
 
+    Cross-match ZTF BTS and NGC <notebooks/ztf_bts-ngc>
     Import catalogs <notebooks/import_catalogs>

--- a/docs/notebooks/ztf_bts-ngc.ipynb
+++ b/docs/notebooks/ztf_bts-ngc.ipynb
@@ -1,0 +1,218 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "baf860d14e6e9d0d",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "# Example use-case: cross-match ZTF BTS and NGC\n",
+    "\n",
+    "Here we demonstrate how to cross-match [Zwicky Transient Facility](https://ztf.caltech.edu) (ZTF) [Bright Transient Survey](https://sites.astro.caltech.edu/ztf/bts) (BTS) and [New General Catalogue](https://en.wikipedia.org/wiki/New_General_Catalogue) (NGC) using LSDB."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6c5c22698dfb620",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-02-05T17:13:28.624426Z",
+     "start_time": "2024-02-05T17:13:25.950199Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Install astroquery, comment this line if you already have it\n",
+    "!pip install astroquery"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cedde7185bbd9650",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-02-05T17:13:29.713920Z",
+     "start_time": "2024-02-05T17:13:28.624569Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import lsdb\n",
+    "import pandas as pd\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "from astroquery.vizier import Vizier\n",
+    "from dask.distributed import Client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4c7f826dfc019ed",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "### Download ZTF BTS and convert coordinates to degrees"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "533f35ae2822a422",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-02-05T17:13:32.649302Z",
+     "start_time": "2024-02-05T17:13:29.714486Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "\n",
+    "df_ztf_bts = pd.read_csv(\n",
+    "    'http://sites.astro.caltech.edu/ztf/bts/explorer.php?format=csv',\n",
+    "    na_values='-',\n",
+    ")\n",
+    "coord = SkyCoord(df_ztf_bts['RA'], df_ztf_bts['Dec'], unit=('hourangle', 'deg'))\n",
+    "df_ztf_bts['ra_deg'], df_ztf_bts['dec_deg'] = coord.ra.deg, coord.dec.deg\n",
+    "df_ztf_bts.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2789dc15c2f46954",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "### Download NGC with `astroquery`\n",
+    "\n",
+    "Please install astroquery first with `pip install astroquery` or `conda install -c conda-forge astroquery`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f27f3c3054bb72e2",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-02-05T17:13:33.699857Z",
+     "start_time": "2024-02-05T17:13:32.641375Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "\n",
+    "vizier = Vizier(row_limit=50_000)\n",
+    "tables = vizier.get_catalogs('VII/118/ngc2000')\n",
+    "df_ngc = tables[0].to_pandas()\n",
+    "coord = SkyCoord(df_ngc['RAB2000'], df_ngc['DEB2000'], unit=('hourangle', 'deg'))\n",
+    "df_ngc['ra_deg'], df_ngc['dec_deg'] = coord.ra.deg, coord.dec.deg\n",
+    "df_ngc.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de39d5296b848de7",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "### Put both catalogs to LSDB and plan cross-match\n",
+    "\n",
+    "Of course ZTF looks much deeper than NGC galaxies from 19th century, so we filter ZTF transients by redshift.\n",
+    "\n",
+    "LSDB is built upon [Dask](https://dask.org) and can be used with Dask distributed cluster. In this cell we just plan computations and do not actually run them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b1b2ebb1c023bca",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-02-05T17:13:33.881118Z",
+     "start_time": "2024-02-05T17:13:33.700251Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "\n",
+    "ztf_bts = lsdb.from_dataframe(df_ztf_bts, ra_column='ra_deg', dec_column='dec_deg')\n",
+    "ngc = lsdb.from_dataframe(df_ngc, ra_column='ra_deg', dec_column='dec_deg')\n",
+    "\n",
+    "ztf_bts = ztf_bts.query('redshift < 0.01')\n",
+    "\n",
+    "matched = ztf_bts.crossmatch(ngc, radius_arcsec=1200, suffixes=('_ztf', '_ngc'))\n",
+    "matched"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e78f8f93cdadb910",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "### Run LSDB pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40085244f8f1c8b",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-02-05T17:13:36.249530Z",
+     "start_time": "2024-02-05T17:13:33.878705Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "\n",
+    "# Create default local cluster\n",
+    "with Client():\n",
+    "    matched_df = matched.compute()\n",
+    "\n",
+    "# Let's output transient name, NGC name and angular distance between them\n",
+    "matched_df[['IAUID_ztf', 'Name_ngc', '_DIST']]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e901f3bdd0edde5",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "We may have some false matches here, because NGC is too shallow for this task. However, if we look to the second and third row we would see that [AT2019rsi](https://www.wis-tns.org/object/2019rsi) and [AT2019sxc](https://www.wis-tns.org/object/2019sxc) are Novae in M31."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/notebooks/ztf_bts-ngc.ipynb
+++ b/docs/notebooks/ztf_bts-ngc.ipynb
@@ -25,7 +25,7 @@
    "outputs": [],
    "source": [
     "# Install astroquery, comment this line if you already have it\n",
-    "!pip install astroquery"
+    "!pip install --quiet astroquery"
    ]
   },
   {


### PR DESCRIPTION
This is a simple toy-example of LSDB usage without pre-HiPSCated data. It takes few seconds to run, because each time it runs it downloads some data from both ZTF and Vizier.

It also adds a new dev dependency, astriquery. We need it to download NGC via Vizier.