### PR TITLE
Remove usage of pixel tree builder

### DIFF
--- a/src/lsdb/catalog/margin_catalog.py
+++ b/src/lsdb/catalog/margin_catalog.py
@@ -4,7 +4,7 @@ import hipscat as hc
 import numpy as np
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.filter import get_filtered_pixel_list
-from hipscat.pixel_tree.pixel_tree_builder import PixelTreeBuilder
+from hipscat.pixel_tree.pixel_tree import PixelTree
 
 from lsdb.catalog.dataset.healpix_dataset import HealpixDataset
 from lsdb.core.search.abstract_search import AbstractSearch
@@ -69,7 +69,7 @@ class MarginCatalog(HealpixDataset):
         margin_pixels = [HealpixPixel(margin_order, pixel) for pixel in margin_pixels]
 
         # Align the margin pixels with the catalog pixels and combine with the search pixels
-        margin_pixel_tree = PixelTreeBuilder.from_healpix(margin_pixels)
+        margin_pixel_tree = PixelTree.from_healpix(margin_pixels)
         filtered_margin_pixels = get_filtered_pixel_list(self.hc_structure.pixel_tree, margin_pixel_tree)
         filtered_pixels = list(set(filtered_search_pixels + filtered_margin_pixels))
 

--- a/src/lsdb/core/search/box_search.py
+++ b/src/lsdb/core/search/box_search.py
@@ -9,7 +9,7 @@ import pandas as pd
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.box_filter import filter_pixels_by_box, wrap_ra_angles
 from hipscat.pixel_math.validators import validate_box_search
-from hipscat.pixel_tree.pixel_tree_builder import PixelTreeBuilder
+from hipscat.pixel_tree.pixel_tree import PixelTree
 
 from lsdb.core.search.abstract_search import AbstractSearch
 
@@ -29,7 +29,7 @@ class BoxSearch(AbstractSearch):
 
     def search_partitions(self, pixels: List[HealpixPixel]) -> List[HealpixPixel]:
         """Determine the target partitions for further filtering."""
-        pixel_tree = PixelTreeBuilder.from_healpix(pixels)
+        pixel_tree = PixelTree.from_healpix(pixels)
         return filter_pixels_by_box(pixel_tree, self.ra, self.dec)
 
     def search_points(self, frame: pd.DataFrame, metadata: hc.catalog.Catalog) -> pd.DataFrame:

--- a/src/lsdb/core/search/cone_search.py
+++ b/src/lsdb/core/search/cone_search.py
@@ -7,7 +7,7 @@ from astropy.coordinates import SkyCoord
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.cone_filter import filter_pixels_by_cone
 from hipscat.pixel_math.validators import validate_declination_values, validate_radius
-from hipscat.pixel_tree.pixel_tree_builder import PixelTreeBuilder
+from hipscat.pixel_tree.pixel_tree import PixelTree
 
 from lsdb.core.search.abstract_search import AbstractSearch
 
@@ -29,7 +29,7 @@ class ConeSearch(AbstractSearch):
 
     def search_partitions(self, pixels: List[HealpixPixel]) -> List[HealpixPixel]:
         """Determine the target partitions for further filtering."""
-        pixel_tree = PixelTreeBuilder.from_healpix(pixels)
+        pixel_tree = PixelTree.from_healpix(pixels)
         return filter_pixels_by_cone(pixel_tree, self.ra, self.dec, self.radius_arcsec)
 
     def search_points(self, frame: pd.DataFrame, metadata: hc.catalog.Catalog) -> pd.DataFrame:

--- a/src/lsdb/core/search/polygon_search.py
+++ b/src/lsdb/core/search/polygon_search.py
@@ -12,7 +12,7 @@ from hipscat.pixel_math.polygon_filter import (
     filter_pixels_by_polygon,
 )
 from hipscat.pixel_math.validators import validate_declination_values, validate_polygon
-from hipscat.pixel_tree.pixel_tree_builder import PixelTreeBuilder
+from hipscat.pixel_tree.pixel_tree import PixelTree
 from lsst.sphgeom import ConvexPolygon, UnitVector3d
 
 from lsdb.core.search.abstract_search import AbstractSearch
@@ -32,7 +32,7 @@ class PolygonSearch(AbstractSearch):
 
     def search_partitions(self, pixels: List[HealpixPixel]) -> List[HealpixPixel]:
         """Determine the target partitions for further filtering."""
-        pixel_tree = PixelTreeBuilder.from_healpix(pixels)
+        pixel_tree = PixelTree.from_healpix(pixels)
         return filter_pixels_by_polygon(pixel_tree, self.vertices_xyz)
 
     def search_points(self, frame: pd.DataFrame, metadata: hc.catalog.Catalog) -> pd.DataFrame:


### PR DESCRIPTION
Removes the usage of the `PixelTreeBuilder` class which was deleted from hipscat in https://github.com/astronomy-commons/hipscat/pull/266.