### PR TITLE
Work around pandas warnings.

### DIFF
--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -69,9 +69,12 @@ class Catalog(HealpixDataset):
             if remaining_rows == 0:
                 break
             partition_head = partition.head(remaining_rows)
-            dfs.append(partition_head)
-            remaining_rows -= len(partition_head)
-        return pd.concat(dfs)
+            if len(partition_head) > 0:
+                dfs.append(partition_head)
+                remaining_rows -= len(partition_head)
+        if len(dfs) > 0:
+            return pd.concat(dfs)
+        return self._ddf._meta
 
     def query(self, expr: str) -> Catalog:
         catalog = super().query(expr)


### PR DESCRIPTION
Two warnings come up for pandas >2.1.1

```
tests/lsdb/loaders/dataframe/test_from_dataframe.py::test_from_dataframe_small_sky_source_with_margins
tests/lsdb/loaders/dataframe/test_from_dataframe.py::test_from_dataframe_small_sky_order3_source_with_margins
tests/lsdb/loaders/dataframe/test_from_dataframe.py::test_from_dataframe_margin_is_empty
  /home/runner/work/lsdb/lsdb/src/lsdb/loaders/dataframe/margin_catalog_generator.py:158: DeprecationWarning: DataFrameGroupBy.apply operated on the grouping columns. This behavior is deprecated, and in a future version of pandas the grouping columns will be excluded from the operation. Either pass `include_groups=False` to exclude the groupings or explicitly select the grouping columns after groupby to silence this warning.
    constrained_data.groupby(["partition_order", "partition_pixel"]).apply(
```

and

```
tests/lsdb/catalog/test_catalog.py::test_head_first_partition_is_empty
  /home/runner/work/lsdb/lsdb/src/lsdb/catalog/catalog.py:74: FutureWarning: The behavior of array concatenation with empty entries is deprecated. In a future version, this will no longer exclude empty items when determining the result dtype. To retain the old behavior, exclude the empty entries before the concat operation.
    return pd.concat(dfs)
```