### PR TITLE
Initialize BoxSearch in search package

### DIFF
--- a/src/lsdb/core/search/__init__.py
+++ b/src/lsdb/core/search/__init__.py
@@ -1,3 +1,4 @@
+from .box_search import BoxSearch
 from .cone_search import ConeSearch
 from .index_search import IndexSearch
 from .order_search import OrderSearch


### PR DESCRIPTION
Imports the BoxSearch in the search package initialization, which was missing.