### PR TITLE
Pin dask.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     # Includes dask[array,dataframe,distributed,diagnostics].
     # dask distributed eases the creation of parallel dask clients.
     # dask diagnostics is required to spin up the dashboard for profiling.
-    "dask[complete]",
+    "dask[complete]<=2024.2.1",
     "hipscat>=0.2.6",
     "pyarrow",
     "deprecated",


### PR DESCRIPTION
Smoke test fails with new dependencies:

```
dask                      2024.3.0
dask-expr                 1.0
```