### PR TITLE
Use faster hipscat paths method

### DIFF
--- a/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
@@ -72,14 +72,7 @@ class AbstractCatalogLoader(Generic[CatalogTypeVar]):
     def _get_paths_from_pixels(
         self, catalog: HCHealpixDataset, ordered_pixels: List[HealpixPixel]
     ) -> List[hc.io.FilePointer]:
-        paths = [
-            hc.io.paths.pixel_catalog_file(
-                catalog_base_dir=catalog.catalog_base_dir,
-                pixel_order=pixel.order,
-                pixel_number=pixel.pixel,
-            )
-            for pixel in ordered_pixels
-        ]
+        paths = hc.io.paths.pixel_catalog_files(catalog.catalog_base_dir, ordered_pixels, self.storage_options)
         return paths
 
     def _load_df_from_paths(

--- a/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
@@ -72,7 +72,9 @@ class AbstractCatalogLoader(Generic[CatalogTypeVar]):
     def _get_paths_from_pixels(
         self, catalog: HCHealpixDataset, ordered_pixels: List[HealpixPixel]
     ) -> List[hc.io.FilePointer]:
-        paths = hc.io.paths.pixel_catalog_files(catalog.catalog_base_dir, ordered_pixels, self.storage_options)
+        paths = hc.io.paths.pixel_catalog_files(
+            catalog.catalog_base_dir, ordered_pixels, self.storage_options
+        )
         return paths
 
     def _load_df_from_paths(


### PR DESCRIPTION
Changes the abstract catalog loader to use the new hipscat method to get multiple paths introduced in astronomy-commons/hipscat#258