### PR TITLE
Update Skymap default

### DIFF
--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, List, Tuple, cast
 
 import dask
 import dask.dataframe as dd
+import healpy as hp
 import hipscat as hc
 import numpy as np
 import pandas as pd
@@ -277,7 +278,7 @@ class HealpixDataset(Dataset):
         self,
         func: Callable[[pd.DataFrame, HealpixPixel], Any],
         order: int | None = None,
-        default_value: Any = 0.0,
+        default_value: Any = hp.pixelfunc.UNSEEN,
         projection="moll",
         plotting_args: Dict | None = None,
         **kwargs,

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -378,7 +378,7 @@ def test_skymap_plot(small_sky_order1_catalog, mocker):
     pixel_map = small_sky_order1_catalog.skymap_data(func)
     pixel_map = {pixel: value.compute() for pixel, value in pixel_map.items()}
     max_order = max(pixel_map.keys(), key=lambda x: x.order).order
-    img = np.zeros(hp.nside2npix(hp.order2nside(max_order)))
+    img = np.full(hp.nside2npix(hp.order2nside(max_order)), hp.pixelfunc.UNSEEN)
     for pixel, value in pixel_map.items():
         dorder = max_order - pixel.order
         start = pixel.pixel * (4**dorder)


### PR DESCRIPTION
Updates default value of skymap non covered tiles from 0 to healpy's `UNSEEN` constant. Closes #248.