### PR TITLE
Add package version property

### DIFF
--- a/src/lsdb/__init__.py
+++ b/src/lsdb/__init__.py
@@ -1,2 +1,3 @@
 from .catalog import Catalog
 from .loaders import from_dataframe, read_hipscat
+from ._version import __version__

--- a/src/lsdb/__init__.py
+++ b/src/lsdb/__init__.py
@@ -1,3 +1,3 @@
+from ._version import __version__
 from .catalog import Catalog
 from .loaders import from_dataframe, read_hipscat
-from ._version import __version__

--- a/tests/lsdb/test_packaging.py
+++ b/tests/lsdb/test_packaging.py
@@ -1,0 +1,6 @@
+import lsdb
+
+
+def test_lsdb_version():
+    """Check to see that we can get the lsdb version"""
+    assert lsdb.__version__ is not None


### PR DESCRIPTION
Adds the `__version__` property to show the installed package version (similar to what TAPE did in https://github.com/lincc-frameworks/tape/pull/302). Closes #160. 