### PR TITLE
Save margin catalog to disk

### DIFF
--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Any, Dict, List, Tuple, Type, Union
+from typing import List, Tuple, Type
 
 import dask.dataframe as dd
 import hipscat as hc
 import pandas as pd
 from hipscat.pixel_math.polygon_filter import SphericalCoordinates
 
-from lsdb import io
 from lsdb.catalog.association_catalog import AssociationCatalog
 from lsdb.catalog.dataset.healpix_dataset import HealpixDataset
 from lsdb.catalog.margin_catalog import MarginCatalog
@@ -323,25 +322,6 @@ class Catalog(HealpixDataset):
             right_index=right_index,
             suffixes=suffixes,
         )
-
-    def to_hipscat(
-        self,
-        base_catalog_path: str,
-        catalog_name: Union[str, None] = None,
-        overwrite: bool = False,
-        storage_options: Union[Dict[Any, Any], None] = None,
-        **kwargs,
-    ):
-        """Saves the catalog to disk in HiPSCat format
-
-        Args:
-            base_catalog_path (str): Location where catalog is saved to
-            catalog_name (str): The name of the catalog to be saved
-            overwrite (bool): If True existing catalog is overwritten
-            storage_options (dict): Dictionary that contains abstract filesystem credentials
-            **kwargs: Arguments to pass to the parquet write operations
-        """
-        io.to_hipscat(self, base_catalog_path, catalog_name, overwrite, storage_options, **kwargs)
 
     def join(
         self,

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Callable, Dict, List, cast
 
 import dask
@@ -10,6 +12,7 @@ from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.healpix_pixel_function import get_pixel_argsort
 from typing_extensions import Self
 
+from lsdb import io
 from lsdb.catalog.dataset.dataset import Dataset
 from lsdb.core.plotting.skymap import plot_skymap
 from lsdb.core.search.abstract_search import AbstractSearch
@@ -170,3 +173,22 @@ class HealpixDataset(Dataset):
         results = dask.compute(*[smdata[pixel] for pixel in pixels])
         result_dict = {pixels[i]: results[i] for i in range(len(pixels))}
         plot_skymap(result_dict)
+
+    def to_hipscat(
+        self,
+        base_catalog_path: str,
+        catalog_name: str | None = None,
+        overwrite: bool = False,
+        storage_options: dict | None = None,
+        **kwargs,
+    ):
+        """Saves the catalog to disk in HiPSCat format
+
+        Args:
+            base_catalog_path (str): Location where catalog is saved to
+            catalog_name (str): The name of the catalog to be saved
+            overwrite (bool): If True existing catalog is overwritten
+            storage_options (dict): Dictionary that contains abstract filesystem credentials
+            **kwargs: Arguments to pass to the parquet write operations
+        """
+        io.to_hipscat(self, base_catalog_path, catalog_name, overwrite, storage_options, **kwargs)

--- a/tests/lsdb/catalog/test_margin_catalog.py
+++ b/tests/lsdb/catalog/test_margin_catalog.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import hipscat as hc
 import pandas as pd
 
@@ -30,3 +32,17 @@ def test_margin_catalog_partitions_correct(small_sky_xmatch_margin_dir):
         partition = margin.get_partition(hp_order, hp_pixel)
         data = pd.read_parquet(path)
         pd.testing.assert_frame_equal(partition.compute(), data)
+
+
+def test_save_margin_catalog(small_sky_xmatch_margin_catalog, tmp_path):
+    new_catalog_name = "small_sky_xmatch_margin"
+    base_catalog_path = Path(tmp_path) / new_catalog_name
+    small_sky_xmatch_margin_catalog.to_hipscat(base_catalog_path, catalog_name=new_catalog_name)
+    expected_catalog = lsdb.read_hipscat(base_catalog_path)
+    assert expected_catalog.hc_structure.catalog_name == new_catalog_name
+    assert (
+        expected_catalog.hc_structure.catalog_info
+        == small_sky_xmatch_margin_catalog.hc_structure.catalog_info
+    )
+    assert expected_catalog.get_healpix_pixels() == small_sky_xmatch_margin_catalog.get_healpix_pixels()
+    pd.testing.assert_frame_equal(expected_catalog.compute(), small_sky_xmatch_margin_catalog._ddf.compute())


### PR DESCRIPTION
Refactors the `to_hipscat` method to enable saving a margin catalog to disk. Closes #206. 