### PR TITLE
Support to query params on http filesystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ _html/
 
 # large, unused fits files
 point_map.fits
+
+# test notebook
+dev/test.ipynb

--- a/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
@@ -67,7 +67,7 @@ class AbstractCatalogLoader(Generic[CatalogTypeVar]):
             catalog.catalog_base_dir,
             ordered_pixels,
             self.config.make_query_url_params(),
-            self.storage_options,
+            storage_options=self.storage_options,
         )
         return paths
 

--- a/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
@@ -64,7 +64,10 @@ class AbstractCatalogLoader(Generic[CatalogTypeVar]):
         self, catalog: HCHealpixDataset, ordered_pixels: List[HealpixPixel]
     ) -> List[hc.io.FilePointer]:
         paths = hc.io.paths.pixel_catalog_files(
-            catalog.catalog_base_dir, ordered_pixels, storage_options=self.storage_options
+            catalog.catalog_base_dir,
+            ordered_pixels,
+            self.config.make_query_url_params(),
+            self.storage_options,
         )
         return paths
 

--- a/src/lsdb/loaders/hipscat/hipscat_loading_config.py
+++ b/src/lsdb/loaders/hipscat/hipscat_loading_config.py
@@ -47,3 +47,20 @@ class HipscatLoadingConfig:
         elif self.dtype_backend == "numpy_nullable":
             mapper = _arrow_dtype_mapping().get
         return mapper
+
+    def make_query_url_params(self) -> dict:
+        """
+        Generates a dictionary of URL parameters with `columns` and `filters` attributes.
+        """
+        url_params = {}
+
+        if self.columns and len(self.columns) > 0:
+            url_params["columns"] = self.columns
+
+        if "filters" in self.kwargs:
+            url_params["filters"] = []
+            for filtr in self.kwargs["filters"]:
+                # This is how hipscat expects the filters to add to the url
+                url_params["filters"].append(f"{filtr[0]}{filtr[1]}{filtr[2]}")
+
+        return url_params


### PR DESCRIPTION
This PR works on top of `hipscat` [#291 PR](https://github.com/astronomy-commons/hipscat/pull/291).

It creates the url params dict to be transformed to url params in hipscat. 

