### PR TITLE
Cross-reference hipscat in the API docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,8 +61,8 @@ html_css_files = ["custom.css"]
 
 nbsphinx_allow_errors = True
 
-# Cross-link hipscat documentation
+# Cross-link hipscat documentation from the API reference:
+ # https://docs.readthedocs.io/en/stable/guides/intersphinx.html
 intersphinx_mapping = {
     "hipscat": ("http://hipscat.readthedocs.io/en/stable/", None),
 }
-intersphinx_disabled_reftypes = ["*"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,7 @@ html_css_files = ["custom.css"]
 nbsphinx_allow_errors = True
 
 # Cross-link hipscat documentation from the API reference:
- # https://docs.readthedocs.io/en/stable/guides/intersphinx.html
+# https://docs.readthedocs.io/en/stable/guides/intersphinx.html
 intersphinx_mapping = {
     "hipscat": ("http://hipscat.readthedocs.io/en/stable/", None),
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,6 @@ nbsphinx_allow_errors = True
 
 # Cross-link hipscat documentation
 intersphinx_mapping = {
-    "hipscat": ("http://hipscat.readthedocs.io/en/latest/", None),
+    "hipscat": ("http://hipscat.readthedocs.io/en/stable/", None),
 }
 intersphinx_disabled_reftypes = ["*"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ version = ".".join(release.split(".")[:2])
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["sphinx.ext.mathjax", "sphinx.ext.napoleon", "sphinx.ext.viewcode"]
+extensions = ["sphinx.ext.mathjax", "sphinx.ext.napoleon", "sphinx.ext.viewcode", "sphinx.ext.intersphinx"]
 
 extensions.append("autoapi.extension")
 extensions.append("nbsphinx")
@@ -60,3 +60,9 @@ html_static_path = ["_static"]
 html_css_files = ["custom.css"]
 
 nbsphinx_allow_errors = True
+
+# Cross-link hipscat documentation
+intersphinx_mapping = {
+    "hipscat": ("http://hipscat.readthedocs.io/en/latest/", None),
+}
+intersphinx_disabled_reftypes = ["*"]


### PR DESCRIPTION
Add cross-references to the hipscat library in the API documentation. Closes #155.