### PR TITLE
Remove performance warnings on filtering

### DIFF
--- a/src/lsdb/core/search/cone_search.py
+++ b/src/lsdb/core/search/cone_search.py
@@ -57,7 +57,5 @@ def cone_filter(data_frame: pd.DataFrame, ra, dec, radius, metadata: hc.catalog.
     df_coords = SkyCoord(df_ras, df_decs, unit="deg")
     center_coord = SkyCoord(ra, dec, unit="deg")
     df_separations = df_coords.separation(center_coord).value
-    data_frame["_CONE_SEP"] = df_separations
-    data_frame = data_frame.loc[data_frame["_CONE_SEP"] < radius]
-    data_frame = data_frame.drop(columns=["_CONE_SEP"])
+    data_frame = data_frame.iloc[df_separations < radius]
     return data_frame

--- a/src/lsdb/core/search/polygon_search.py
+++ b/src/lsdb/core/search/polygon_search.py
@@ -56,9 +56,8 @@ def polygon_filter(data_frame: pd.DataFrame, polygon: ConvexPolygon, metadata: h
     """
     ra_values = np.radians(data_frame[metadata.catalog_info.ra_column].values)
     dec_values = np.radians(data_frame[metadata.catalog_info.dec_column].values)
-    data_frame["_INSIDE_POLYGON"] = polygon.contains(ra_values, dec_values)
-    data_frame = data_frame.loc[data_frame["_INSIDE_POLYGON"]]
-    data_frame = data_frame.drop(columns=["_INSIDE_POLYGON"])
+    inside_polygon = polygon.contains(ra_values, dec_values)
+    data_frame = data_frame.iloc[inside_polygon]
     return data_frame
 
 


### PR DESCRIPTION
Filters partitions with a numpy array mask instead of appending a new dataframe column and applying filtering based on it (for both `cone` and `polygon` search). This clears performance warnings of this kind: `PerformanceWarning: DataFrame is highly fragmented`. Closes #102. 