### PR TITLE
Use custom representation for catalog.

### DIFF
--- a/docs/notebooks/import_catalogs.ipynb
+++ b/docs/notebooks/import_catalogs.ipynb
@@ -244,7 +244,7 @@
    "outputs": [],
    "source": [
     "from_dataframe_catalog = lsdb.read_hipscat(catalog_from_dataframe)\n",
-    "from_dataframe_catalog._ddf"
+    "from_dataframe_catalog"
    ]
   },
   {
@@ -260,7 +260,7 @@
    "outputs": [],
    "source": [
     "from_importer_catalog = lsdb.read_hipscat(catalog_from_importer)\n",
-    "from_importer_catalog._ddf"
+    "from_importer_catalog"
    ]
   },
   {

--- a/src/lsdb/catalog/dataset/dataset.py
+++ b/src/lsdb/catalog/dataset/dataset.py
@@ -31,9 +31,7 @@ class Dataset:
 
     def _repr_html_(self):
         # pylint: disable=protected-access
-        data = self._ddf._repr_data().to_html(
-            max_rows=5, show_dimensions=False, notebook=True
-        )
+        data = self._ddf._repr_data().to_html(max_rows=5, show_dimensions=False, notebook=True)
         return f"<div><strong>lsdb Catalog {self.name}:</strong></div>{data}"
 
     def compute(self) -> pd.DataFrame:

--- a/src/lsdb/catalog/dataset/dataset.py
+++ b/src/lsdb/catalog/dataset/dataset.py
@@ -30,7 +30,11 @@ class Dataset:
         return self._ddf.__repr__()
 
     def _repr_html_(self):
-        return self._ddf._repr_html_()  # pylint: disable=protected-access
+        # pylint: disable=protected-access
+        data = self._ddf._repr_data().to_html(
+            max_rows=5, show_dimensions=False, notebook=True
+        )
+        return f"<div><strong>lsdb Catalog {self.name}:</strong></div>{data}"
 
     def compute(self) -> pd.DataFrame:
         """Compute dask distributed dataframe to pandas dataframe"""

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -23,7 +23,10 @@ def test_catalog_repr_equals_ddf_repr(small_sky_order1_catalog):
 
 
 def test_catalog_html_repr_equals_ddf_html_repr(small_sky_order1_catalog):
-    assert small_sky_order1_catalog._repr_html_() == small_sky_order1_catalog._ddf._repr_html_()
+    full_html = small_sky_order1_catalog._repr_html_()
+    assert small_sky_order1_catalog.name in full_html
+    # this is a _hipscat_index that's in the data
+    assert "12682136550675316736" in full_html
 
 
 def test_catalog_compute_equals_ddf_compute(small_sky_order1_catalog):


### PR DESCRIPTION
Closes #126 

- includes the name of the catalog
- doesn't issue a warning from within dask

![image](https://github.com/astronomy-commons/lsdb/assets/113376043/0bf3a33e-e30e-4cf6-ba6c-56b7738ec55b)
