### PR TITLE
Support dask versions >=2024.3 by disabling dask expressions

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11.8']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11.8']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     # Includes dask[array,dataframe,distributed,diagnostics].
     # dask distributed eases the creation of parallel dask clients.
     # dask diagnostics is required to spin up the dashboard for profiling.
-    "dask[complete]<=2024.2.1",
+    "dask[complete]",
     "hipscat>=0.2.8",
     "pyarrow",
     "deprecated",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     # dask distributed eases the creation of parallel dask clients.
     # dask diagnostics is required to spin up the dashboard for profiling.
     "dask[complete]",
-    "hipscat>=0.2.8",
+    "hipscat>=0.3",
     "pyarrow",
     "deprecated",
     "scipy", # kdtree

--- a/src/lsdb/__init__.py
+++ b/src/lsdb/__init__.py
@@ -8,6 +8,7 @@ if QUERY_PLANNING_ON is not False:
     warnings.warn("This version of lsdb does not support dataframe query-planning, which has been disabled.")
     dask.config.set({"dataframe.query-planning": False})
 
+# pylint: disable=wrong-import-position
 from ._version import __version__
 from .catalog import Catalog
 from .loaders import from_dataframe, read_hipscat

--- a/src/lsdb/__init__.py
+++ b/src/lsdb/__init__.py
@@ -1,3 +1,15 @@
+import warnings
+
+import dask
+
 from ._version import __version__
 from .catalog import Catalog
 from .loaders import from_dataframe, read_hipscat
+
+QUERY_PLANNING_ON = dask.config.get("dataframe.query-planning")
+# Force the use of dask-expressions backends
+if QUERY_PLANNING_ON:
+    warnings.warn(
+        "This version of lsdb (<=0.2.0) does not support dataframe query-planning, which has been disabled."
+    )
+    dask.config.set({"dataframe.query-planning": False})

--- a/src/lsdb/__init__.py
+++ b/src/lsdb/__init__.py
@@ -2,14 +2,12 @@ import warnings
 
 import dask
 
+QUERY_PLANNING_ON = dask.config.get("dataframe.query-planning")
+# Force the use of dask-expressions backends
+if QUERY_PLANNING_ON is not False:
+    warnings.warn("This version of lsdb does not support dataframe query-planning, which has been disabled.")
+    dask.config.set({"dataframe.query-planning": False})
+
 from ._version import __version__
 from .catalog import Catalog
 from .loaders import from_dataframe, read_hipscat
-
-QUERY_PLANNING_ON = dask.config.get("dataframe.query-planning")
-# Force the use of dask-expressions backends
-if QUERY_PLANNING_ON:
-    warnings.warn(
-        "This version of lsdb (<=0.2.0) does not support dataframe query-planning, which has been disabled."
-    )
-    dask.config.set({"dataframe.query-planning": False})


### PR DESCRIPTION
- Sets dask config to not use dask expressions in the __init__ when importing lsdb by setting the `dataframe.query-planning` config setting to False. 
- Removes dask requirement version pin in pyproject and python 3.11 version pin in workflows.