### PR TITLE
Update dask dataframe imports to use legacy dataframe directly

### DIFF
--- a/src/lsdb/__init__.py
+++ b/src/lsdb/__init__.py
@@ -1,14 +1,3 @@
-import warnings
-
-import dask
-
-QUERY_PLANNING_ON = dask.config.get("dataframe.query-planning")
-# Force the use of dask-expressions backends
-if QUERY_PLANNING_ON is not False:
-    warnings.warn("This version of lsdb does not support dataframe query-planning, which has been disabled.")
-    dask.config.set({"dataframe.query-planning": False})
-
-# pylint: disable=wrong-import-position
 from ._version import __version__
 from .catalog import Catalog
 from .loaders import from_dataframe, read_hipscat

--- a/src/lsdb/catalog/association_catalog.py
+++ b/src/lsdb/catalog/association_catalog.py
@@ -18,7 +18,7 @@ class AssociationCatalog(HealpixDataset):
 
     def __init__(
         self,
-        ddf: dd.DataFrame,
+        ddf: dd.core.DataFrame,
         ddf_pixel_map: DaskDFPixelMap,
         hc_structure: hc.catalog.AssociationCatalog,
     ):

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -35,7 +35,7 @@ class Catalog(HealpixDataset):
 
     def __init__(
         self,
-        ddf: dd.DataFrame,
+        ddf: dd.core.DataFrame,
         ddf_pixel_map: DaskDFPixelMap,
         hc_structure: hc.catalog.Catalog,
         margin: MarginCatalog | None = None,
@@ -309,7 +309,7 @@ class Catalog(HealpixDataset):
         left_index: bool = False,
         right_index: bool = False,
         suffixes: Tuple[str, str] | None = None,
-    ) -> dd.DataFrame:
+    ) -> dd.core.DataFrame:
         """Performs the merge of two catalog Dataframes
 
         More information about pandas merge is available

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -39,7 +39,7 @@ class HealpixDataset(Dataset):
 
     def __init__(
         self,
-        ddf: dd.DataFrame,
+        ddf: dd.core.DataFrame,
         ddf_pixel_map: DaskDFPixelMap,
         hc_structure: HCHealpixDataset,
     ):
@@ -80,7 +80,7 @@ class HealpixDataset(Dataset):
         pixels = self.get_healpix_pixels()
         return np.array(pixels)[get_pixel_argsort(pixels)]
 
-    def get_partition(self, order: int, pixel: int) -> dd.DataFrame:
+    def get_partition(self, order: int, pixel: int) -> dd.core.DataFrame:
         """Get the dask partition for a given HEALPix pixel
 
         Args:
@@ -158,7 +158,7 @@ class HealpixDataset(Dataset):
 
     def _construct_search_ddf(
         self, filtered_pixels: List[HealpixPixel], filtered_partitions: List[Delayed]
-    ) -> Tuple[dict, dd.DataFrame]:
+    ) -> Tuple[dict, dd.core.DataFrame]:
         """Constructs a search catalog pixel map and respective Dask Dataframe
 
         Args:
@@ -169,8 +169,8 @@ class HealpixDataset(Dataset):
             The catalog pixel map and the respective Dask DataFrame
         """
         divisions = get_pixels_divisions(filtered_pixels)
-        search_ddf = dd.from_delayed(filtered_partitions, meta=self._ddf._meta, divisions=divisions)
-        search_ddf = cast(dd.DataFrame, search_ddf)
+        search_ddf = dd.io.from_delayed(filtered_partitions, meta=self._ddf._meta, divisions=divisions)
+        search_ddf = cast(dd.core.DataFrame, search_ddf)
         ddf_partition_map = {pixel: i for i, pixel in enumerate(filtered_pixels)}
         return ddf_partition_map, search_ddf
 

--- a/src/lsdb/catalog/margin_catalog.py
+++ b/src/lsdb/catalog/margin_catalog.py
@@ -24,7 +24,7 @@ class MarginCatalog(HealpixDataset):
 
     def __init__(
         self,
-        ddf: dd.DataFrame,
+        ddf: dd.core.DataFrame,
         ddf_pixel_map: DaskDFPixelMap,
         hc_structure: hc.catalog.MarginCatalog,
     ):

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -163,8 +163,8 @@ def construct_catalog_args(
 
     # create dask df from delayed partitions
     divisions = get_pixels_divisions(list(partition_map.keys()))
-    ddf = dd.from_delayed(partitions, meta=meta_df, divisions=divisions)
-    ddf = cast(dd.DataFrame, ddf)
+    ddf = dd.io.from_delayed(partitions, meta=meta_df, divisions=divisions)
+    ddf = cast(dd.core.DataFrame, ddf)
     return ddf, partition_map, alignment
 
 

--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -144,7 +144,7 @@ class DataframeCatalogLoader:
 
     def _generate_dask_df_and_map(
         self, pixel_map: Dict[HealpixPixel, HealpixInfo]
-    ) -> Tuple[dd.DataFrame, DaskDFPixelMap, int]:
+    ) -> Tuple[dd.core.DataFrame, DaskDFPixelMap, int]:
         """Load Dask DataFrame from HEALPix pixel Dataframes and
         generate a mapping of HEALPix pixels to HEALPix Dataframes
 

--- a/src/lsdb/loaders/dataframe/from_dataframe_utils.py
+++ b/src/lsdb/loaders/dataframe/from_dataframe_utils.py
@@ -13,7 +13,7 @@ from lsdb.dask.divisions import get_pixels_divisions
 
 def _generate_dask_dataframe(
     pixel_dfs: List[pd.DataFrame], pixels: List[HealpixPixel]
-) -> Tuple[dd.DataFrame, int]:
+) -> Tuple[dd.core.DataFrame, int]:
     """Create the Dask Dataframe from the list of HEALPix pixel Dataframes
 
     Args:
@@ -26,8 +26,8 @@ def _generate_dask_dataframe(
     schema = pixel_dfs[0].iloc[:0, :].copy() if len(pixels) > 0 else []
     divisions = get_pixels_divisions(pixels)
     delayed_dfs = [delayed(df) for df in pixel_dfs]
-    ddf = dd.from_delayed(delayed_dfs, meta=schema, divisions=divisions)
-    return ddf if isinstance(ddf, dd.DataFrame) else ddf.to_frame(), len(ddf)
+    ddf = dd.io.from_delayed(delayed_dfs, meta=schema, divisions=divisions)
+    return ddf if isinstance(ddf, dd.core.DataFrame) else ddf.to_frame(), len(ddf)
 
 
 def _append_partition_information_to_dataframe(dataframe: pd.DataFrame, pixel: HealpixPixel) -> pd.DataFrame:

--- a/src/lsdb/loaders/dataframe/margin_catalog_generator.py
+++ b/src/lsdb/loaders/dataframe/margin_catalog_generator.py
@@ -78,7 +78,7 @@ class MarginCatalogGenerator:
         margin_structure = hc.catalog.MarginCatalog(margin_catalog_info, margin_pixels)
         return MarginCatalog(ddf, ddf_pixel_map, margin_structure)
 
-    def _generate_dask_df_and_map(self) -> Tuple[dd.DataFrame, Dict[HealpixPixel, int], int]:
+    def _generate_dask_df_and_map(self) -> Tuple[dd.core.DataFrame, Dict[HealpixPixel, int], int]:
         """Create the Dask Dataframe containing the data points in the margins
         for the catalog as well as the mapping of those HEALPix to Dataframes
 

--- a/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
@@ -59,7 +59,7 @@ class AbstractCatalogLoader(Generic[CatalogTypeVar]):
         catalog_info = dataclasses.replace(hc_structure.catalog_info, total_rows=None)
         return catalog_type(catalog_info, pixels_to_load, self.path, self.storage_options)
 
-    def _load_dask_df_and_map(self, catalog: HCHealpixDataset) -> Tuple[dd.DataFrame, DaskDFPixelMap]:
+    def _load_dask_df_and_map(self, catalog: HCHealpixDataset) -> Tuple[dd.core.DataFrame, DaskDFPixelMap]:
         """Load Dask DF from parquet files and make dict of HEALPix pixel to partition index"""
         pixels = catalog.get_healpix_pixels()
         ordered_pixels = np.array(pixels)[get_pixel_argsort(pixels)]
@@ -79,12 +79,12 @@ class AbstractCatalogLoader(Generic[CatalogTypeVar]):
 
     def _load_df_from_paths(
         self, catalog: HCHealpixDataset, paths: List[hc.io.FilePointer], divisions: Tuple[int, ...] | None
-    ) -> dd.DataFrame:
+    ) -> dd.core.DataFrame:
         metadata_schema = self._load_parquet_metadata_schema(catalog)
         dask_meta_schema = metadata_schema.empty_table().to_pandas()
         if self.config.columns:
             dask_meta_schema = dask_meta_schema[self.config.columns]
-        ddf = dd.from_map(
+        ddf = dd.io.from_map(
             file_io.read_parquet_file_to_pandas,
             paths,
             divisions=divisions,

--- a/src/lsdb/loaders/hipscat/association_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/association_catalog_loader.py
@@ -24,5 +24,5 @@ class AssociationCatalogLoader(AbstractCatalogLoader[AssociationCatalog]):
     def _load_empty_dask_df_and_map(self, hc_catalog):
         metadata_schema = self._load_parquet_metadata_schema(hc_catalog)
         dask_meta_schema = metadata_schema.empty_table().to_pandas()
-        ddf = dd.from_pandas(dask_meta_schema, npartitions=0)
+        ddf = dd.io.from_pandas(dask_meta_schema, npartitions=0)
         return ddf, {}

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -63,7 +63,7 @@ def test_head_rows_less_than_requested(small_sky_order1_catalog):
     schema = small_sky_order1_catalog.dtypes
     two_rows = small_sky_order1_catalog._ddf.partitions[0].compute()[:2]
     tiny_df = pd.DataFrame(data=two_rows, columns=schema.index, dtype=schema.values)
-    altered_ddf = dd.from_pandas(tiny_df, npartitions=1)
+    altered_ddf = dd.io.from_pandas(tiny_df, npartitions=1)
     catalog = lsdb.Catalog(altered_ddf, {}, small_sky_order1_catalog.hc_structure)
     # The head only contains two values
     assert len(catalog.head()) == 2
@@ -73,8 +73,8 @@ def test_head_first_partition_is_empty(small_sky_order1_catalog):
     # The same catalog but now the first partition is empty
     schema = small_sky_order1_catalog.dtypes
     empty_df = pd.DataFrame(columns=schema.index, dtype=schema.values)
-    empty_ddf = dd.from_pandas(empty_df, npartitions=1)
-    altered_ddf = dd.concat([empty_ddf, small_sky_order1_catalog._ddf])
+    empty_ddf = dd.io.from_pandas(empty_df, npartitions=1)
+    altered_ddf = dd.multi.concat([empty_ddf, small_sky_order1_catalog._ddf])
     catalog = lsdb.Catalog(altered_ddf, {}, small_sky_order1_catalog.hc_structure)
     # The first partition is empty
     first_partition_df = catalog._ddf.partitions[0].compute()
@@ -87,7 +87,7 @@ def test_head_empty_catalog(small_sky_order1_catalog):
     # Create an empty Pandas DataFrame with the same schema
     schema = small_sky_order1_catalog.dtypes
     empty_df = pd.DataFrame(columns=schema.index, dtype=schema.values)
-    empty_ddf = dd.from_pandas(empty_df, npartitions=1)
+    empty_ddf = dd.io.from_pandas(empty_df, npartitions=1)
     empty_catalog = lsdb.Catalog(empty_ddf, {}, small_sky_order1_catalog.hc_structure)
     assert len(empty_catalog.head()) == 0
 
@@ -419,7 +419,7 @@ def test_square_bracket_column(small_sky_order1_catalog):
     column = small_sky_order1_catalog[column_name]
     pd.testing.assert_series_equal(column.compute(), small_sky_order1_catalog.compute()[column_name])
     assert np.all(column.compute().index.values == small_sky_order1_catalog.compute().index.values)
-    assert isinstance(column, dd.Series)
+    assert isinstance(column, dd.core.Series)
 
 
 def test_square_bracket_filter(small_sky_order1_catalog):

--- a/tests/lsdb/catalog/test_merge.py
+++ b/tests/lsdb/catalog/test_merge.py
@@ -11,7 +11,7 @@ def test_catalog_merge_on_indices(small_sky_catalog, small_sky_order1_catalog, h
     small_sky_order1_catalog._ddf = small_sky_order1_catalog._ddf.set_index("id")
     # The wrapper outputs the same result as the underlying pandas merge
     merged_ddf = small_sky_catalog.merge(small_sky_order1_catalog, **kwargs)
-    assert isinstance(merged_ddf, dd.DataFrame)
+    assert isinstance(merged_ddf, dd.core.DataFrame)
     expected_df = small_sky_catalog._ddf.merge(small_sky_order1_catalog._ddf, **kwargs)
     pd.testing.assert_frame_equal(expected_df.compute(), merged_ddf.compute())
 
@@ -24,7 +24,7 @@ def test_catalog_merge_on_columns(small_sky_catalog, small_sky_order1_catalog, h
     small_sky_order1_catalog._ddf = small_sky_order1_catalog._ddf.reset_index()
     # The wrapper outputs the same result as the underlying pandas merge
     merged_ddf = small_sky_catalog.merge(small_sky_order1_catalog, **kwargs)
-    assert isinstance(merged_ddf, dd.DataFrame)
+    assert isinstance(merged_ddf, dd.core.DataFrame)
     expected_df = small_sky_catalog._ddf.merge(small_sky_order1_catalog._ddf, **kwargs)
     pd.testing.assert_frame_equal(expected_df.compute(), merged_ddf.compute())
 
@@ -38,7 +38,7 @@ def test_catalog_merge_on_index_and_column(small_sky_catalog, small_sky_order1_c
     small_sky_order1_catalog._ddf = small_sky_order1_catalog._ddf.reset_index()
     # The wrapper outputs the same result as the underlying pandas merge
     merged_ddf = small_sky_catalog.merge(small_sky_order1_catalog, **kwargs)
-    assert isinstance(merged_ddf, dd.DataFrame)
+    assert isinstance(merged_ddf, dd.core.DataFrame)
     expected_df = small_sky_catalog._ddf.merge(small_sky_order1_catalog._ddf, **kwargs)
     pd.testing.assert_frame_equal(expected_df.compute(), merged_ddf.compute())
 
@@ -52,7 +52,7 @@ def test_catalog_merge_invalid_suffixes(small_sky_catalog, small_sky_order1_cata
 
 def test_catalog_merge_no_suffixes(small_sky_catalog, small_sky_order1_catalog):
     merged_ddf = small_sky_catalog.merge(small_sky_order1_catalog, how="inner", on="id")
-    assert isinstance(merged_ddf, dd.DataFrame)
+    assert isinstance(merged_ddf, dd.core.DataFrame)
     # Get the columns with the same name in both catalogs
     non_join_columns_left = small_sky_catalog._ddf.columns.drop("id")
     non_join_columns_right = small_sky_order1_catalog._ddf.columns.drop("id")


### PR DESCRIPTION
Changes dask data frame methods to use the legacy ones directly without needing to set the dask config to disable query planning.