### PR TITLE
Only pass catalog_info to delayed tasks instead of full hipscat catalog metadata

### DIFF
--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -150,7 +150,7 @@ class HealpixDataset(Dataset):
         partitions = self._ddf.to_delayed()
         targeted_partitions = [partitions[self._ddf_pixel_map[pixel]] for pixel in filtered_pixels]
         filtered_partitions = (
-            [search.search_points(partition, metadata) for partition in targeted_partitions]
+            [search.search_points(partition, metadata.catalog_info) for partition in targeted_partitions]
             if fine
             else targeted_partitions
         )

--- a/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
+++ b/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
@@ -38,11 +38,11 @@ class AbstractCrossmatchAlgorithm(ABC):
             left_pixel (int): The HEALPix pixel number in NESTED ordering of the left pixel
             right_order (int): The HEALPix order of the right pixel
             right_pixel (int): The HEALPix pixel number in NESTED ordering of the right pixel
-            left_metadata (hipscat.CatalogInfo): The hipscat CatalogInfo object with the metadata of the
+            left_catalog_info (hipscat.CatalogInfo): The hipscat CatalogInfo object with the metadata of the
                 left catalog
-            right_metadata (hipscat.CatalogInfo): The hipscat CatalogInfo object with the metadata of the
+            right_catalog_info (hipscat.CatalogInfo): The hipscat CatalogInfo object with the metadata of the
                 right catalog
-            right_margin_hc_structure (hipscat.MarginCacheCatalogInfo): The hipscat MarginCacheCatalogInfo
+            right_margin_catalog_info (hipscat.MarginCacheCatalogInfo): The hipscat MarginCacheCatalogInfo
                 objects with the metadata of the right **margin** catalog
             suffixes (Tuple[str,str]): A pair of suffixes to be appended to the end of each column
                 name, with the first appended to the left columns and the second to the right

--- a/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
+++ b/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Tuple
 
-import hipscat as hc
 import pandas as pd
 from hipscat.catalog.catalog_info import CatalogInfo
 from hipscat.catalog.margin_cache import MarginCacheCatalogInfo

--- a/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
+++ b/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
@@ -5,6 +5,8 @@ from typing import Tuple
 
 import hipscat as hc
 import pandas as pd
+from hipscat.catalog.catalog_info import CatalogInfo
+from hipscat.catalog.margin_cache import MarginCacheCatalogInfo
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
 
 
@@ -23,9 +25,9 @@ class AbstractCrossmatchAlgorithm(ABC):
         left_pixel: int,
         right_order: int,
         right_pixel: int,
-        left_metadata: hc.catalog.Catalog,
-        right_metadata: hc.catalog.Catalog,
-        right_margin_hc_structure: hc.catalog.MarginCatalog | None,
+        left_catalog_info: CatalogInfo,
+        right_catalog_info: CatalogInfo,
+        right_margin_catalog_info: MarginCacheCatalogInfo | None,
         suffixes: Tuple[str, str],
     ):
         """Initializes a crossmatch algorithm
@@ -37,12 +39,12 @@ class AbstractCrossmatchAlgorithm(ABC):
             left_pixel (int): The HEALPix pixel number in NESTED ordering of the left pixel
             right_order (int): The HEALPix order of the right pixel
             right_pixel (int): The HEALPix pixel number in NESTED ordering of the right pixel
-            left_metadata (hipscat.Catalog): The hipscat Catalog object with the metadata of the
+            left_metadata (hipscat.CatalogInfo): The hipscat CatalogInfo object with the metadata of the
                 left catalog
-            right_metadata (hipscat.Catalog): The hipscat Catalog object with the metadata of the
+            right_metadata (hipscat.CatalogInfo): The hipscat CatalogInfo object with the metadata of the
                 right catalog
-            right_margin_hc_structure (hipscat.MarginCatalog): The hipscat MarginCatalog objects
-                with the metadata of the right **margin** catalog
+            right_margin_hc_structure (hipscat.MarginCacheCatalogInfo): The hipscat MarginCacheCatalogInfo
+                objects with the metadata of the right **margin** catalog
             suffixes (Tuple[str,str]): A pair of suffixes to be appended to the end of each column
                 name, with the first appended to the left columns and the second to the right
                 columns
@@ -53,9 +55,9 @@ class AbstractCrossmatchAlgorithm(ABC):
         self.left_pixel = left_pixel
         self.right_order = right_order
         self.right_pixel = right_pixel
-        self.left_metadata = left_metadata
-        self.right_metadata = right_metadata
-        self.right_margin_hc_structure = right_margin_hc_structure
+        self.left_catalog_info = left_catalog_info
+        self.right_catalog_info = right_catalog_info
+        self.right_margin_catalog_info = right_margin_catalog_info
         self.suffixes = suffixes
 
     @abstractmethod
@@ -76,16 +78,16 @@ class AbstractCrossmatchAlgorithm(ABC):
         if self.right.index.name != HIPSCAT_ID_COLUMN:
             raise ValueError(f"index of right table must be {HIPSCAT_ID_COLUMN}")
         column_names = self.left.columns
-        if self.left_metadata.catalog_info.ra_column not in column_names:
-            raise ValueError(f"left table must have column {self.left_metadata.catalog_info.ra_column}")
-        if self.left_metadata.catalog_info.dec_column not in column_names:
-            raise ValueError(f"left table must have column {self.left_metadata.catalog_info.dec_column}")
+        if self.left_catalog_info.ra_column not in column_names:
+            raise ValueError(f"left table must have column {self.left_catalog_info.ra_column}")
+        if self.left_catalog_info.dec_column not in column_names:
+            raise ValueError(f"left table must have column {self.left_catalog_info.dec_column}")
 
         column_names = self.right.columns
-        if self.right_metadata.catalog_info.ra_column not in column_names:
-            raise ValueError(f"right table must have column {self.right_metadata.catalog_info.ra_column}")
-        if self.right_metadata.catalog_info.dec_column not in column_names:
-            raise ValueError(f"right table must have column {self.right_metadata.catalog_info.dec_column}")
+        if self.right_catalog_info.ra_column not in column_names:
+            raise ValueError(f"right table must have column {self.right_catalog_info.ra_column}")
+        if self.right_catalog_info.dec_column not in column_names:
+            raise ValueError(f"right table must have column {self.right_catalog_info.dec_column}")
 
     @staticmethod
     def _rename_columns_with_suffix(dataframe, suffix):

--- a/src/lsdb/core/crossmatch/kdtree_match.py
+++ b/src/lsdb/core/crossmatch/kdtree_match.py
@@ -31,11 +31,11 @@ class KdTreeCrossmatch(AbstractCrossmatchAlgorithm):
         if n_neighbors < 1:
             raise ValueError("n_neighbors must be greater than 1")
         # Check that the margin exists and has a compatible radius.
-        if self.right_margin_hc_structure is None:
+        if self.right_margin_catalog_info is None:
             if require_right_margin:
                 raise ValueError("Right catalog margin cache is required for cross-match.")
         else:
-            if self.right_margin_hc_structure.catalog_info.margin_threshold < radius_arcsec:
+            if self.right_margin_catalog_info.margin_threshold < radius_arcsec:
                 raise ValueError("Cross match radius is greater than margin threshold")
 
     def crossmatch(
@@ -73,12 +73,12 @@ class KdTreeCrossmatch(AbstractCrossmatchAlgorithm):
 
     def _get_point_coordinates(self) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
         left_xyz = _lon_lat_to_xyz(
-            lon=self.left[self.left_metadata.catalog_info.ra_column].to_numpy(),
-            lat=self.left[self.left_metadata.catalog_info.dec_column].to_numpy(),
+            lon=self.left[self.left_catalog_info.ra_column].to_numpy(),
+            lat=self.left[self.left_catalog_info.dec_column].to_numpy(),
         )
         right_xyz = _lon_lat_to_xyz(
-            lon=self.right[self.right_metadata.catalog_info.ra_column].to_numpy(),
-            lat=self.right[self.right_metadata.catalog_info.dec_column].to_numpy(),
+            lon=self.right[self.right_catalog_info.ra_column].to_numpy(),
+            lat=self.right[self.right_catalog_info.dec_column].to_numpy(),
         )
         return left_xyz, right_xyz
 

--- a/src/lsdb/core/search/abstract_search.py
+++ b/src/lsdb/core/search/abstract_search.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import List
 
-import hipscat as hc
 import pandas as pd
 from hipscat.catalog.catalog_info import CatalogInfo
 from hipscat.pixel_math import HealpixPixel

--- a/src/lsdb/core/search/abstract_search.py
+++ b/src/lsdb/core/search/abstract_search.py
@@ -5,6 +5,7 @@ from typing import List
 
 import hipscat as hc
 import pandas as pd
+from hipscat.catalog.catalog_info import CatalogInfo
 from hipscat.pixel_math import HealpixPixel
 
 
@@ -25,5 +26,5 @@ class AbstractSearch(ABC):
         """Determine the target partitions for further filtering."""
 
     @abstractmethod
-    def search_points(self, frame: pd.DataFrame, metadata: hc.catalog.Catalog) -> pd.DataFrame:
+    def search_points(self, frame: pd.DataFrame, metadata: CatalogInfo) -> pd.DataFrame:
         """Determine the search results within a data frame"""

--- a/src/lsdb/core/search/box_search.py
+++ b/src/lsdb/core/search/box_search.py
@@ -6,6 +6,7 @@ import dask
 import hipscat as hc
 import numpy as np
 import pandas as pd
+from hipscat.catalog.catalog_info import CatalogInfo
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.box_filter import filter_pixels_by_box, wrap_ra_angles
 from hipscat.pixel_math.validators import validate_box_search
@@ -32,7 +33,7 @@ class BoxSearch(AbstractSearch):
         pixel_tree = PixelTree.from_healpix(pixels)
         return filter_pixels_by_box(pixel_tree, self.ra, self.dec)
 
-    def search_points(self, frame: pd.DataFrame, metadata: hc.catalog.Catalog) -> pd.DataFrame:
+    def search_points(self, frame: pd.DataFrame, metadata: CatalogInfo) -> pd.DataFrame:
         """Determine the search results within a data frame"""
         return box_filter(frame, self.ra, self.dec, metadata)
 
@@ -42,7 +43,7 @@ def box_filter(
     data_frame: pd.DataFrame,
     ra: Tuple[float, float] | None,
     dec: Tuple[float, float] | None,
-    metadata: hc.catalog.Catalog,
+    metadata: CatalogInfo,
 ):
     """Filters a dataframe to only include points within the specified box region.
 
@@ -57,12 +58,12 @@ def box_filter(
     """
     mask = np.ones(len(data_frame), dtype=bool)
     if ra is not None:
-        ra_values = data_frame[metadata.catalog_info.ra_column]
+        ra_values = data_frame[metadata.ra_column]
         wrapped_ra = np.asarray(wrap_ra_angles(ra_values))
         mask_ra = _create_ra_mask(ra, wrapped_ra)
         mask = np.logical_and(mask, mask_ra)
     if dec is not None:
-        dec_values = data_frame[metadata.catalog_info.dec_column].to_numpy()
+        dec_values = data_frame[metadata.dec_column].to_numpy()
         mask_dec = np.logical_and(dec[0] <= dec_values, dec_values <= dec[1])
         mask = np.logical_and(mask, mask_dec)
     data_frame = data_frame.iloc[mask]

--- a/src/lsdb/core/search/box_search.py
+++ b/src/lsdb/core/search/box_search.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import List, Tuple
 
 import dask
-import hipscat as hc
 import numpy as np
 import pandas as pd
 from hipscat.catalog.catalog_info import CatalogInfo

--- a/src/lsdb/core/search/cone_search.py
+++ b/src/lsdb/core/search/cone_search.py
@@ -1,7 +1,6 @@
 from typing import List
 
 import dask
-import hipscat as hc
 import pandas as pd
 from astropy.coordinates import SkyCoord
 from hipscat.catalog.catalog_info import CatalogInfo

--- a/src/lsdb/core/search/polygon_search.py
+++ b/src/lsdb/core/search/polygon_search.py
@@ -5,6 +5,7 @@ import healpy as hp
 import hipscat as hc
 import numpy as np
 import pandas as pd
+from hipscat.catalog.catalog_info import CatalogInfo
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.polygon_filter import (
     CartesianCoordinates,
@@ -35,13 +36,13 @@ class PolygonSearch(AbstractSearch):
         pixel_tree = PixelTree.from_healpix(pixels)
         return filter_pixels_by_polygon(pixel_tree, self.vertices_xyz)
 
-    def search_points(self, frame: pd.DataFrame, metadata: hc.catalog.Catalog) -> pd.DataFrame:
+    def search_points(self, frame: pd.DataFrame, metadata: CatalogInfo) -> pd.DataFrame:
         """Determine the search results within a data frame"""
         return polygon_filter(frame, self.polygon, metadata)
 
 
 @dask.delayed
-def polygon_filter(data_frame: pd.DataFrame, polygon: ConvexPolygon, metadata: hc.catalog.Catalog):
+def polygon_filter(data_frame: pd.DataFrame, polygon: ConvexPolygon, metadata: CatalogInfo):
     """Filters a dataframe to only include points within the specified polygon.
 
     Args:
@@ -52,8 +53,8 @@ def polygon_filter(data_frame: pd.DataFrame, polygon: ConvexPolygon, metadata: h
     Returns:
         A new DataFrame with the rows from `dataframe` filtered to only the pixels inside the polygon.
     """
-    ra_values = np.radians(data_frame[metadata.catalog_info.ra_column].to_numpy())
-    dec_values = np.radians(data_frame[metadata.catalog_info.dec_column].to_numpy())
+    ra_values = np.radians(data_frame[metadata.ra_column].to_numpy())
+    dec_values = np.radians(data_frame[metadata.dec_column].to_numpy())
     inside_polygon = polygon.contains(ra_values, dec_values)
     data_frame = data_frame.iloc[inside_polygon]
     return data_frame

--- a/src/lsdb/core/search/polygon_search.py
+++ b/src/lsdb/core/search/polygon_search.py
@@ -2,7 +2,6 @@ from typing import List, Tuple
 
 import dask
 import healpy as hp
-import hipscat as hc
 import numpy as np
 import pandas as pd
 from hipscat.catalog.catalog_info import CatalogInfo

--- a/src/lsdb/dask/crossmatch_catalog_data.py
+++ b/src/lsdb/dask/crossmatch_catalog_data.py
@@ -36,9 +36,9 @@ def perform_crossmatch(
     left_pix,
     right_pix,
     right_margin_pix,
-    left_hc_structure,
-    right_hc_structure,
-    right_margin_hc_structure,
+    left_catalog_info,
+    right_catalog_info,
+    right_margin_catalog_info,
     algorithm,
     suffixes,
     right_columns,
@@ -61,9 +61,9 @@ def perform_crossmatch(
         left_pix.pixel,
         right_pix.order,
         right_pix.pixel,
-        left_hc_structure,
-        right_hc_structure,
-        right_margin_hc_structure,
+        left_catalog_info,
+        right_catalog_info,
+        right_margin_catalog_info,
         suffixes,
     ).crossmatch(**kwargs)
 
@@ -106,9 +106,9 @@ def crossmatch_catalog_data(
         0,
         0,
         0,
-        left.hc_structure,
-        right.hc_structure,
-        right.margin.hc_structure if right.margin is not None else None,
+        left.hc_structure.catalog_info,
+        right.hc_structure.catalog_info,
+        right.margin.hc_structure.catalog_info if right.margin is not None else None,
         suffixes,
     )
     meta_df_crossmatch.validate(**kwargs)

--- a/src/lsdb/dask/join_catalog_data.py
+++ b/src/lsdb/dask/join_catalog_data.py
@@ -9,6 +9,9 @@ import dask
 import dask.dataframe as dd
 import hipscat as hc
 import pandas as pd
+from hipscat.catalog.association_catalog import AssociationCatalogInfo
+from hipscat.catalog.catalog_info import CatalogInfo
+from hipscat.catalog.margin_cache import MarginCacheCatalogInfo
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
 from hipscat.pixel_tree import PixelAlignment
@@ -59,9 +62,9 @@ def perform_join_on(
     left_pixel: HealpixPixel,
     right_pixel: HealpixPixel,
     right_margin_pixel: HealpixPixel,
-    left_structure: hc.catalog.Catalog,
-    right_structure: hc.catalog.Catalog,
-    right_margin_structure: hc.catalog.Catalog,
+    left_catalog_info: CatalogInfo,
+    right_catalog_info: CatalogInfo,
+    right_margin_catalog_info: MarginCacheCatalogInfo,
     left_on: str,
     right_on: str,
     suffixes: Tuple[str, str],
@@ -76,9 +79,9 @@ def perform_join_on(
         left_pixel (HealpixPixel): the HEALPix pixel of the left partition
         right_pixel (HealpixPixel): the HEALPix pixel of the right partition
         right_margin_pixel (HealpixPixel): the HEALPix pixel of the right margin partition
-        left_structure (hc.Catalog): the hipscat structure of the left catalog
-        right_structure (hc.Catalog): the hipscat structure of the right catalog
-        right_margin_structure (hc.Catalog): the hipscat structure of the right margin catalog
+        left_catalog_info (hc.CatalogInfo): the catalog info of the left catalog
+        right_catalog_info (hc.CatalogInfo): the catalog info of the right catalog
+        right_margin_catalog_info (hc.MarginCacheCatalogInfo): the catalog info of the right margin catalog
         left_on (str): the column to join on from the left partition
         right_on (str): the column to join on from the right partition
         suffixes (Tuple[str,str]): the suffixes to apply to each partition's column names
@@ -111,10 +114,10 @@ def perform_join_through(
     right_pixel: HealpixPixel,
     right_margin_pixel: HealpixPixel,
     through_pixel: HealpixPixel,
-    left_catalog: hc.catalog.Catalog,
-    right_catalog: hc.catalog.Catalog,
-    right_margin_catalog: hc.catalog.Catalog,
-    assoc_catalog: hc.catalog.AssociationCatalog,
+    left_catalog_info: CatalogInfo,
+    right_catalog_info: CatalogInfo,
+    right_margin_catalog_info: MarginCacheCatalogInfo,
+    assoc_catalog_info: AssociationCatalogInfo,
     suffixes: Tuple[str, str],
     right_columns: List[str],
 ):
@@ -139,8 +142,7 @@ def perform_join_through(
     Returns:
         A dataframe with the result of merging the left and right partitions on the specified columns
     """
-    catalog_info = assoc_catalog.catalog_info
-    if catalog_info.primary_column is None or catalog_info.join_column is None:
+    if assoc_catalog_info.primary_column is None or assoc_catalog_info.join_column is None:
         raise ValueError("Invalid catalog_info")
     if right_pixel.order > left_pixel.order:
         left = filter_by_hipscat_index_to_pixel(left, right_pixel.order, right_pixel.pixel)
@@ -149,9 +151,9 @@ def perform_join_through(
 
     left, right_joined_df = rename_columns_with_suffixes(left, right_joined_df, suffixes)
 
-    join_columns = [catalog_info.primary_column_association]
-    if catalog_info.join_column_association != catalog_info.primary_column_association:
-        join_columns.append(catalog_info.join_column_association)
+    join_columns = [assoc_catalog_info.primary_column_association]
+    if assoc_catalog_info.join_column_association != assoc_catalog_info.primary_column_association:
+        join_columns.append(assoc_catalog_info.join_column_association)
 
     through = through.drop(NON_JOINING_ASSOCIATION_COLUMNS, axis=1)
 
@@ -159,13 +161,13 @@ def perform_join_through(
         left.reset_index()
         .merge(
             through,
-            left_on=catalog_info.primary_column + suffixes[0],
-            right_on=catalog_info.primary_column_association,
+            left_on=assoc_catalog_info.primary_column + suffixes[0],
+            right_on=assoc_catalog_info.primary_column_association,
         )
         .merge(
             right_joined_df,
-            left_on=catalog_info.join_column_association,
-            right_on=catalog_info.join_column + suffixes[1],
+            left_on=assoc_catalog_info.join_column_association,
+            right_on=assoc_catalog_info.join_column + suffixes[1],
         )
     )
 

--- a/src/lsdb/dask/join_catalog_data.py
+++ b/src/lsdb/dask/join_catalog_data.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, List, Tuple
 
 import dask
 import dask.dataframe as dd
-import hipscat as hc
 import pandas as pd
 from hipscat.catalog.association_catalog import AssociationCatalogInfo
 from hipscat.catalog.catalog_info import CatalogInfo

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -116,12 +116,14 @@ def align_and_apply(
 
     # gets the pixels and hc_structures to pass to the function
     pixels = [pixels for (_, pixels) in catalog_mappings]
-    hc_structures = [cat.hc_structure if cat is not None else None for (cat, _) in catalog_mappings]
+    catalog_infos = [
+        cat.hc_structure.catalog_info if cat is not None else None for (cat, _) in catalog_mappings
+    ]
 
     # defines an inner function that can be vectorized to apply the given function to each of the partitions
     # with the additional arguments including as the hc_structures and any specified additional arguments
     def apply_func(*partitions_and_pixels):
-        return func(*partitions_and_pixels, *hc_structures, *args, **kwargs)
+        return func(*partitions_and_pixels, *catalog_infos, *args, **kwargs)
 
     resulting_partitions = np.vectorize(apply_func)(*aligned_partitions, *pixels)
     return resulting_partitions

--- a/tests/lsdb/core/test_kdtree_validation.py
+++ b/tests/lsdb/core/test_kdtree_validation.py
@@ -15,9 +15,9 @@ def kdtree_args(small_sky_catalog, small_sky_order1_source_with_margin):
         0,
         0,
         0,
-        small_sky_catalog.hc_structure,
-        small_sky_order1_source_with_margin.hc_structure,
-        small_sky_order1_source_with_margin.margin.hc_structure,
+        small_sky_catalog.hc_structure.catalog_info,
+        small_sky_order1_source_with_margin.hc_structure.catalog_info,
+        small_sky_order1_source_with_margin.margin.hc_structure.catalog_info,
         ("_a", "_b"),
     )
 
@@ -49,7 +49,7 @@ def test_bounded_kdtree_radius_invalid(bounded_kdtree_crossmatch):
 
 
 def test_kdtree_no_margin(kdtree_crossmatch):
-    kdtree_crossmatch.right_margin_hc_structure = None
+    kdtree_crossmatch.right_margin_catalog_info = None
     with pytest.raises(ValueError, match="Right catalog margin cache is required for cross-match"):
         kdtree_crossmatch.validate(require_right_margin=True)
 


### PR DESCRIPTION
Changes the crossmatch, join, and search delayed calls to only pass the hipscat `catalog_info` instead of the full `Catalog` object. Avoids pickling and sending excess data to dask workers, and fixes #316 issues pickling MOCpy objects.