### PR TITLE
Require new hipscat.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     # dask distributed eases the creation of parallel dask clients.
     # dask diagnostics is required to spin up the dashboard for profiling.
     "dask[complete]",
-    "hipscat>=0.3",
+    "hipscat>=0.3.1",
     "pyarrow",
     "deprecated",
     "scipy", # kdtree


### PR DESCRIPTION
LSDB v0.2.1 and hipscat 0.3.1 fails with message like:

`ModuleNotFoundError: No module named 'hipscat.pixel_tree.pixel_tree_builder'`

I'd like to require hipscat v0.3.1, and tag a new released of lsdb.

