### PR TITLE
Change metadata loading method to use right file

### DIFF
--- a/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
@@ -87,6 +87,6 @@ class AbstractCatalogLoader(Generic[CatalogTypeVar]):
         return ddf
 
     def _load_parquet_metadata_schema(self, catalog: HCHealpixDataset) -> pyarrow.Schema:
-        metadata_pointer = hc.io.paths.get_parquet_metadata_pointer(catalog.catalog_base_dir)
+        metadata_pointer = hc.io.paths.get_common_metadata_pointer(catalog.catalog_base_dir)
         metadata = file_io.read_parquet_metadata(metadata_pointer, storage_options=self.storage_options)
         return metadata.schema.to_arrow_schema()


### PR DESCRIPTION
uses `_common_metadata` instead of `_metadata`, which gives a large performance improvement to loading catalogs