### PR TITLE
Allow margin path argument in `read_hipscat`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,7 +101,7 @@ repos:
         name: mypy (python files in src/ and tests/)
         entry: mypy
         language: system
-        types: [python]
+        types_or: [python, pyi]
         files: ^(src|tests)/
         args:
           [

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,7 +101,7 @@ repos:
         name: mypy (python files in src/ and tests/)
         entry: mypy
         language: system
-        types_or: [python, pyi]
+        types: [python]
         files: ^(src|tests)/
         args:
           [

--- a/src/lsdb/__init__.py
+++ b/src/lsdb/__init__.py
@@ -1,3 +1,4 @@
 from ._version import __version__
 from .catalog import Catalog, MarginCatalog
-from .loaders import from_dataframe, read_hipscat
+from .loaders.dataframe.from_dataframe import from_dataframe
+from .loaders.hipscat.read_hipscat import read_hipscat

--- a/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
@@ -74,7 +74,7 @@ class AbstractCatalogLoader(Generic[CatalogTypeVar]):
         dask_meta_schema = self._load_metadata_schema(catalog)
         if self.config.columns:
             dask_meta_schema = dask_meta_schema[self.config.columns]
-        kwargs = self.config.get_kwargs_dict()
+        kwargs = dict(self.config.kwargs)
         if self.config.dtype_backend is not None:
             kwargs["dtype_backend"] = self.config.dtype_backend
         return dd.io.from_map(

--- a/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import dataclasses
 
 import hipscat as hc
 
-from lsdb.catalog.catalog import Catalog
+from lsdb.catalog.catalog import Catalog, MarginCatalog
+from lsdb.loaders import read_hipscat
 from lsdb.loaders.hipscat.abstract_catalog_loader import AbstractCatalogLoader
 
 
@@ -18,7 +21,7 @@ class HipscatCatalogLoader(AbstractCatalogLoader[Catalog]):
         hc_catalog = self._load_hipscat_catalog(hc.catalog.Catalog)
         filtered_hc_catalog = self._filter_hipscat_catalog(hc_catalog)
         dask_df, dask_df_pixel_map = self._load_dask_df_and_map(filtered_hc_catalog)
-        return Catalog(dask_df, dask_df_pixel_map, filtered_hc_catalog, self.config.margin_cache)
+        return Catalog(dask_df, dask_df_pixel_map, filtered_hc_catalog, self._load_margin_catalog())
 
     def _filter_hipscat_catalog(self, hc_catalog: hc.catalog.Catalog) -> hc.catalog.Catalog:
         """Filter the catalog pixels according to the spatial filter provided at loading time.
@@ -34,3 +37,19 @@ class HipscatCatalogLoader(AbstractCatalogLoader[Catalog]):
         return hc.catalog.Catalog(
             catalog_info, pixels_to_load, self.path, hc_catalog.moc, self.storage_options
         )
+
+    def _load_margin_catalog(self) -> MarginCatalog | None:
+        """Load the margin catalog. It can be provided using a margin catalog
+        instance or a path to the catalog on disk."""
+        margin_catalog = None
+        if self.config.margin_cache is not None:
+            margin_catalog = self.config.margin_cache
+        elif self.config.margin_path is not None:
+            margin_catalog = read_hipscat(
+                path=self.config.margin_path,
+                catalog_type=MarginCatalog,
+                search_filter=self.config.search_filter,
+                storage_options=self.storage_options,
+                **self.config.get_kwargs_dict(),
+            )
+        return margin_catalog

--- a/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
@@ -42,15 +42,14 @@ class HipscatCatalogLoader(AbstractCatalogLoader[Catalog]):
         """Load the margin catalog. It can be provided using a margin catalog
         instance or a path to the catalog on disk."""
         margin_catalog = None
-        if self.config.margin_cache is not None:
+        if isinstance(self.config.margin_cache, MarginCatalog):
             margin_catalog = self.config.margin_cache
-        elif self.config.margin_path is not None:
+        elif isinstance(self.config.margin_cache, str):
             margin_catalog = lsdb.read_hipscat(
-                path=self.config.margin_path,
+                path=self.config.margin_cache,
                 catalog_type=MarginCatalog,
                 search_filter=self.config.search_filter,
                 margin_cache=None,
-                margin_path=None,
                 dtype_backend=self.config.dtype_backend,
                 storage_options=self.storage_options,
                 **self.config.kwargs,

--- a/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
@@ -4,9 +4,9 @@ import dataclasses
 
 import hipscat as hc
 
+import lsdb
 from lsdb.catalog.catalog import Catalog, MarginCatalog
 from lsdb.loaders.hipscat.abstract_catalog_loader import AbstractCatalogLoader
-from lsdb.loaders.hipscat.read_hipscat import read_hipscat
 
 
 class HipscatCatalogLoader(AbstractCatalogLoader[Catalog]):
@@ -45,7 +45,7 @@ class HipscatCatalogLoader(AbstractCatalogLoader[Catalog]):
         if self.config.margin_cache is not None:
             margin_catalog = self.config.margin_cache
         elif self.config.margin_path is not None:
-            margin_catalog = read_hipscat(
+            margin_catalog = lsdb.read_hipscat(
                 path=self.config.margin_path,
                 catalog_type=MarginCatalog,
                 search_filter=self.config.search_filter,

--- a/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
@@ -5,8 +5,8 @@ import dataclasses
 import hipscat as hc
 
 from lsdb.catalog.catalog import Catalog, MarginCatalog
-from lsdb.loaders import read_hipscat
 from lsdb.loaders.hipscat.abstract_catalog_loader import AbstractCatalogLoader
+from lsdb.loaders.hipscat.read_hipscat import read_hipscat
 
 
 class HipscatCatalogLoader(AbstractCatalogLoader[Catalog]):
@@ -49,7 +49,8 @@ class HipscatCatalogLoader(AbstractCatalogLoader[Catalog]):
                 path=self.config.margin_path,
                 catalog_type=MarginCatalog,
                 search_filter=self.config.search_filter,
+                dtype_backend=self.config.dtype_backend,
                 storage_options=self.storage_options,
-                **self.config.get_kwargs_dict(),
+                **self.config.kwargs,
             )
         return margin_catalog

--- a/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
@@ -49,6 +49,8 @@ class HipscatCatalogLoader(AbstractCatalogLoader[Catalog]):
                 path=self.config.margin_path,
                 catalog_type=MarginCatalog,
                 search_filter=self.config.search_filter,
+                margin_cache=None,
+                margin_path=None,
                 dtype_backend=self.config.dtype_backend,
                 storage_options=self.storage_options,
                 **self.config.kwargs,

--- a/src/lsdb/loaders/hipscat/hipscat_loading_config.py
+++ b/src/lsdb/loaders/hipscat/hipscat_loading_config.py
@@ -30,10 +30,15 @@ class HipscatLoadingConfig:
     """The backend data type to apply to the catalog. It defaults to "pyarrow" and 
     if it is None no type conversion is performed."""
 
+    margin_path: str | None = None
+    """The path for the margin cache catalog. By default, it is None"""
+
     kwargs: dict | None = None
     """Extra kwargs"""
 
     def __post_init__(self):
+        if self.margin_cache is not None and self.margin_path is not None:
+            raise ValueError("Only one of 'margin_path' or 'margin_cache' can be provided")
         if self.dtype_backend not in ["pyarrow", "numpy_nullable", None]:
             raise ValueError("The data type backend must be either 'pyarrow' or 'numpy_nullable'")
 

--- a/src/lsdb/loaders/hipscat/hipscat_loading_config.py
+++ b/src/lsdb/loaders/hipscat/hipscat_loading_config.py
@@ -23,11 +23,9 @@ class HipscatLoadingConfig:
     columns: List[str] | None = None
     """Columns to load from the catalog. If not specified, all columns are loaded"""
 
-    margin_cache: MarginCatalog | None = None
-    """Margin cache for the catalog. By default, it is None"""
-
-    margin_path: str | None = None
-    """The path for the margin cache catalog. By default, it is None"""
+    margin_cache: MarginCatalog | str | None = None
+    """Margin cache for the catalog. It can be provided as a path for the margin on disk,
+    or as a margin object instance. By default, it is None."""
 
     dtype_backend: str | None = "pyarrow"
     """The backend data type to apply to the catalog. It defaults to "pyarrow" and 
@@ -37,8 +35,8 @@ class HipscatLoadingConfig:
     """Extra kwargs for the pandas parquet file reader"""
 
     def __post_init__(self):
-        if self.margin_cache is not None and self.margin_path is not None:
-            raise ValueError("Only one of 'margin_path' or 'margin_cache' can be provided")
+        if self.margin_cache is not None and not isinstance(self.margin_cache, (MarginCatalog, str)):
+            raise ValueError("`margin_cache` must be of type 'MarginCatalog' or 'str'")
         if self.dtype_backend not in ["pyarrow", "numpy_nullable", None]:
             raise ValueError("The data type backend must be either 'pyarrow' or 'numpy_nullable'")
 

--- a/src/lsdb/loaders/hipscat/hipscat_loading_config.py
+++ b/src/lsdb/loaders/hipscat/hipscat_loading_config.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Callable, List
 
 import pandas as pd
@@ -26,25 +26,21 @@ class HipscatLoadingConfig:
     margin_cache: MarginCatalog | None = None
     """Margin cache for the catalog. By default, it is None"""
 
+    margin_path: str | None = None
+    """The path for the margin cache catalog. By default, it is None"""
+
     dtype_backend: str | None = "pyarrow"
     """The backend data type to apply to the catalog. It defaults to "pyarrow" and 
     if it is None no type conversion is performed."""
 
-    margin_path: str | None = None
-    """The path for the margin cache catalog. By default, it is None"""
-
-    kwargs: dict | None = None
-    """Extra kwargs"""
+    kwargs: dict = field(default_factory=dict)
+    """Extra kwargs for the pandas parquet file reader"""
 
     def __post_init__(self):
         if self.margin_cache is not None and self.margin_path is not None:
             raise ValueError("Only one of 'margin_path' or 'margin_cache' can be provided")
         if self.dtype_backend not in ["pyarrow", "numpy_nullable", None]:
             raise ValueError("The data type backend must be either 'pyarrow' or 'numpy_nullable'")
-
-    def get_kwargs_dict(self) -> dict:
-        """Returns a dictionary with the extra kwargs"""
-        return self.kwargs if self.kwargs is not None else {}
 
     def get_dtype_mapper(self) -> Callable | None:
         """Returns a mapper for pyarrow or numpy types, mirroring Pandas behaviour."""

--- a/src/lsdb/loaders/hipscat/read_hipscat.py
+++ b/src/lsdb/loaders/hipscat/read_hipscat.py
@@ -12,6 +12,7 @@ from lsdb.catalog.catalog import Catalog
 from lsdb.catalog.dataset.dataset import Dataset
 from lsdb.catalog.margin_catalog import MarginCatalog
 from lsdb.core.search.abstract_search import AbstractSearch
+from lsdb.loaders.hipscat.abstract_catalog_loader import CatalogTypeVar
 from lsdb.loaders.hipscat.hipscat_loader_factory import get_loader_for_type
 from lsdb.loaders.hipscat.hipscat_loading_config import HipscatLoadingConfig
 
@@ -26,15 +27,14 @@ dataset_class_for_catalog_type: Dict[CatalogType, Type[Dataset]] = {
 # pylint: disable=unused-argument
 def read_hipscat(
     path: str,
-    catalog_type: Type[Dataset] | None = None,
+    catalog_type: Type[CatalogTypeVar] | None = None,
     search_filter: AbstractSearch | None = None,
     columns: List[str] | None = None,
-    margin_cache: MarginCatalog | None = None,
-    margin_path: str | None = None,
+    margin_cache: MarginCatalog | str | None = None,
     dtype_backend: str | None = "pyarrow",
     storage_options: dict | None = None,
     **kwargs,
-) -> Dataset | None:
+) -> CatalogTypeVar | None:
     """Load a catalog from a HiPSCat formatted catalog.
 
     Typical usage example, where we load a catalog with a subset of columns:
@@ -46,7 +46,7 @@ def read_hipscat(
             path="./my_catalog_dir",
             catalog_type=lsdb.Catalog,
             columns=["ra","dec"],
-            filter=lsdb.core.search.ConeSearch(ra, dec, radius_arcsec),
+            search_filter=lsdb.core.search.ConeSearch(ra, dec, radius_arcsec),
         )
 
     Args:
@@ -58,10 +58,8 @@ def read_hipscat(
             the lsdb class for that catalog.
         search_filter (Type[AbstractSearch]): Default `None`. The filter method to be applied.
         columns (List[str]): Default `None`. The set of columns to filter the catalog on.
-        margin_cache (MarginCatalog): The margin cache for the main catalog. Only one of `margin_cache`
-            or `margin_path` can be provided. Defaults to None.
-        margin_path (str): The path that locates the root of the margin HiPSCat catalog. Only one of
-            `margin_cache` or `margin_path` can be provided. Defaults to None.
+        margin_cache (MarginCatalog | str): The margin cache for the main catalog, provided as a path
+            on disk or as an instance of the MarginCatalog object. Defaults to None.
         dtype_backend (str): Backend data type to apply to the catalog.
             Defaults to "pyarrow". If None, no type conversion is performed.
         storage_options (dict): Dictionary that contains abstract filesystem credentials

--- a/src/lsdb/loaders/hipscat/read_hipscat.py
+++ b/src/lsdb/loaders/hipscat/read_hipscat.py
@@ -30,6 +30,7 @@ def read_hipscat(
     search_filter: AbstractSearch | None = None,
     columns: List[str] | None = None,
     margin_cache: MarginCatalog | None = None,
+    margin_path: str | None = None,
     dtype_backend: str | None = "pyarrow",
     storage_options: dict | None = None,
     **kwargs,
@@ -57,7 +58,10 @@ def read_hipscat(
             the lsdb class for that catalog.
         search_filter (Type[AbstractSearch]): Default `None`. The filter method to be applied.
         columns (List[str]): Default `None`. The set of columns to filter the catalog on.
-        margin_cache (MarginCatalog): The margin cache for the main catalog
+        margin_cache (MarginCatalog): The margin cache for the main catalog. Only one of `margin_cache`
+            or `margin_path` can be provided. Defaults to None.
+        margin_path (str): The path that locates the root of the margin HiPSCat catalog. Only one of
+            `margin_cache` or `margin_path` can be provided. Defaults to None.
         dtype_backend (str): Backend data type to apply to the catalog.
             Defaults to "pyarrow". If None, no type conversion is performed.
         storage_options (dict): Dictionary that contains abstract filesystem credentials

--- a/src/lsdb/loaders/hipscat/read_hipscat.pyi
+++ b/src/lsdb/loaders/hipscat/read_hipscat.pyi
@@ -27,6 +27,7 @@ def read_hipscat(
     storage_options: dict | None = None,
     columns: List[str] | None = None,
     margin_cache: MarginCatalog | None = None,
+    margin_path: str | None = None,
 ) -> Dataset: ...
 @overload
 def read_hipscat(
@@ -36,5 +37,6 @@ def read_hipscat(
     storage_options: dict | None = None,
     columns: List[str] | None = None,
     margin_cache: MarginCatalog | None = None,
+    margin_path: str | None = None,
     **kwargs,
 ) -> CatalogTypeVar: ...

--- a/src/lsdb/loaders/hipscat/read_hipscat.pyi
+++ b/src/lsdb/loaders/hipscat/read_hipscat.pyi
@@ -24,19 +24,20 @@ from lsdb.loaders.hipscat.abstract_catalog_loader import CatalogTypeVar
 def read_hipscat(
     path: str,
     search_filter: AbstractSearch | None = None,
-    storage_options: dict | None = None,
     columns: List[str] | None = None,
-    margin_cache: MarginCatalog | None = None,
-    margin_path: str | None = None,
-) -> Dataset: ...
+    margin_cache: MarginCatalog | str | None = None,
+    dtype_backend: str | None = "pyarrow",
+    storage_options: dict | None = None,
+    **kwargs,
+) -> Dataset | None: ...
 @overload
 def read_hipscat(
     path: str,
     catalog_type: Type[CatalogTypeVar],
     search_filter: AbstractSearch | None = None,
-    storage_options: dict | None = None,
     columns: List[str] | None = None,
-    margin_cache: MarginCatalog | None = None,
-    margin_path: str | None = None,
+    margin_cache: MarginCatalog | str | None = None,
+    dtype_backend: str | None = "pyarrow",
+    storage_options: dict | None = None,
     **kwargs,
-) -> CatalogTypeVar: ...
+) -> CatalogTypeVar | None: ...

--- a/tests/lsdb/loaders/hipscat/test_read_hipscat.py
+++ b/tests/lsdb/loaders/hipscat/test_read_hipscat.py
@@ -72,16 +72,37 @@ def test_read_hipscat_specify_wrong_catalog_type(small_sky_dir):
         lsdb.read_hipscat(small_sky_dir, catalog_type=int)
 
 
-def test_catalog_with_margin(small_sky_xmatch_dir, small_sky_xmatch_margin_catalog):
+def test_catalog_with_margin(
+    small_sky_xmatch_dir, small_sky_xmatch_margin_catalog, small_sky_xmatch_margin_dir
+):
+    # Provide the margin cache catalog object
     catalog = lsdb.read_hipscat(small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_catalog)
     assert isinstance(catalog, lsdb.Catalog)
     assert catalog.margin is small_sky_xmatch_margin_catalog
+    # Provide the margin cache catalog path
+    catalog_2 = lsdb.read_hipscat(small_sky_xmatch_dir, margin_path=small_sky_xmatch_margin_dir)
+    assert isinstance(catalog_2, lsdb.Catalog)
+    # The catalogs obtained are identical
+    assert catalog.margin.hc_structure.catalog_info == catalog_2.margin.hc_structure.catalog_info
+    assert catalog.margin.get_healpix_pixels() == catalog_2.margin.get_healpix_pixels()
+    pd.testing.assert_frame_equal(catalog.margin.compute(), catalog_2.margin.compute())
 
 
 def test_catalog_without_margin_is_none(small_sky_xmatch_dir):
     catalog = lsdb.read_hipscat(small_sky_xmatch_dir)
     assert isinstance(catalog, lsdb.Catalog)
     assert catalog.margin is None
+
+
+def test_catalog_with_wrong_margin_args(
+    small_sky_xmatch_dir, small_sky_xmatch_margin_catalog, small_sky_xmatch_margin_dir
+):
+    with pytest.raises(ValueError, match="Only one of 'margin_path' or 'margin_cache'"):
+        lsdb.read_hipscat(
+            small_sky_xmatch_dir,
+            margin_cache=small_sky_xmatch_margin_catalog,
+            margin_path=small_sky_xmatch_margin_dir,
+        )
 
 
 def test_read_hipscat_subset_with_cone_search(small_sky_order1_dir, small_sky_order1_catalog):

--- a/tests/lsdb/loaders/hipscat/test_read_hipscat.py
+++ b/tests/lsdb/loaders/hipscat/test_read_hipscat.py
@@ -80,7 +80,7 @@ def test_catalog_with_margin(
     assert isinstance(catalog, lsdb.Catalog)
     assert catalog.margin is small_sky_xmatch_margin_catalog
     # Provide the margin cache catalog path
-    catalog_2 = lsdb.read_hipscat(small_sky_xmatch_dir, margin_path=small_sky_xmatch_margin_dir)
+    catalog_2 = lsdb.read_hipscat(small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_dir)
     assert isinstance(catalog_2, lsdb.Catalog)
     # The catalogs obtained are identical
     assert catalog.margin.hc_structure.catalog_info == catalog_2.margin.hc_structure.catalog_info
@@ -94,15 +94,9 @@ def test_catalog_without_margin_is_none(small_sky_xmatch_dir):
     assert catalog.margin is None
 
 
-def test_catalog_with_wrong_margin_args(
-    small_sky_xmatch_dir, small_sky_xmatch_margin_catalog, small_sky_xmatch_margin_dir
-):
-    with pytest.raises(ValueError, match="Only one of 'margin_path' or 'margin_cache'"):
-        lsdb.read_hipscat(
-            small_sky_xmatch_dir,
-            margin_cache=small_sky_xmatch_margin_catalog,
-            margin_path=small_sky_xmatch_margin_dir,
-        )
+def test_catalog_with_wrong_margin_args(small_sky_xmatch_dir):
+    with pytest.raises(ValueError, match="must be of type"):
+        lsdb.read_hipscat(small_sky_xmatch_dir, margin_cache=1)
 
 
 def test_read_hipscat_subset_with_cone_search(small_sky_order1_dir, small_sky_order1_catalog):


### PR DESCRIPTION
Adds a `margin_path` argument to the `read_hipscat` interface allowing for standard HiPSCat catalogs to be loaded with margins (in parquet format) from their path on disk. Closes #314.