### PR TITLE
Use MOCs for spatial filters

### DIFF
--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -309,10 +309,9 @@ class Catalog(HealpixDataset):
         Returns:
             A new Catalog containing the points filtered to those matching the search parameters.
         """
-        filtered_pixels = search.search_partitions(self.hc_structure.get_healpix_pixels())
-        filtered_hc_structure = self.hc_structure.filter_from_pixel_list(filtered_pixels)
+        filtered_hc_structure = search.filter_hc_catalog(self.hc_structure)
         ddf_partition_map, search_ddf = self._perform_search(
-            filtered_hc_structure, filtered_pixels, search, fine
+            filtered_hc_structure, filtered_hc_structure.get_healpix_pixels(), search, fine
         )
         margin = self.margin._search(filtered_hc_structure, search, fine) if self.margin is not None else None
         return Catalog(search_ddf, ddf_partition_map, filtered_hc_structure, margin=margin)

--- a/src/lsdb/catalog/margin_catalog.py
+++ b/src/lsdb/catalog/margin_catalog.py
@@ -48,26 +48,14 @@ class MarginCatalog(HealpixDataset):
         max_order_size = hp.nside2resol(2**max_order, arcmin=True)
         if self.hc_structure.catalog_info.margin_threshold > max_order_size * 60:
             raise ValueError(
-                f"Margin size {self.hc_structure.catalog_info.margin_threshold} is greater than the size of "
-                f"a pixel at the highest order {max_order}."
+                f"Cannot Filter Margin: Margin size {self.hc_structure.catalog_info.margin_threshold} is "
+                f"greater than the size of a pixel at the highest order {max_order}."
             )
 
-        # Get the pixels that match the search pixels
-        filtered_search_pixels = metadata.get_healpix_pixels()
+        margin_search_moc = metadata.pixel_tree.to_moc().degrade_to_order(max_order).add_neighbours()
 
-        filtered_pixels = []
-
-        if len(filtered_search_pixels) > 0:
-            # Get the margin pixels at the max order from the search pixels
-            orders = np.array([p.order for p in filtered_search_pixels])
-            pixels = np.array([p.pixel for p in filtered_search_pixels])
-            max_order = np.max(orders)
-
-            search_moc = MOC.from_healpix_cells(pixels, orders, max_depth=max_order).add_neighbours()
-
-            # Align the margin pixels with the catalog pixels and combine with the search pixels
-            filtered_pixels = filter_by_moc(self.hc_structure.pixel_tree, search_moc).get_healpix_pixels()
-
-        filtered_hc_structure = self.hc_structure.filter_from_pixel_list(filtered_pixels)
-        ddf_partition_map, search_ddf = self._perform_search(metadata, filtered_pixels, search, fine)
+        filtered_hc_structure = self.hc_structure.filter_by_moc(margin_search_moc)
+        ddf_partition_map, search_ddf = self._perform_search(
+            metadata, filtered_hc_structure.get_healpix_pixels(), search, fine
+        )
         return self.__class__(search_ddf, ddf_partition_map, filtered_hc_structure)

--- a/src/lsdb/catalog/margin_catalog.py
+++ b/src/lsdb/catalog/margin_catalog.py
@@ -1,9 +1,5 @@
 import dask.dataframe as dd
-import healpy as hp
 import hipscat as hc
-import numpy as np
-from hipscat.pixel_tree.moc_filter import filter_by_moc
-from mocpy import MOC
 
 from lsdb.catalog.dataset.healpix_dataset import HealpixDataset
 from lsdb.core.search.abstract_search import AbstractSearch

--- a/src/lsdb/catalog/margin_catalog.py
+++ b/src/lsdb/catalog/margin_catalog.py
@@ -44,15 +44,7 @@ class MarginCatalog(HealpixDataset):
         """
 
         # if the margin size is greater than the size of a pixel, this is an invalid search
-        max_order = self.hc_structure.pixel_tree.get_max_depth()
-        max_order_size = hp.nside2resol(2**max_order, arcmin=True)
-        if self.hc_structure.catalog_info.margin_threshold > max_order_size * 60:
-            raise ValueError(
-                f"Cannot Filter Margin: Margin size {self.hc_structure.catalog_info.margin_threshold} is "
-                f"greater than the size of a pixel at the highest order {max_order}."
-            )
-
-        margin_search_moc = metadata.pixel_tree.to_moc().degrade_to_order(max_order).add_neighbours()
+        margin_search_moc = metadata.pixel_tree.to_moc()
 
         filtered_hc_structure = self.hc_structure.filter_by_moc(margin_search_moc)
         ddf_partition_map, search_ddf = self._perform_search(

--- a/src/lsdb/core/search/abstract_search.py
+++ b/src/lsdb/core/search/abstract_search.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List
 
 import pandas as pd
 from hipscat.catalog.catalog_info import CatalogInfo
-from hipscat.pixel_math import HealpixPixel
+from mocpy import MOC
+
+from lsdb.loaders.hipscat.abstract_catalog_loader import HCCatalogTypeVar
 
 
 # pylint: disable=too-many-instance-attributes, too-many-arguments
@@ -20,8 +21,14 @@ class AbstractSearch(ABC):
           individual rows matching the query terms.
     """
 
+    def filter_hc_catalog(self, hc_structure: HCCatalogTypeVar) -> HCCatalogTypeVar:
+        max_order = hc_structure.pixel_tree.tree_order
+        max_order = max(hc_structure.moc.max_order, max_order) if hc_structure.moc is not None else max_order
+        search_moc = self.generate_search_moc(max_order)
+        return hc_structure.filter_by_moc(search_moc)
+
     @abstractmethod
-    def search_partitions(self, pixels: List[HealpixPixel]) -> List[HealpixPixel]:
+    def generate_search_moc(self, max_order: int) -> MOC:
         """Determine the target partitions for further filtering."""
 
     @abstractmethod

--- a/src/lsdb/core/search/abstract_search.py
+++ b/src/lsdb/core/search/abstract_search.py
@@ -24,6 +24,7 @@ class AbstractSearch(ABC):
     """
 
     def filter_hc_catalog(self, hc_structure: HCCatalogTypeVar) -> HCCatalogTypeVar:
+        """Filters the hispcat catalog object to the partitions included in the search"""
         max_order = hc_structure.get_max_coverage_order()
         search_moc = self.generate_search_moc(max_order)
         return hc_structure.filter_by_moc(search_moc)

--- a/src/lsdb/core/search/abstract_search.py
+++ b/src/lsdb/core/search/abstract_search.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 import pandas as pd
 from hipscat.catalog.catalog_info import CatalogInfo
 from mocpy import MOC
 
-from lsdb.loaders.hipscat.abstract_catalog_loader import HCCatalogTypeVar
+if TYPE_CHECKING:
+    from lsdb.loaders.hipscat.abstract_catalog_loader import HCCatalogTypeVar
 
 
 # pylint: disable=too-many-instance-attributes, too-many-arguments
@@ -27,9 +29,11 @@ class AbstractSearch(ABC):
         search_moc = self.generate_search_moc(max_order)
         return hc_structure.filter_by_moc(search_moc)
 
-    @abstractmethod
     def generate_search_moc(self, max_order: int) -> MOC:
         """Determine the target partitions for further filtering."""
+        raise NotImplementedError(
+            "Search Class must implement `generate_search_moc` method or overwrite `filter_hc_catalog`"
+        )
 
     @abstractmethod
     def search_points(self, frame: pd.DataFrame, metadata: CatalogInfo) -> pd.DataFrame:

--- a/src/lsdb/core/search/abstract_search.py
+++ b/src/lsdb/core/search/abstract_search.py
@@ -24,8 +24,7 @@ class AbstractSearch(ABC):
     """
 
     def filter_hc_catalog(self, hc_structure: HCCatalogTypeVar) -> HCCatalogTypeVar:
-        max_order = hc_structure.pixel_tree.tree_order
-        max_order = max(hc_structure.moc.max_order, max_order) if hc_structure.moc is not None else max_order
+        max_order = hc_structure.get_max_coverage_order()
         search_moc = self.generate_search_moc(max_order)
         return hc_structure.filter_by_moc(search_moc)
 

--- a/src/lsdb/core/search/box_search.py
+++ b/src/lsdb/core/search/box_search.py
@@ -6,10 +6,8 @@ import dask
 import numpy as np
 import pandas as pd
 from hipscat.catalog.catalog_info import CatalogInfo
-from hipscat.pixel_math import HealpixPixel
-from hipscat.pixel_math.box_filter import filter_pixels_by_box, wrap_ra_angles, generate_box_moc
+from hipscat.pixel_math.box_filter import wrap_ra_angles, generate_box_moc
 from hipscat.pixel_math.validators import validate_box_search
-from hipscat.pixel_tree.pixel_tree import PixelTree
 from mocpy import MOC
 
 from lsdb.core.search.abstract_search import AbstractSearch

--- a/src/lsdb/core/search/box_search.py
+++ b/src/lsdb/core/search/box_search.py
@@ -7,9 +7,10 @@ import numpy as np
 import pandas as pd
 from hipscat.catalog.catalog_info import CatalogInfo
 from hipscat.pixel_math import HealpixPixel
-from hipscat.pixel_math.box_filter import filter_pixels_by_box, wrap_ra_angles
+from hipscat.pixel_math.box_filter import filter_pixels_by_box, wrap_ra_angles, generate_box_moc
 from hipscat.pixel_math.validators import validate_box_search
 from hipscat.pixel_tree.pixel_tree import PixelTree
+from mocpy import MOC
 
 from lsdb.core.search.abstract_search import AbstractSearch
 
@@ -27,10 +28,8 @@ class BoxSearch(AbstractSearch):
         validate_box_search(ra, dec)
         self.ra, self.dec = ra, dec
 
-    def search_partitions(self, pixels: List[HealpixPixel]) -> List[HealpixPixel]:
-        """Determine the target partitions for further filtering."""
-        pixel_tree = PixelTree.from_healpix(pixels)
-        return filter_pixels_by_box(pixel_tree, self.ra, self.dec)
+    def generate_search_moc(self, max_order: int) -> MOC:
+        return generate_box_moc(self.ra, self.dec, max_order)
 
     def search_points(self, frame: pd.DataFrame, metadata: CatalogInfo) -> pd.DataFrame:
         """Determine the search results within a data frame"""

--- a/src/lsdb/core/search/box_search.py
+++ b/src/lsdb/core/search/box_search.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from typing import List, Tuple
+from typing import Tuple
 
 import dask
 import numpy as np
 import pandas as pd
 from hipscat.catalog.catalog_info import CatalogInfo
-from hipscat.pixel_math.box_filter import wrap_ra_angles, generate_box_moc
+from hipscat.pixel_math.box_filter import generate_box_moc, wrap_ra_angles
 from hipscat.pixel_math.validators import validate_box_search
 from mocpy import MOC
 

--- a/src/lsdb/core/search/cone_search.py
+++ b/src/lsdb/core/search/cone_search.py
@@ -5,9 +5,10 @@ import pandas as pd
 from astropy.coordinates import SkyCoord
 from hipscat.catalog.catalog_info import CatalogInfo
 from hipscat.pixel_math import HealpixPixel
-from hipscat.pixel_math.cone_filter import filter_pixels_by_cone
+from hipscat.pixel_math.cone_filter import filter_pixels_by_cone, generate_cone_moc
 from hipscat.pixel_math.validators import validate_declination_values, validate_radius
 from hipscat.pixel_tree.pixel_tree import PixelTree
+from mocpy import MOC
 
 from lsdb.core.search.abstract_search import AbstractSearch
 
@@ -27,10 +28,8 @@ class ConeSearch(AbstractSearch):
         self.dec = dec
         self.radius_arcsec = radius_arcsec
 
-    def search_partitions(self, pixels: List[HealpixPixel]) -> List[HealpixPixel]:
-        """Determine the target partitions for further filtering."""
-        pixel_tree = PixelTree.from_healpix(pixels)
-        return filter_pixels_by_cone(pixel_tree, self.ra, self.dec, self.radius_arcsec)
+    def generate_search_moc(self, max_order: int) -> MOC:
+        return generate_cone_moc(self.ra, self.dec, self.radius_arcsec, max_order)
 
     def search_points(self, frame: pd.DataFrame, metadata: CatalogInfo) -> pd.DataFrame:
         """Determine the search results within a data frame"""

--- a/src/lsdb/core/search/cone_search.py
+++ b/src/lsdb/core/search/cone_search.py
@@ -1,13 +1,9 @@
-from typing import List
-
 import dask
 import pandas as pd
 from astropy.coordinates import SkyCoord
 from hipscat.catalog.catalog_info import CatalogInfo
-from hipscat.pixel_math import HealpixPixel
-from hipscat.pixel_math.cone_filter import filter_pixels_by_cone, generate_cone_moc
+from hipscat.pixel_math.cone_filter import generate_cone_moc
 from hipscat.pixel_math.validators import validate_declination_values, validate_radius
-from hipscat.pixel_tree.pixel_tree import PixelTree
 from mocpy import MOC
 
 from lsdb.core.search.abstract_search import AbstractSearch

--- a/src/lsdb/core/search/index_search.py
+++ b/src/lsdb/core/search/index_search.py
@@ -1,10 +1,14 @@
-from typing import List
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import pandas as pd
 from hipscat.catalog.index.index_catalog import IndexCatalog
-from hipscat.pixel_math import HealpixPixel
 
 from lsdb.core.search.abstract_search import AbstractSearch
+
+if TYPE_CHECKING:
+    from lsdb.loaders.hipscat.abstract_catalog_loader import HCCatalogTypeVar
 
 
 class IndexSearch(AbstractSearch):
@@ -20,9 +24,9 @@ class IndexSearch(AbstractSearch):
         self.ids = ids
         self.catalog_index = catalog_index
 
-    def search_partitions(self, _: List[HealpixPixel]) -> List[HealpixPixel]:
-        """Determine the target partitions for further filtering."""
-        return self.catalog_index.loc_partitions(self.ids)
+    def filter_hc_catalog(self, hc_structure: HCCatalogTypeVar) -> HCCatalogTypeVar:
+        healpix_pixels = self.catalog_index.loc_partitions(self.ids)
+        return hc_structure.filter_from_pixel_list(healpix_pixels)
 
     def search_points(self, frame: pd.DataFrame, _) -> pd.DataFrame:
         """Determine the search results within a data frame"""

--- a/src/lsdb/core/search/pixel_search.py
+++ b/src/lsdb/core/search/pixel_search.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
-from typing import List, Tuple
+from typing import List, Tuple, TYPE_CHECKING
 
 import pandas as pd
 from hipscat.catalog.catalog_info import CatalogInfo
 from hipscat.pixel_math import HealpixPixel
-from hipscat.pixel_math.filter import get_filtered_pixel_list
-from hipscat.pixel_tree.pixel_tree import PixelTree
 
 from lsdb.core.search.abstract_search import AbstractSearch
+
+if TYPE_CHECKING:
+    from lsdb.loaders.hipscat.abstract_catalog_loader import HCCatalogTypeVar
 
 
 class PixelSearch(AbstractSearch):
@@ -21,10 +22,8 @@ class PixelSearch(AbstractSearch):
     def __init__(self, pixels: List[Tuple[int, int]]):
         self.pixels = [HealpixPixel(o, p) for o, p in set(pixels)]
 
-    def search_partitions(self, pixels: List[HealpixPixel]) -> List[HealpixPixel]:
-        pixel_tree = PixelTree.from_healpix(pixels)
-        filter_pixel_tree = PixelTree.from_healpix(self.pixels)
-        return get_filtered_pixel_list(pixel_tree, filter_pixel_tree)
+    def filter_hc_catalog(self, hc_structure: HCCatalogTypeVar) -> HCCatalogTypeVar:
+        return hc_structure.filter_from_pixel_list(self.pixels)
 
     def search_points(self, frame: pd.DataFrame, metadata: CatalogInfo) -> pd.DataFrame:
         return frame

--- a/src/lsdb/core/search/pixel_search.py
+++ b/src/lsdb/core/search/pixel_search.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Tuple
 
 import pandas as pd
 from hipscat.catalog.catalog_info import CatalogInfo

--- a/src/lsdb/core/search/polygon_search.py
+++ b/src/lsdb/core/search/polygon_search.py
@@ -5,15 +5,14 @@ import healpy as hp
 import numpy as np
 import pandas as pd
 from hipscat.catalog.catalog_info import CatalogInfo
-from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.polygon_filter import (
-    CartesianCoordinates,
     SphericalCoordinates,
-    filter_pixels_by_polygon,
+    CartesianCoordinates,
+    generate_polygon_moc,
 )
 from hipscat.pixel_math.validators import validate_declination_values, validate_polygon
-from hipscat.pixel_tree.pixel_tree import PixelTree
 from lsst.sphgeom import ConvexPolygon, UnitVector3d
+from mocpy import MOC
 
 from lsdb.core.search.abstract_search import AbstractSearch
 
@@ -28,12 +27,11 @@ class PolygonSearch(AbstractSearch):
     def __init__(self, vertices: List[SphericalCoordinates]):
         _, dec = np.array(vertices).T
         validate_declination_values(dec)
+        self.vertices = np.array(vertices)
         self.polygon, self.vertices_xyz = get_cartesian_polygon(vertices)
 
-    def search_partitions(self, pixels: List[HealpixPixel]) -> List[HealpixPixel]:
-        """Determine the target partitions for further filtering."""
-        pixel_tree = PixelTree.from_healpix(pixels)
-        return filter_pixels_by_polygon(pixel_tree, self.vertices_xyz)
+    def generate_search_moc(self, max_order: int) -> MOC:
+        return generate_polygon_moc(self.vertices_xyz, max_order)
 
     def search_points(self, frame: pd.DataFrame, metadata: CatalogInfo) -> pd.DataFrame:
         """Determine the search results within a data frame"""

--- a/src/lsdb/core/search/polygon_search.py
+++ b/src/lsdb/core/search/polygon_search.py
@@ -5,11 +5,7 @@ import healpy as hp
 import numpy as np
 import pandas as pd
 from hipscat.catalog.catalog_info import CatalogInfo
-from hipscat.pixel_math.polygon_filter import (
-    SphericalCoordinates,
-    CartesianCoordinates,
-    generate_polygon_moc,
-)
+from hipscat.pixel_math.polygon_filter import CartesianCoordinates, SphericalCoordinates, generate_polygon_moc
 from hipscat.pixel_math.validators import validate_declination_values, validate_polygon
 from lsst.sphgeom import ConvexPolygon, UnitVector3d
 from mocpy import MOC

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -12,6 +12,7 @@ from hipscat.catalog import PartitionInfo
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN, healpix_to_hipscat_id
 from hipscat.pixel_tree import PixelAlignment, PixelAlignmentType, align_trees
+from hipscat.pixel_tree.moc_utils import copy_moc
 from hipscat.pixel_tree.pixel_alignment import align_with_mocs
 
 from lsdb.dask.divisions import get_pixels_divisions
@@ -89,7 +90,7 @@ def align_catalogs(left: Catalog, right: Catalog, add_right_margin: bool = True)
     if right_added_radius is not None:
         right_moc_depth_resol = hp.nside2resol(hp.order2nside(right_moc.max_order), arcmin=True) * 60
         if right_added_radius < right_moc_depth_resol:
-            right_moc = right_moc.add_neighbours()
+            right_moc = copy_moc(right_moc).add_neighbours()
         else:
             delta_order = int(np.ceil(np.log2(right_added_radius / right_moc_depth_resol)))
             right_moc = right_moc.degrade_to_order(right_moc.max_order - delta_order).add_neighbours()

--- a/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
@@ -77,15 +77,17 @@ class AbstractCatalogLoader(Generic[CatalogTypeVar]):
         kwargs = dict(self.config.kwargs)
         if self.config.dtype_backend is not None:
             kwargs["dtype_backend"] = self.config.dtype_backend
-        return dd.io.from_map(
-            file_io.read_parquet_file_to_pandas,
-            paths,
-            columns=self.config.columns,
-            divisions=divisions,
-            meta=dask_meta_schema,
-            storage_options=self.storage_options,
-            **kwargs,
-        )
+        if len(paths) > 0:
+            return dd.io.from_map(
+                file_io.read_parquet_file_to_pandas,
+                paths,
+                columns=self.config.columns,
+                divisions=divisions,
+                meta=dask_meta_schema,
+                storage_options=self.storage_options,
+                **kwargs,
+            )
+        return dd.io.from_pandas(dask_meta_schema, npartitions=1)
 
     def _load_metadata_schema(self, catalog: HCHealpixDataset) -> pd.DataFrame:
         metadata_pointer = hc.io.paths.get_common_metadata_pointer(catalog.catalog_base_dir)

--- a/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
@@ -48,6 +48,7 @@ class HipscatCatalogLoader(AbstractCatalogLoader[Catalog]):
         if isinstance(self.config.margin_cache, MarginCatalog):
             margin_catalog = self.config.margin_cache
             if self.config.search_filter is not None:
+                # pylint: disable=protected-access
                 margin_catalog = margin_catalog._search(metadata, self.config.search_filter, fine=False)
         elif isinstance(self.config.margin_cache, str):
             margin_catalog = lsdb.read_hipscat(

--- a/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import dataclasses
-
 import hipscat as hc
 
 import lsdb

--- a/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
@@ -30,12 +30,15 @@ class HipscatCatalogLoader(AbstractCatalogLoader[Catalog]):
         coverage for the desired region in the sky."""
         if self.config.search_filter is None:
             return hc_catalog
-        pixels_to_load = self.config.search_filter.search_partitions(hc_catalog.get_healpix_pixels())
-        if len(pixels_to_load) == 0:
+        filtered_catalog = self.config.search_filter.filter_hc_catalog(hc_catalog)
+        if len(filtered_catalog.get_healpix_pixels()) == 0:
             raise ValueError("The selected sky region has no coverage")
-        catalog_info = dataclasses.replace(hc_catalog.catalog_info, total_rows=None)
         return hc.catalog.Catalog(
-            catalog_info, pixels_to_load, self.path, hc_catalog.moc, self.storage_options
+            filtered_catalog.catalog_info,
+            filtered_catalog.pixel_tree,
+            catalog_path=hc_catalog.catalog_path,
+            moc=filtered_catalog.moc,
+            storage_options=hc_catalog.storage_options,
         )
 
     def _load_margin_catalog(self) -> MarginCatalog | None:

--- a/src/lsdb/loaders/hipscat/margin_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/margin_catalog_loader.py
@@ -20,9 +20,7 @@ class MarginCatalogLoader(AbstractCatalogLoader[MarginCatalog]):
         dask_df, dask_df_pixel_map = self._load_dask_df_and_map(filtered_hc_catalog)
         return MarginCatalog(dask_df, dask_df_pixel_map, filtered_hc_catalog)
 
-    def _filter_hipscat_catalog(
-        self, hc_catalog: hc.catalog.MarginCatalog
-    ) -> hc.catalog.MarginCatalog | None:
+    def _filter_hipscat_catalog(self, hc_catalog: hc.catalog.MarginCatalog) -> hc.catalog.MarginCatalog:
         """Filter the catalog pixels according to the spatial filter provided at loading time.
         Margin catalogs, unlike object and source catalogs, are allowed to be filtered to an
         empty catalog. In that case, the margin catalog is considered None."""

--- a/src/lsdb/loaders/hipscat/margin_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/margin_catalog_loader.py
@@ -17,8 +17,6 @@ class MarginCatalogLoader(AbstractCatalogLoader[MarginCatalog]):
         """
         hc_catalog = self._load_hipscat_catalog(hc.catalog.MarginCatalog)
         filtered_hc_catalog = self._filter_hipscat_catalog(hc_catalog)
-        if filtered_hc_catalog is None:
-            return None
         dask_df, dask_df_pixel_map = self._load_dask_df_and_map(filtered_hc_catalog)
         return MarginCatalog(dask_df, dask_df_pixel_map, filtered_hc_catalog)
 
@@ -31,8 +29,6 @@ class MarginCatalogLoader(AbstractCatalogLoader[MarginCatalog]):
         if self.config.search_filter is None:
             return hc_catalog
         filtered_catalog = self.config.search_filter.filter_hc_catalog(hc_catalog)
-        if len(filtered_catalog.get_healpix_pixels()) == 0:
-            return None
         return hc.catalog.MarginCatalog(
             filtered_catalog.catalog_info,
             filtered_catalog.pixel_tree,

--- a/src/lsdb/loaders/hipscat/margin_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/margin_catalog_loader.py
@@ -32,10 +32,12 @@ class MarginCatalogLoader(AbstractCatalogLoader[MarginCatalog]):
         empty catalog. In that case, the margin catalog is considered None."""
         if self.config.search_filter is None:
             return hc_catalog
-        pixels_to_load = self.config.search_filter.search_partitions(hc_catalog.get_healpix_pixels())
-        if len(pixels_to_load) == 0:
+        filtered_catalog = self.config.search_filter.filter_hc_catalog(hc_catalog)
+        if len(filtered_catalog.get_healpix_pixels()) == 0:
             return None
-        catalog_info = dataclasses.replace(hc_catalog.catalog_info, total_rows=None)
         return hc.catalog.MarginCatalog(
-            catalog_info, pixels_to_load, self.path, hc_catalog.moc, self.storage_options
+            filtered_catalog.catalog_info,
+            filtered_catalog.pixel_tree,
+            catalog_path=hc_catalog.catalog_path,
+            storage_options=hc_catalog.storage_options,
         )

--- a/src/lsdb/loaders/hipscat/margin_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/margin_catalog_loader.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import dataclasses
-
 import hipscat as hc
 
 from lsdb.catalog.margin_catalog import MarginCatalog

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -216,17 +216,17 @@ class TestBoundedCrossmatch:
     def test_crossmatch_empty_left_partition(algo, small_sky_order1_catalog, small_sky_xmatch_catalog):
         ra = 300
         dec = -60
-        radius_arcsec = 1 * 3600
+        radius_arcsec = 3 * 3600
         cone = small_sky_order1_catalog.cone_search(ra, dec, radius_arcsec)
         assert len(cone.get_healpix_pixels()) == 2
-        assert len(cone.get_partition(1, 44)) == 2
+        assert len(cone.get_partition(1, 44)) == 5
         # There is an empty partition in the left catalog
         assert len(cone.get_partition(1, 46)) == 0
         with pytest.warns(RuntimeWarning, match="Results may be incomplete and/or inaccurate"):
             xmatched = cone.crossmatch(
                 small_sky_xmatch_catalog, radius_arcsec=0.01 * 3600, algorithm=algo
             ).compute()
-        assert len(xmatched) == 2
+        assert len(xmatched) == 3
         assert all(xmatched["_dist_arcsec"] <= 0.01 * 3600)
 
 

--- a/tests/lsdb/loaders/hipscat/test_read_hipscat.py
+++ b/tests/lsdb/loaders/hipscat/test_read_hipscat.py
@@ -190,7 +190,7 @@ def test_read_hipscat_with_invalid_backend(small_sky_dir):
 def test_read_hipscat_margin_catalog_subset(
     small_sky_order1_source_margin_dir, small_sky_order1_source_margin_catalog, assert_divisions_are_correct
 ):
-    search_filter = ConeSearch(ra=320, dec=-35, radius_arcsec=1 * 3600)
+    search_filter = ConeSearch(ra=315, dec=-60, radius_arcsec=10)
     margin = lsdb.read_hipscat(small_sky_order1_source_margin_dir, search_filter=search_filter)
 
     margin_info = margin.hc_structure.catalog_info
@@ -200,11 +200,19 @@ def test_read_hipscat_margin_catalog_subset(
     assert margin_info.catalog_name == small_sky_order1_source_margin_info.catalog_name
     assert margin_info.primary_catalog == small_sky_order1_source_margin_info.primary_catalog
     assert margin_info.margin_threshold == small_sky_order1_source_margin_info.margin_threshold
-    assert margin.get_healpix_pixels() == [HealpixPixel(1, 45), HealpixPixel(1, 47)]
+    assert margin.get_healpix_pixels() == [
+        HealpixPixel(1, 44),
+        HealpixPixel(1, 45),
+        HealpixPixel(1, 46),
+        HealpixPixel(1, 47),
+    ]
     assert_divisions_are_correct(margin)
 
 
 def test_read_hipscat_margin_catalog_subset_is_empty(small_sky_order1_source_margin_dir):
-    search_filter = ConeSearch(ra=30, dec=10, radius_arcsec=1)
+    search_filter = ConeSearch(ra=100, dec=80, radius_arcsec=1)
     margin_catalog = lsdb.read_hipscat(small_sky_order1_source_margin_dir, search_filter=search_filter)
-    assert margin_catalog is None
+    assert len(margin_catalog.get_healpix_pixels()) == 0
+    assert len(margin_catalog._ddf_pixel_map) == 0
+    assert len(margin_catalog.compute()) == 0
+    assert len(margin_catalog.hc_structure.pixel_tree) == 0

--- a/tests/lsdb/loaders/hipscat/test_read_hipscat.py
+++ b/tests/lsdb/loaders/hipscat/test_read_hipscat.py
@@ -167,6 +167,26 @@ def test_read_hipscat_subset_no_partitions(small_sky_order1_dir, small_sky_order
         lsdb.read_hipscat(small_sky_order1_dir, search_filter=index_search)
 
 
+def test_read_hipscat_with_margin_subset(
+    small_sky_order1_source_dir, small_sky_order1_source_with_margin, small_sky_order1_source_margin_catalog
+):
+    cone_search = ConeSearch(ra=315, dec=-66, radius_arcsec=20)
+    # Filtering using catalog's cone_search
+    cone_search_catalog = small_sky_order1_source_with_margin.cone_search(ra=315, dec=-66, radius_arcsec=20)
+    # Filtering when calling `read_hipscat`
+    cone_search_catalog_2 = lsdb.read_hipscat(
+        small_sky_order1_source_dir,
+        search_filter=cone_search,
+        margin_cache=small_sky_order1_source_margin_catalog,
+    )
+    assert isinstance(cone_search_catalog_2, lsdb.Catalog)
+    # The partitions of the catalogs are equivalent
+    assert cone_search_catalog.get_healpix_pixels() == cone_search_catalog_2.get_healpix_pixels()
+    assert (
+        cone_search_catalog.margin.get_healpix_pixels() == cone_search_catalog_2.margin.get_healpix_pixels()
+    )
+
+
 def test_read_hipscat_with_backend(small_sky_dir):
     # By default, the schema is backed by pyarrow
     default_catalog = lsdb.read_hipscat(small_sky_dir)


### PR DESCRIPTION
Refactors Search Filter class to use hipscat MOC filtering methods. MOCs are now filtered and passed through to the returned catalog after filtering, and filtering now doesn't need to generate and align multiple pixel trees, and reuses more code from hispcat and has less code overall.

Margin filtering now uses Margin Filter code in hipscat, so performing a search filter in read_hipscat on a margin catalog now works.

Fixes #330, fixes #329, fixes #268 