### PR TITLE
Fix inconsistent `_hipscat_index` type

### DIFF
--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Callable, List, Sequence, Tuple, cast
 
 import dask.dataframe as dd
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 from dask.delayed import Delayed
 from hipscat.pixel_math import HealpixPixel
@@ -161,6 +162,7 @@ def generate_meta_df_for_joined_tables(
     suffixes: Sequence[str],
     extra_columns: pd.DataFrame | None = None,
     index_name: str = HIPSCAT_ID_COLUMN,
+    index_type: npt.DTypeLike = np.uint64,
 ) -> pd.DataFrame:
     """Generates a Dask meta DataFrame that would result from joining two catalogs
 
@@ -172,6 +174,7 @@ def generate_meta_df_for_joined_tables(
         suffixes (Sequence[Str]): The column suffixes to apply each catalog
         extra_columns (pd.Dataframe): Any additional columns to the merged catalogs
         index_name (str): The name of the index in the resulting DataFrame
+        index_type (npt.DTypeLike): The type of the index in the resulting DataFrame
 
     Returns:
     An empty dataframe with the columns of each catalog with their respective suffix, and any extra columns
@@ -185,8 +188,8 @@ def generate_meta_df_for_joined_tables(
     # Construct meta for crossmatch result columns
     if extra_columns is not None:
         meta.update(extra_columns)
-    meta_df = pd.DataFrame(meta)
-    meta_df.index.name = index_name
+    index = pd.Index(pd.Series(dtype=index_type), name=index_name)
+    meta_df = pd.DataFrame(meta, index)
     return meta_df
 
 

--- a/tests/lsdb/catalog/test_join.py
+++ b/tests/lsdb/catalog/test_join.py
@@ -1,5 +1,7 @@
+import numpy as np
 import pandas as pd
 import pytest
+from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
 
 
 def test_small_sky_join_small_sky_order1(
@@ -7,10 +9,14 @@ def test_small_sky_join_small_sky_order1(
 ):
     suffixes = ("_a", "_b")
     joined = small_sky_catalog.join(small_sky_order1_catalog, left_on="id", right_on="id", suffixes=suffixes)
+
     for col_name, dtype in small_sky_catalog.dtypes.items():
         assert (col_name + suffixes[0], dtype) in joined.dtypes.items()
     for col_name, dtype in small_sky_order1_catalog.dtypes.items():
         assert (col_name + suffixes[1], dtype) in joined.dtypes.items()
+    assert joined._ddf.index.name == HIPSCAT_ID_COLUMN
+    assert joined._ddf.index.dtype == np.uint64
+
     joined_compute = joined.compute()
     small_sky_compute = small_sky_catalog.compute()
     small_sky_order1_compute = small_sky_order1_catalog.compute()
@@ -47,9 +53,10 @@ def test_join_association(small_sky_catalog, small_sky_xmatch_catalog, small_sky
 
     for col in small_sky_catalog._ddf.columns:
         assert col + suffixes[0] in joined._ddf.columns
-
     for col in small_sky_xmatch_catalog._ddf.columns:
         assert col + suffixes[1] in joined._ddf.columns
+    assert joined._ddf.index.name == HIPSCAT_ID_COLUMN
+    assert joined._ddf.index.dtype == np.uint64
 
     for _, row in association_data.iterrows():
         left_col = small_sky_to_xmatch_catalog.hc_structure.catalog_info.primary_column + suffixes[0]


### PR DESCRIPTION
Forces the `_hipscat_index` type on joined catalogs to be `uint64`. We were not enforcing the index type before so Pandas was infering `int64`, which is incorrect. Closes #145.