### PR TITLE
Add quickstart guide

### DIFF
--- a/docs/gettingstarted/quickstart.ipynb
+++ b/docs/gettingstarted/quickstart.ipynb
@@ -90,13 +90,25 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "611cd2f6",
+   "metadata": {},
+   "source": [
+    "For the purpose of this tutorial we will only read a small 1 degree cone region of Gaia DR3, one that should contain our objects. While LSDB typically loads only the minimal amount of data it needs for our workflow, manually providing it with spatial information helps it identify which files to search for on disk."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "b8e31774",
    "metadata": {},
    "outputs": [],
    "source": [
-    "gaia = lsdb.read_hipscat(\"https://epyc.astro.washington.edu/~lincc-frameworks/hipscat_surveys/gaia_dr3/gaia\")\n",
+    "from lsdb.core.search import ConeSearch\n",
+    "\n",
+    "gaia_path = \"https://epyc.astro.washington.edu/~lincc-frameworks/hipscat_surveys/gaia_dr3/gaia\"\n",
+    "\n",
+    "gaia = lsdb.read_hipscat(gaia_path, search_filter=ConeSearch(ra=180, dec=10, radius_arcsec=0.5 * 3600))\n",
     "gaia"
    ]
   },

--- a/docs/gettingstarted/quickstart.ipynb
+++ b/docs/gettingstarted/quickstart.ipynb
@@ -2,24 +2,175 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "8c4f492a",
    "metadata": {},
    "source": [
-    "# Quickstart"
+    "# Quickstart\n",
+    "\n",
+    "To get started with LSDB we will demonstrate a very common workflow. It consists of crossmatching a small set of objects of your interest with a large survey catalog stored in HiPSCat format (e.g. Gaia), and saving the final result."
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "35ecb774",
    "metadata": {},
    "source": [
-    "LSDB provides a scalable framework for analyzing and cross-matching large astronomical catalogs. This tutorial section is under construction. "
+    "The first thing you need to do is to import our package."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7977b2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import lsdb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42f8fda0",
+   "metadata": {},
+   "source": [
+    "Create a Pandas Dataframe containing the objects you want to crossmatch with Gaia."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5afacf2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "# The coordinates (ra, dec) for our objects of interest\n",
+    "objects = [(180.080612, 9.507394), (179.884664, 10.479632), (179.790319, 9.551745)]\n",
+    "\n",
+    "objects_df = pd.DataFrame(objects, columns=[\"ra\", \"dec\"])\n",
+    "objects_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0570402f",
+   "metadata": {},
+   "source": [
+    "Now that the data is in a DataFrame you can create an LSDB catalog to have it in HiPSCat format."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9e098d25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_object_catalog = lsdb.from_dataframe(objects_df, catalog_name=\"my_object_catalog\", catalog_type=\"object\")\n",
+    "my_object_catalog"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b889e0e",
+   "metadata": {},
+   "source": [
+    "Next, read the catalog we want to crossmatch with. Because we will download it from the web we decided to go with a small half degree region of Gaia. In this case we need to install __aiohttp__ but if your catalog happens to be present in local storage you can call `read_hipscat` directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fcca5a0b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install aiohttp --quiet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8e31774",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "small_gaia = lsdb.read_hipscat(\"https://epyc.astro.washington.edu/~lincc-frameworks/half_degree_surveys/gaia\")\n",
+    "small_gaia"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "792fbff7",
+   "metadata": {},
+   "source": [
+    "Let's crossmatch them! As a result we will have a catalog with the objects in the small Gaia that match our initial objects of interest, according to a specified maximum distance. We will use the default K nearest neighbors algorithm with `k=1` and a maximum separation distance of 1 arcsecond."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b5869df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = my_object_catalog.crossmatch(\n",
+    "    small_gaia, n_neighbors=1, radius_arcsec=1 * 3600, require_right_margin=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35994f0d",
+   "metadata": {},
+   "source": [
+    "As expected, we obtained at most 1 match for each of our initial objects:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9e3d201d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result.compute()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0db1bf14",
+   "metadata": {},
+   "source": [
+    "Let's say you're done with your workflow. Generally, it is a good idea to save your catalog to disk to prevent regenerating it later on. Our catalog interface exposes the `to_hipscat` API for that, you just need to provide it with a path for the `target directory` and a `catalog name`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "552ecd48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result.to_hipscat(\"lsdb_catalogs\", catalog_name=\"my_object_catalog_x_small_gaia\")"
    ]
   }
  ],
  "metadata": {
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/docs/gettingstarted/quickstart.ipynb
+++ b/docs/gettingstarted/quickstart.ipynb
@@ -94,7 +94,7 @@
    "id": "611cd2f6",
    "metadata": {},
    "source": [
-    "On this tutorial we will read a small 1 degree cone region of Gaia DR3, one that should contain our objects. While LSDB typically reads into memory only the minimal amount of data it needs for our workflow, manually providing it with spatial information helps it identify which files to search for on disk."
+    "In this tutorial we will read a small 1 degree cone region of Gaia DR3, one that should contain our objects. While LSDB typically reads into memory only the minimal amount of data it needs for our workflow, manually providing it with spatial information helps it identify which files to search for on disk."
    ]
   },
   {

--- a/docs/gettingstarted/quickstart.ipynb
+++ b/docs/gettingstarted/quickstart.ipynb
@@ -169,7 +169,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result.to_hipscat(\"lsdb_catalogs\", catalog_name=\"my_object_catalog_x_small_gaia\")"
+    "result.to_hipscat(\"lsdb_catalogs\", catalog_name=\"my_object_catalog_x_gaia\")"
    ]
   }
  ],

--- a/docs/gettingstarted/quickstart.ipynb
+++ b/docs/gettingstarted/quickstart.ipynb
@@ -94,7 +94,7 @@
    "id": "611cd2f6",
    "metadata": {},
    "source": [
-    "For the purpose of this tutorial we will only read a small 1 degree cone region of Gaia DR3, one that should contain our objects. While LSDB typically loads only the minimal amount of data it needs for our workflow, manually providing it with spatial information helps it identify which files to search for on disk."
+    "On this tutorial we will read a small 1 degree cone region of Gaia DR3, one that should contain our objects. While LSDB typically reads into memory only the minimal amount of data it needs for our workflow, manually providing it with spatial information helps it identify which files to search for on disk."
    ]
   },
   {
@@ -153,7 +153,7 @@
    "id": "35994f0d",
    "metadata": {},
    "source": [
-    "Our workflow takes advantage of Dask's \"lazy\" evaluation. This means that we have been defining a set of tasks which will only be executed at our command. When that happens, data will be loaded into disk and operations will be distributed among the several works for parallel computation. To trigger this we will call `compute` on the catalog that resulted from the crossmatch. The final result will be presented in a Pandas DataFrame."
+    "Our workflow takes advantage of Dask's \"lazy\" evaluation. This means that we have been defining a set of tasks which will only be executed at our command. When that happens, data will be read into disk and operations will be distributed among the several workers for parallel computation. To trigger this we will call `compute` on the catalog that resulted from the crossmatch. The final result will be presented in a Pandas DataFrame."
    ]
   },
   {
@@ -196,7 +196,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/docs/gettingstarted/quickstart.ipynb
+++ b/docs/gettingstarted/quickstart.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Quickstart\n",
     "\n",
-    "To get started with LSDB we will demonstrate a very common workflow. It consists of crossmatching a small set of objects of your interest with a large survey catalog stored in HiPSCat format (e.g. Gaia), and saving the final result."
+    "To get started with LSDB we will demonstrate a very common workflow. It consists of crossmatching a small set of objects of your interest with a large survey catalog stored in HiPSCat format (e.g. Gaia) and saving the final result."
    ]
   },
   {
@@ -33,7 +33,7 @@
    "id": "42f8fda0",
    "metadata": {},
    "source": [
-    "Create a Pandas Dataframe containing the objects you want to crossmatch with Gaia."
+    "Create a Pandas Dataframe containing the equatorial coordinates (right ascension and declination) for your objects."
    ]
   },
   {
@@ -57,7 +57,7 @@
    "id": "0570402f",
    "metadata": {},
    "source": [
-    "Now that the data is in a DataFrame you can create an LSDB catalog to have it in HiPSCat format."
+    "You can then create an LSDB catalog to have this data in HiPSCat format."
    ]
   },
   {
@@ -76,7 +76,7 @@
    "id": "3b889e0e",
    "metadata": {},
    "source": [
-    "Next, read the catalog we want to crossmatch with. Because we will download it from the web we decided to go with a small half degree region of Gaia. In this case we need to install __aiohttp__ but if your catalog happens to be present in local storage you can call `read_hipscat` directly."
+    "Next, read the catalog we want to crossmatch with. Because we will download it from the web we decided to go with a small half degree region of Gaia, but this would normally be your full-sized catalog. In this case we need to install __aiohttp__ but if your catalog happens to be present in local storage you can call `read_hipscat` directly."
    ]
   },
   {
@@ -105,7 +105,7 @@
    "id": "792fbff7",
    "metadata": {},
    "source": [
-    "Let's crossmatch them! As a result we will have a catalog with the objects in the small Gaia that match our initial objects of interest, according to a specified maximum distance. We will use the default K nearest neighbors algorithm with `k=1` and a maximum separation distance of 1 arcsecond."
+    "Let's crossmatch them! As a result we will have a catalog with the objects in the small Gaia that match our initial objects of interest, within a specified distance. We will use the default K nearest neighbors algorithm with `k=1` and a maximum separation distance of 1 arcsecond."
    ]
   },
   {
@@ -125,7 +125,7 @@
    "id": "35994f0d",
    "metadata": {},
    "source": [
-    "As expected, we obtained at most 1 match for each of our initial objects:"
+    "We obtained at most 1 match for each of our initial objects."
    ]
   },
   {
@@ -143,7 +143,7 @@
    "id": "0db1bf14",
    "metadata": {},
    "source": [
-    "Let's say you're done with your workflow. Generally, it is a good idea to save your catalog to disk to prevent regenerating it later on. Our catalog interface exposes the `to_hipscat` API for that, you just need to provide it with a path for the `target directory` and a `catalog name`."
+    "Let's say you're done with your workflow. Generally, it is a good idea to save your catalog to disk to prevent regenerating it later on. The catalog exposes the `to_hipscat` API for that, you just need to provide it with a path for the target `base directory` and a `catalog name`."
    ]
   },
   {

--- a/docs/gettingstarted/quickstart.ipynb
+++ b/docs/gettingstarted/quickstart.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Quickstart\n",
     "\n",
-    "To get started with LSDB we will demonstrate a very common workflow. It consists of crossmatching a small set of objects of your interest with a large survey catalog stored in HiPSCat format (e.g. Gaia) and saving the final result."
+    "To get started with LSDB we will demonstrate a very common workflow. It consists of crossmatching a small set of objects of your interest with a large survey catalog stored in HiPSCat format (Gaia), applying cuts to the data, and saving the final result."
    ]
   },
   {
@@ -33,7 +33,7 @@
    "id": "42f8fda0",
    "metadata": {},
    "source": [
-    "Create a Pandas Dataframe containing the equatorial coordinates (right ascension and declination) for your objects."
+    "Create a Pandas Dataframe with the equatorial coordinates (right ascension and declination, in degrees) for your objects."
    ]
   },
   {
@@ -57,7 +57,7 @@
    "id": "0570402f",
    "metadata": {},
    "source": [
-    "You can then create an LSDB catalog to have this data in HiPSCat format."
+    "Now that the data is in a DataFrame you can create an LSDB catalog to have it in HiPSCat format."
    ]
   },
   {
@@ -76,7 +76,7 @@
    "id": "3b889e0e",
    "metadata": {},
    "source": [
-    "Next, read the catalog we want to crossmatch with. Because we will download it from the web we decided to go with a small half degree region of Gaia, but this would normally be your full-sized catalog. In this case we need to install __aiohttp__ but if your catalog happens to be present in local storage you can call `read_hipscat` directly."
+    "Next, read the catalog we want to crossmatch with. Because we are downloading it from a web source we need to install an additional package (__aiohttp__). If your catalog happens to be present in local storage you can call `read_hipscat` directly."
    ]
   },
   {
@@ -96,8 +96,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "small_gaia = lsdb.read_hipscat(\"https://epyc.astro.washington.edu/~lincc-frameworks/half_degree_surveys/gaia\")\n",
-    "small_gaia"
+    "gaia = lsdb.read_hipscat(\"https://epyc.astro.washington.edu/~lincc-frameworks/hipscat_surveys/gaia_dr3/gaia\")\n",
+    "gaia"
    ]
   },
   {
@@ -105,7 +105,7 @@
    "id": "792fbff7",
    "metadata": {},
    "source": [
-    "Let's crossmatch them! As a result we will have a catalog with the objects in the small Gaia that match our initial objects of interest, within a specified distance. We will use the default K nearest neighbors algorithm with `k=1` and a maximum separation distance of 1 arcsecond."
+    "Let's crossmatch them! As a result we will have a catalog with the objects from Gaia that match our initial objects of interest, according to a specified maximum distance. We will use the default K nearest neighbors algorithm with `k=1` and a maximum separation distance of 1 arcsecond."
    ]
   },
   {
@@ -115,9 +115,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = my_object_catalog.crossmatch(\n",
-    "    small_gaia, n_neighbors=1, radius_arcsec=1 * 3600, require_right_margin=False\n",
-    ")"
+    "result = my_object_catalog.crossmatch(gaia, n_neighbors=1, radius_arcsec=1 * 3600, require_right_margin=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44651e88",
+   "metadata": {},
+   "source": [
+    "Now let's say we wish to apply a cut to our data to get all the objects with a mean magnitude in the G band greater than 18 and a total number of observations AL greater than 200. We can build a query expression and filter the catalog. Because of the crossmatch, the name of the Gaia columns for the query need to contain the name of the catalog as a suffix, `_gaia`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0bda0472",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = result.query(\"phot_g_mean_mag_gaia > 18 and astrometric_n_obs_al_gaia > 200\")"
    ]
   },
   {
@@ -125,7 +141,7 @@
    "id": "35994f0d",
    "metadata": {},
    "source": [
-    "We obtained at most 1 match for each of our initial objects."
+    "Our workflow takes advantage of Dask's \"lazy\" evaluation. This means that we have been defining a set of tasks which will only be executed at our command. When that happens, data will be loaded into disk and operations will be distributed among the several works for parallel computation. To trigger this we will call `compute` on the catalog that resulted from the crossmatch. The final result will be presented in a Pandas DataFrame."
    ]
   },
   {
@@ -143,7 +159,7 @@
    "id": "0db1bf14",
    "metadata": {},
    "source": [
-    "Let's say you're done with your workflow. Generally, it is a good idea to save your catalog to disk to prevent regenerating it later on. The catalog exposes the `to_hipscat` API for that, you just need to provide it with a path for the target `base directory` and a `catalog name`."
+    "You will want to save your resulting catalog to disk, especially if it is too large to fit in memory or if you will need to use it later on. The catalog exposes the `to_hipscat` API for that, you just need to provide it with a path for the target `base directory` and a `catalog name`."
    ]
   },
   {


### PR DESCRIPTION
Adds the quickstart guide which exemplifies the usage of:

- `from_dataframe`, to create an object catalog with a handful of points
- `read_hipscat`, to Ioad a catalog in HiPSCat format
- `crossmatch`, to perform a K nearest neighbors crossmatch between two catalogs
- `to_hipscat`, to save the resulting catalog to disk

Closes #224.