### PR TITLE
Change `require_right_margin` default and update warning message

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -40,7 +40,7 @@ def time_kdtree_crossmatch():
     """Time computations are prefixed with 'time'."""
     small_sky = load_small_sky()
     small_sky_xmatch = load_small_sky_xmatch()
-    small_sky.crossmatch(small_sky_xmatch, require_right_margin=False).compute()
+    small_sky.crossmatch(small_sky_xmatch).compute()
 
 
 def time_polygon_search():

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -40,7 +40,7 @@ def time_kdtree_crossmatch():
     """Time computations are prefixed with 'time'."""
     small_sky = load_small_sky()
     small_sky_xmatch = load_small_sky_xmatch()
-    small_sky.crossmatch(small_sky_xmatch).compute()
+    small_sky.crossmatch(small_sky_xmatch, require_right_margin=False).compute()
 
 
 def time_polygon_search():

--- a/src/lsdb/core/crossmatch/bounded_kdtree_match.py
+++ b/src/lsdb/core/crossmatch/bounded_kdtree_match.py
@@ -14,7 +14,7 @@ class BoundedKdTreeCrossmatch(KdTreeCrossmatch):
         self,
         n_neighbors: int = 1,
         radius_arcsec: float = 1,
-        require_right_margin: bool = True,
+        require_right_margin: bool = False,
         min_radius_arcsec: float = 0,
     ):
         super().validate(n_neighbors, radius_arcsec, require_right_margin)
@@ -28,7 +28,7 @@ class BoundedKdTreeCrossmatch(KdTreeCrossmatch):
         n_neighbors: int = 1,
         radius_arcsec: float = 1,
         # We need it here because the signature is shared with .validate()
-        require_right_margin: bool = True,  # pylint: disable=unused-argument
+        require_right_margin: bool = False,  # pylint: disable=unused-argument
         min_radius_arcsec: float = 0,
     ) -> pd.DataFrame:
         """Perform a cross-match between the data from two HEALPix pixels

--- a/src/lsdb/core/crossmatch/kdtree_match.py
+++ b/src/lsdb/core/crossmatch/kdtree_match.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import Tuple
 
 import numpy as np
@@ -21,7 +22,7 @@ class KdTreeCrossmatch(AbstractCrossmatchAlgorithm):
         self,
         n_neighbors: int = 1,
         radius_arcsec: float = 1,
-        require_right_margin=True,
+        require_right_margin: bool = False,
     ):
         super().validate()
         # Validate radius
@@ -32,7 +33,8 @@ class KdTreeCrossmatch(AbstractCrossmatchAlgorithm):
         # Check that the margin exists and has a compatible radius.
         if self.right_margin_hc_structure is None:
             if require_right_margin:
-                raise ValueError("Right margin is required for cross-match")
+                raise ValueError("Right catalog margin is required for cross-match")
+            warnings.warn("Right catalog does not have a margin cache. Results may be inaccurate")
         else:
             if self.right_margin_hc_structure.catalog_info.margin_threshold < radius_arcsec:
                 raise ValueError("Cross match radius is greater than margin threshold")
@@ -42,7 +44,7 @@ class KdTreeCrossmatch(AbstractCrossmatchAlgorithm):
         n_neighbors: int = 1,
         radius_arcsec: float = 1,
         # We need it here because the signature is shared with .validate()
-        require_right_margin=True,  # pylint: disable=unused-argument
+        require_right_margin: bool = False,  # pylint: disable=unused-argument
     ) -> pd.DataFrame:
         """Perform a cross-match between the data from two HEALPix pixels
 

--- a/src/lsdb/core/crossmatch/kdtree_match.py
+++ b/src/lsdb/core/crossmatch/kdtree_match.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from typing import Tuple
 
 import numpy as np
@@ -33,8 +32,7 @@ class KdTreeCrossmatch(AbstractCrossmatchAlgorithm):
         # Check that the margin exists and has a compatible radius.
         if self.right_margin_hc_structure is None:
             if require_right_margin:
-                raise ValueError("Right catalog margin is required for cross-match")
-            warnings.warn("Right catalog does not have a margin cache. Results may be inaccurate")
+                raise ValueError("Right catalog margin cache is required for cross-match.")
         else:
             if self.right_margin_hc_structure.catalog_info.margin_threshold < radius_arcsec:
                 raise ValueError("Cross match radius is greater than margin threshold")

--- a/src/lsdb/dask/crossmatch_catalog_data.py
+++ b/src/lsdb/dask/crossmatch_catalog_data.py
@@ -115,7 +115,7 @@ def crossmatch_catalog_data(
 
     if right.margin is None:
         warnings.warn(
-            "Right catalog does not have a margin cache. Results may be incomplete or inaccurate.",
+            "Right catalog does not have a margin cache. Results may be incomplete and/or inaccurate.",
             RuntimeWarning,
         )
 

--- a/src/lsdb/dask/crossmatch_catalog_data.py
+++ b/src/lsdb/dask/crossmatch_catalog_data.py
@@ -114,7 +114,10 @@ def crossmatch_catalog_data(
     meta_df_crossmatch.validate(**kwargs)
 
     if right.margin is None:
-        warnings.warn("Right catalog does not have a margin cache. Results may be inaccurate", RuntimeWarning)
+        warnings.warn(
+            "Right catalog does not have a margin cache. Results may be incomplete or inaccurate.",
+            RuntimeWarning,
+        )
 
     # perform alignment on the two catalogs
     alignment = align_catalogs(left, right)

--- a/src/lsdb/dask/join_catalog_data.py
+++ b/src/lsdb/dask/join_catalog_data.py
@@ -193,7 +193,7 @@ def join_catalog_data_on(
     """
     if right.margin is None:
         warnings.warn(
-            "Right catalog does not have a margin cache. Results may be incomplete or inaccurate.",
+            "Right catalog does not have a margin cache. Results may be incomplete and/or inaccurate.",
             RuntimeWarning,
         )
 
@@ -249,7 +249,7 @@ def join_catalog_data_through(
 
     if right.margin is None:
         warnings.warn(
-            "Right catalog does not have a margin cache. Results may be incomplete or inaccurate.",
+            "Right catalog does not have a margin cache. Results may be incomplete and/or inaccurate.",
             RuntimeWarning,
         )
 

--- a/src/lsdb/dask/join_catalog_data.py
+++ b/src/lsdb/dask/join_catalog_data.py
@@ -192,7 +192,10 @@ def join_catalog_data_on(
         catalogs.
     """
     if right.margin is None:
-        warnings.warn("Right catalog does not have a margin cache. Results may be inaccurate", RuntimeWarning)
+        warnings.warn(
+            "Right catalog does not have a margin cache. Results may be incomplete or inaccurate.",
+            RuntimeWarning,
+        )
 
     alignment = align_catalogs(left, right)
 
@@ -245,7 +248,10 @@ def join_catalog_data_through(
         )
 
     if right.margin is None:
-        warnings.warn("Right catalog does not have a margin cache. Results may be inaccurate", RuntimeWarning)
+        warnings.warn(
+            "Right catalog does not have a margin cache. Results may be incomplete or inaccurate.",
+            RuntimeWarning,
+        )
 
     alignment = align_catalogs(left, right)
 

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -15,10 +15,7 @@ class TestCrossmatch:
     def test_kdtree_crossmatch(algo, small_sky_catalog, small_sky_xmatch_catalog, xmatch_correct):
         with pytest.warns(RuntimeWarning, match="Results may be inaccurate"):
             xmatched = small_sky_catalog.crossmatch(
-                small_sky_xmatch_catalog,
-                algorithm=algo,
-                radius_arcsec=0.01 * 3600,
-                require_right_margin=False,
+                small_sky_xmatch_catalog, algorithm=algo, radius_arcsec=0.01 * 3600
             ).compute()
         assert len(xmatched) == len(xmatch_correct)
         for _, correct_row in xmatch_correct.iterrows():
@@ -34,7 +31,6 @@ class TestCrossmatch:
                 small_sky_xmatch_catalog,
                 radius_arcsec=0.005 * 3600,
                 algorithm=algo,
-                require_right_margin=False,
             ).compute()
         assert len(xmatched) == len(xmatch_correct_005)
         for _, correct_row in xmatch_correct_005.iterrows():
@@ -53,7 +49,6 @@ class TestCrossmatch:
                 n_neighbors=3,
                 radius_arcsec=2 * 3600,
                 algorithm=algo,
-                require_right_margin=False,
             ).compute()
         assert len(xmatched) == len(xmatch_correct_3n_2t_no_margin)
         for _, correct_row in xmatch_correct_3n_2t_no_margin.iterrows():
@@ -127,7 +122,6 @@ class TestBoundedCrossmatch:
                 radius_arcsec=0.005 * 3600,
                 min_radius_arcsec=0.002 * 3600,
                 algorithm=algo,
-                require_right_margin=False,
             ).compute()
         assert len(xmatched) == len(xmatch_correct_002_005)
         for _, correct_row in xmatch_correct_002_005.iterrows():
@@ -153,7 +147,6 @@ class TestBoundedCrossmatch:
             radius_arcsec=2 * 3600,
             min_radius_arcsec=0.5 * 3600,
             algorithm=algo,
-            require_right_margin=False,
         ).compute()
         assert len(xmatched) == len(xmatch_correct_05_2_3n_margin)
         for _, correct_row in xmatch_correct_05_2_3n_margin.iterrows():
@@ -177,7 +170,6 @@ class TestBoundedCrossmatch:
                 radius_arcsec=0.005 * 3600,
                 min_radius_arcsec=1,
                 algorithm=algo,
-                require_right_margin=False,
             ).compute()
         assert len(xmatched) == len(xmatch_correct_005)
         for _, correct_row in xmatch_correct_005.iterrows():
@@ -199,7 +191,6 @@ class TestBoundedCrossmatch:
                 radius_arcsec=2 * 3600,
                 min_radius_arcsec=0.5 * 3600,
                 algorithm=algo,
-                require_right_margin=False,
             ).compute()
         assert len(xmatched) == 72
         assert all(xmatched.groupby("id_small_sky").size()) <= 50
@@ -209,13 +200,13 @@ class TestBoundedCrossmatch:
         # Read a second small sky catalog to not have duplicate labels
         small_sky_catalog_2 = lsdb.read_hipscat(small_sky_dir)
         small_sky_catalog_2.hc_structure.catalog_name = "small_sky_2"
-        xmatched = small_sky_catalog.crossmatch(
-            small_sky_catalog_2,
-            min_radius_arcsec=0,
-            radius_arcsec=0.005 * 3600,
-            algorithm=algo,
-            require_right_margin=False,
-        ).compute()
+        with pytest.warns(RuntimeWarning, match="Results may be inaccurate"):
+            xmatched = small_sky_catalog.crossmatch(
+                small_sky_catalog_2,
+                min_radius_arcsec=0,
+                radius_arcsec=0.005 * 3600,
+                algorithm=algo,
+            ).compute()
         assert len(xmatched) == len(small_sky_catalog.compute())
         assert all(xmatched["_dist_arcsec"] == 0)
 

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -13,7 +13,7 @@ from lsdb.core.crossmatch.kdtree_match import KdTreeCrossmatch
 class TestCrossmatch:
     @staticmethod
     def test_kdtree_crossmatch(algo, small_sky_catalog, small_sky_xmatch_catalog, xmatch_correct):
-        with pytest.warns(RuntimeWarning, match="Results may be inaccurate"):
+        with pytest.warns(RuntimeWarning, match="Results may be incomplete or inaccurate"):
             xmatched = small_sky_catalog.crossmatch(
                 small_sky_xmatch_catalog, algorithm=algo, radius_arcsec=0.01 * 3600
             ).compute()
@@ -26,7 +26,7 @@ class TestCrossmatch:
 
     @staticmethod
     def test_kdtree_crossmatch_thresh(algo, small_sky_catalog, small_sky_xmatch_catalog, xmatch_correct_005):
-        with pytest.warns(RuntimeWarning, match="Results may be inaccurate"):
+        with pytest.warns(RuntimeWarning, match="Results may be incomplete or inaccurate"):
             xmatched = small_sky_catalog.crossmatch(
                 small_sky_xmatch_catalog,
                 radius_arcsec=0.005 * 3600,
@@ -43,7 +43,7 @@ class TestCrossmatch:
     def test_kdtree_crossmatch_multiple_neighbors(
         algo, small_sky_catalog, small_sky_xmatch_catalog, xmatch_correct_3n_2t_no_margin
     ):
-        with pytest.warns(RuntimeWarning, match="Results may be inaccurate"):
+        with pytest.warns(RuntimeWarning, match="Results may be incomplete or inaccurate"):
             xmatched = small_sky_catalog.crossmatch(
                 small_sky_xmatch_catalog,
                 n_neighbors=3,
@@ -116,7 +116,7 @@ class TestBoundedCrossmatch:
     def test_kdtree_crossmatch_min_thresh(
         algo, small_sky_catalog, small_sky_xmatch_catalog, xmatch_correct_002_005
     ):
-        with pytest.warns(RuntimeWarning, match="Results may be inaccurate"):
+        with pytest.warns(RuntimeWarning, match="Results may be incomplete or inaccurate"):
             xmatched = small_sky_catalog.crossmatch(
                 small_sky_xmatch_catalog,
                 radius_arcsec=0.005 * 3600,
@@ -164,7 +164,7 @@ class TestBoundedCrossmatch:
     ):
         # Set a very small minimum radius so that there is not a single point
         # with a very close neighbor
-        with pytest.warns(RuntimeWarning, match="Results may be inaccurate"):
+        with pytest.warns(RuntimeWarning, match="Results may be incomplete or inaccurate"):
             xmatched = small_sky_catalog.crossmatch(
                 small_sky_xmatch_catalog,
                 radius_arcsec=0.005 * 3600,
@@ -184,7 +184,7 @@ class TestBoundedCrossmatch:
     ):
         # The small_sky_xmatch catalog has 3 partitions (2 of length 41 and 1 of length 29).
         # Let's use n_neighbors above that to request more neighbors than there are points available.
-        with pytest.warns(RuntimeWarning, match="Results may be inaccurate"):
+        with pytest.warns(RuntimeWarning, match="Results may be incomplete or inaccurate"):
             xmatched = small_sky_catalog.crossmatch(
                 small_sky_xmatch_catalog,
                 n_neighbors=50,
@@ -200,7 +200,7 @@ class TestBoundedCrossmatch:
         # Read a second small sky catalog to not have duplicate labels
         small_sky_catalog_2 = lsdb.read_hipscat(small_sky_dir)
         small_sky_catalog_2.hc_structure.catalog_name = "small_sky_2"
-        with pytest.warns(RuntimeWarning, match="Results may be inaccurate"):
+        with pytest.warns(RuntimeWarning, match="Results may be incomplete or inaccurate"):
             xmatched = small_sky_catalog.crossmatch(
                 small_sky_catalog_2,
                 min_radius_arcsec=0,
@@ -250,7 +250,7 @@ class MockCrossmatchAlgorithm(AbstractCrossmatchAlgorithm):
 
 
 def test_custom_crossmatch_algorithm(small_sky_catalog, small_sky_xmatch_catalog, xmatch_mock):
-    with pytest.warns(RuntimeWarning, match="Results may be inaccurate"):
+    with pytest.warns(RuntimeWarning, match="Results may be incomplete or inaccurate"):
         xmatched = small_sky_catalog.crossmatch(
             small_sky_xmatch_catalog, algorithm=MockCrossmatchAlgorithm, mock_results=xmatch_mock
         ).compute()

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -13,7 +13,7 @@ from lsdb.core.crossmatch.kdtree_match import KdTreeCrossmatch
 class TestCrossmatch:
     @staticmethod
     def test_kdtree_crossmatch(algo, small_sky_catalog, small_sky_xmatch_catalog, xmatch_correct):
-        with pytest.warns(RuntimeWarning, match="Results may be incomplete or inaccurate"):
+        with pytest.warns(RuntimeWarning, match="Results may be incomplete and/or inaccurate"):
             xmatched = small_sky_catalog.crossmatch(
                 small_sky_xmatch_catalog, algorithm=algo, radius_arcsec=0.01 * 3600
             ).compute()
@@ -26,7 +26,7 @@ class TestCrossmatch:
 
     @staticmethod
     def test_kdtree_crossmatch_thresh(algo, small_sky_catalog, small_sky_xmatch_catalog, xmatch_correct_005):
-        with pytest.warns(RuntimeWarning, match="Results may be incomplete or inaccurate"):
+        with pytest.warns(RuntimeWarning, match="Results may be incomplete and/or inaccurate"):
             xmatched = small_sky_catalog.crossmatch(
                 small_sky_xmatch_catalog,
                 radius_arcsec=0.005 * 3600,
@@ -43,7 +43,7 @@ class TestCrossmatch:
     def test_kdtree_crossmatch_multiple_neighbors(
         algo, small_sky_catalog, small_sky_xmatch_catalog, xmatch_correct_3n_2t_no_margin
     ):
-        with pytest.warns(RuntimeWarning, match="Results may be incomplete or inaccurate"):
+        with pytest.warns(RuntimeWarning, match="Results may be incomplete and/or inaccurate"):
             xmatched = small_sky_catalog.crossmatch(
                 small_sky_xmatch_catalog,
                 n_neighbors=3,
@@ -116,7 +116,7 @@ class TestBoundedCrossmatch:
     def test_kdtree_crossmatch_min_thresh(
         algo, small_sky_catalog, small_sky_xmatch_catalog, xmatch_correct_002_005
     ):
-        with pytest.warns(RuntimeWarning, match="Results may be incomplete or inaccurate"):
+        with pytest.warns(RuntimeWarning, match="Results may be incomplete and/or inaccurate"):
             xmatched = small_sky_catalog.crossmatch(
                 small_sky_xmatch_catalog,
                 radius_arcsec=0.005 * 3600,
@@ -164,7 +164,7 @@ class TestBoundedCrossmatch:
     ):
         # Set a very small minimum radius so that there is not a single point
         # with a very close neighbor
-        with pytest.warns(RuntimeWarning, match="Results may be incomplete or inaccurate"):
+        with pytest.warns(RuntimeWarning, match="Results may be incomplete and/or inaccurate"):
             xmatched = small_sky_catalog.crossmatch(
                 small_sky_xmatch_catalog,
                 radius_arcsec=0.005 * 3600,
@@ -184,7 +184,7 @@ class TestBoundedCrossmatch:
     ):
         # The small_sky_xmatch catalog has 3 partitions (2 of length 41 and 1 of length 29).
         # Let's use n_neighbors above that to request more neighbors than there are points available.
-        with pytest.warns(RuntimeWarning, match="Results may be incomplete or inaccurate"):
+        with pytest.warns(RuntimeWarning, match="Results may be incomplete and/or inaccurate"):
             xmatched = small_sky_catalog.crossmatch(
                 small_sky_xmatch_catalog,
                 n_neighbors=50,
@@ -200,7 +200,7 @@ class TestBoundedCrossmatch:
         # Read a second small sky catalog to not have duplicate labels
         small_sky_catalog_2 = lsdb.read_hipscat(small_sky_dir)
         small_sky_catalog_2.hc_structure.catalog_name = "small_sky_2"
-        with pytest.warns(RuntimeWarning, match="Results may be incomplete or inaccurate"):
+        with pytest.warns(RuntimeWarning, match="Results may be incomplete and/or inaccurate"):
             xmatched = small_sky_catalog.crossmatch(
                 small_sky_catalog_2,
                 min_radius_arcsec=0,
@@ -250,7 +250,7 @@ class MockCrossmatchAlgorithm(AbstractCrossmatchAlgorithm):
 
 
 def test_custom_crossmatch_algorithm(small_sky_catalog, small_sky_xmatch_catalog, xmatch_mock):
-    with pytest.warns(RuntimeWarning, match="Results may be incomplete or inaccurate"):
+    with pytest.warns(RuntimeWarning, match="Results may be incomplete and/or inaccurate"):
         xmatched = small_sky_catalog.crossmatch(
             small_sky_xmatch_catalog, algorithm=MockCrossmatchAlgorithm, mock_results=xmatch_mock
         ).compute()

--- a/tests/lsdb/core/test_kdtree_validation.py
+++ b/tests/lsdb/core/test_kdtree_validation.py
@@ -50,10 +50,8 @@ def test_bounded_kdtree_radius_invalid(bounded_kdtree_crossmatch):
 
 def test_kdtree_no_margin(kdtree_crossmatch):
     kdtree_crossmatch.right_margin_hc_structure = None
-    with pytest.raises(ValueError, match="Right catalog margin is required"):
+    with pytest.raises(ValueError, match="Right catalog margin cache is required for cross-match"):
         kdtree_crossmatch.validate(require_right_margin=True)
-
-    kdtree_crossmatch.validate(require_right_margin=False)
 
 
 def test_kdtree_left_columns(kdtree_crossmatch):

--- a/tests/lsdb/core/test_kdtree_validation.py
+++ b/tests/lsdb/core/test_kdtree_validation.py
@@ -50,8 +50,8 @@ def test_bounded_kdtree_radius_invalid(bounded_kdtree_crossmatch):
 
 def test_kdtree_no_margin(kdtree_crossmatch):
     kdtree_crossmatch.right_margin_hc_structure = None
-    with pytest.raises(ValueError, match="Right margin is required"):
-        kdtree_crossmatch.validate()
+    with pytest.raises(ValueError, match="Right catalog margin is required"):
+        kdtree_crossmatch.validate(require_right_margin=True)
 
     kdtree_crossmatch.validate(require_right_margin=False)
 


### PR DESCRIPTION
Changes the crossmatch `require_right_margin` argument to be False, by default. It also updates the warning messages issued when the right catalog does not have a margin. Closes #296 and #297. 