### PR TITLE
Use MOCs for alignment and generate MOC in from_dataframe

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -62,7 +62,7 @@ def time_box_filter_on_partition():
     mock_partition_df = pd.DataFrame(
         np.linspace(-1000, 1000, 100_000), columns=[metadata.catalog_info.ra_column]
     )
-    box_filter(mock_partition_df, ra=(-20, 40), dec=None, metadata=metadata).compute()
+    box_filter(mock_partition_df, ra=(-20, 40), dec=None, metadata=metadata.catalog_info).compute()
 
 
 def time_create_midsize_catalog():

--- a/src/.pylintrc
+++ b/src/.pylintrc
@@ -62,7 +62,7 @@ ignore-patterns=_version.py
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis). It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+ignored-modules=astropy.units
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().

--- a/src/lsdb/dask/crossmatch_catalog_data.py
+++ b/src/lsdb/dask/crossmatch_catalog_data.py
@@ -123,10 +123,8 @@ def crossmatch_catalog_data(
             RuntimeWarning,
         )
 
-    xmatch_radius = kwargs["radius_arcsec"] if "radius_arcsec" in kwargs else None
-
     # perform alignment on the two catalogs
-    alignment = align_catalogs(left, right, right_added_radius_arcsec=xmatch_radius)
+    alignment = align_catalogs(left, right, add_right_margin=True)
 
     # get lists of HEALPix pixels from alignment to pass to cross-match
     left_pixels, right_pixels = get_healpix_pixels_from_alignment(alignment)

--- a/src/lsdb/dask/crossmatch_catalog_data.py
+++ b/src/lsdb/dask/crossmatch_catalog_data.py
@@ -123,8 +123,10 @@ def crossmatch_catalog_data(
             RuntimeWarning,
         )
 
+    xmatch_radius = kwargs["radius_arcsec"] if "radius_arcsec" in kwargs else None
+
     # perform alignment on the two catalogs
-    alignment = align_catalogs(left, right)
+    alignment = align_catalogs(left, right, right_added_radius_arcsec=xmatch_radius)
 
     # get lists of HEALPix pixels from alignment to pass to cross-match
     left_pixels, right_pixels = get_healpix_pixels_from_alignment(alignment)

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -79,8 +79,12 @@ def align_catalogs(left: Catalog, right: Catalog, right_added_radius_arcsec: flo
     else:
         right_tree = right.hc_structure.pixel_tree
 
-    right_moc = right.hc_structure.moc
-    if right_moc is not None and right_added_radius_arcsec is not None:
+    right_moc = (
+        right.hc_structure.moc
+        if right.hc_structure.moc is not None
+        else right.hc_structure.pixel_tree.to_moc()
+    )
+    if right_added_radius_arcsec is not None:
         right_moc_depth_resol = hp.nside2resol(hp.order2nside(right_moc.max_order), arcmin=True) * 60
         if right_added_radius_arcsec < right_moc_depth_resol:
             right_moc = right_moc.add_neighbours()

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -62,8 +62,8 @@ def align_catalogs(left: Catalog, right: Catalog, add_right_margin: bool = True)
     Args:
         left (lsdb.Catalog): The left catalog to align
         right (lsdb.Catalog): The right catalog to align
-        add_right_margin (float): When using MOCs to align catalogs, adds a border to the
-            right catalog's moc to include the margin of the right catalog, if the right margin exists
+        add_right_margin (bool): If True, when using MOCs to align catalogs, adds a border to the
+            right catalog's moc to include the margin of the right catalog, if it exists. Defaults to True.
     Returns:
         The PixelAlignment object from aligning the catalogs
     """

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -56,7 +56,9 @@ def concat_partition_and_margin(
     return joined_df
 
 
-def align_catalogs(left: Catalog, right: Catalog, right_added_radius_arcsec: float = None) -> PixelAlignment:
+def align_catalogs(
+    left: Catalog, right: Catalog, right_added_radius_arcsec: float | None = None
+) -> PixelAlignment:
     """Aligns two catalogs, also using the right catalog's margin if it exists
 
     Args:

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Callable, List, Sequence, Tuple, cast
 
 import dask.dataframe as dd
+import healpy as hp
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
@@ -11,6 +12,7 @@ from hipscat.catalog import PartitionInfo
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN, healpix_to_hipscat_id
 from hipscat.pixel_tree import PixelAlignment, PixelAlignmentType, align_trees
+from hipscat.pixel_tree.pixel_alignment import align_with_mocs
 
 from lsdb.dask.divisions import get_pixels_divisions
 from lsdb.types import DaskDFPixelMap
@@ -54,12 +56,14 @@ def concat_partition_and_margin(
     return joined_df
 
 
-def align_catalogs(left: Catalog, right: Catalog) -> PixelAlignment:
+def align_catalogs(left: Catalog, right: Catalog, right_added_radius_arcsec: float = None) -> PixelAlignment:
     """Aligns two catalogs, also using the right catalog's margin if it exists
 
     Args:
         left (lsdb.Catalog): The left catalog to align
         right (lsdb.Catalog): The right catalog to align
+        right_added_radius_arcsec (float): When using MOCs to align catalogs, add an additional radius to the
+            right catalog's moc to include some overlap
     Returns:
         The PixelAlignment object from aligning the catalogs
     """
@@ -70,9 +74,27 @@ def align_catalogs(left: Catalog, right: Catalog) -> PixelAlignment:
             right.margin.hc_structure.pixel_tree,
             alignment_type=PixelAlignmentType.OUTER,
         ).pixel_tree
+        if right_added_radius_arcsec is None:
+            right_added_radius_arcsec = right.margin.hc_structure.catalog_info.margin_threshold
     else:
         right_tree = right.hc_structure.pixel_tree
-    return align_trees(left.hc_structure.pixel_tree, right_tree, alignment_type=PixelAlignmentType.INNER)
+
+    right_moc = right.hc_structure.moc
+    if right_moc is not None and right_added_radius_arcsec is not None:
+        right_moc_depth_resol = hp.nside2resol(hp.order2nside(right_moc.max_order), arcmin=True) * 60
+        if right_added_radius_arcsec < right_moc_depth_resol:
+            right_moc = right_moc.add_neighbours()
+        else:
+            delta_order = int(np.ceil(np.log2(right_added_radius_arcsec / right_moc_depth_resol)))
+            right_moc = right_moc.degrade_to_order(right_moc.max_order - delta_order).add_neighbours()
+
+    return align_with_mocs(
+        left.hc_structure.pixel_tree,
+        right_tree,
+        left.hc_structure.moc,
+        right_moc,
+        alignment_type=PixelAlignmentType.INNER,
+    )
 
 
 def align_and_apply(

--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -4,6 +4,7 @@ import dataclasses
 import math
 from typing import Dict, List, Tuple
 
+import astropy.units as u
 import dask.dataframe as dd
 import hipscat as hc
 import numpy as np
@@ -21,7 +22,6 @@ from lsdb.loaders.dataframe.from_dataframe_utils import (
     _generate_dask_dataframe,
 )
 from lsdb.types import DaskDFPixelMap, HealpixInfo
-import astropy.units as u
 
 pd.options.mode.chained_assignment = None  # default='warn'
 

--- a/src/lsdb/loaders/dataframe/from_dataframe.py
+++ b/src/lsdb/loaders/dataframe/from_dataframe.py
@@ -15,6 +15,8 @@ def from_dataframe(
     threshold: int | None = None,
     margin_order: int | None = -1,
     margin_threshold: float | None = 5.0,
+    should_generate_moc: bool = True,
+    moc_max_order: int = 10,
     use_pyarrow_types: bool = True,
     **kwargs,
 ) -> Catalog:
@@ -42,6 +44,8 @@ def from_dataframe(
         highest_order,
         partition_size,
         threshold,
+        should_generate_moc,
+        moc_max_order,
         use_pyarrow_types,
         **kwargs,
     ).load_catalog()

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -62,7 +62,7 @@ ignore-patterns=_version.py
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis). It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+ignored-modules=astropy.units
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
+from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
 
 import lsdb
@@ -265,6 +266,17 @@ class MockCrossmatchAlgorithm(AbstractCrossmatchAlgorithm):
         self._append_extra_columns(out, extra_columns)
 
         return out
+
+
+def test_crossmatch_with_moc(small_sky_order1_catalog):
+    order = 1
+    pixels = [44, 45, 46]
+    partitions = [small_sky_order1_catalog.get_partition(order, p).compute() for p in pixels]
+    df = pd.concat(partitions)
+    subset_catalog = lsdb.from_dataframe(df)
+    assert subset_catalog.get_healpix_pixels() == [HealpixPixel(0, 11)]
+    xmatched = small_sky_order1_catalog.crossmatch(subset_catalog)
+    assert xmatched.get_healpix_pixels() == [HealpixPixel(order, p) for p in pixels]
 
 
 def test_custom_crossmatch_algorithm(small_sky_catalog, small_sky_xmatch_catalog, xmatch_mock):

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -230,6 +230,19 @@ class TestBoundedCrossmatch:
         assert all(xmatched["_dist_arcsec"] <= 0.01 * 3600)
 
 
+def test_crossmatch_with_moc(small_sky_order1_catalog):
+    order = 1
+    pixels = [44, 45, 46]
+    partitions = [small_sky_order1_catalog.get_partition(order, p).compute() for p in pixels]
+    df = pd.concat(partitions)
+    subset_catalog = lsdb.from_dataframe(df)
+    assert subset_catalog.get_healpix_pixels() == [HealpixPixel(0, 11)]
+    xmatched = small_sky_order1_catalog.crossmatch(subset_catalog)
+    assert xmatched.get_healpix_pixels() == [HealpixPixel(order, p) for p in pixels]
+    xmatched = subset_catalog.crossmatch(small_sky_order1_catalog)
+    assert xmatched.get_healpix_pixels() == [HealpixPixel(order, p) for p in pixels]
+
+
 # pylint: disable=too-few-public-methods
 class MockCrossmatchAlgorithm(AbstractCrossmatchAlgorithm):
     """Mock class used to test a crossmatch algorithm"""
@@ -266,17 +279,6 @@ class MockCrossmatchAlgorithm(AbstractCrossmatchAlgorithm):
         self._append_extra_columns(out, extra_columns)
 
         return out
-
-
-def test_crossmatch_with_moc(small_sky_order1_catalog):
-    order = 1
-    pixels = [44, 45, 46]
-    partitions = [small_sky_order1_catalog.get_partition(order, p).compute() for p in pixels]
-    df = pd.concat(partitions)
-    subset_catalog = lsdb.from_dataframe(df)
-    assert subset_catalog.get_healpix_pixels() == [HealpixPixel(0, 11)]
-    xmatched = small_sky_order1_catalog.crossmatch(subset_catalog)
-    assert xmatched.get_healpix_pixels() == [HealpixPixel(order, p) for p in pixels]
 
 
 def test_custom_crossmatch_algorithm(small_sky_catalog, small_sky_xmatch_catalog, xmatch_mock):

--- a/tests/lsdb/loaders/dataframe/test_from_dataframe.py
+++ b/tests/lsdb/loaders/dataframe/test_from_dataframe.py
@@ -1,10 +1,10 @@
+import astropy.units as u
 import healpy as hp
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
 import pytest
 from hipscat.catalog import CatalogType
-import astropy.units as u
 from hipscat.pixel_math.healpix_pixel_function import get_pixel_argsort
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
 from mocpy import MOC


### PR DESCRIPTION
Uses the MOC alignment functions recently added to hipscat to perform alignment for crossmatch and join with higher order coverage. Generates a MOC when `from_dataframe` is called.