### PR TITLE
Update catalog threshold estimation

### DIFF
--- a/docs/tutorials/import_catalogs.ipynb
+++ b/docs/tutorials/import_catalogs.ipynb
@@ -281,14 +281,6 @@
    "source": [
     "tmp_dir.cleanup()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "006a2917",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/tutorials/import_catalogs.ipynb
+++ b/docs/tutorials/import_catalogs.ipynb
@@ -111,6 +111,7 @@
     "    pd.read_csv(catalog_csv_path),\n",
     "    catalog_name=\"from_dataframe\",\n",
     "    catalog_type=\"object\",\n",
+    "    lowest_order=2,\n",
     "    highest_order=5,\n",
     "    threshold=100,\n",
     ")\n",
@@ -186,6 +187,7 @@
     "args = ImportArguments(\n",
     "    ra_column=\"ra\",\n",
     "    dec_column=\"dec\",\n",
+    "    lowest_healpix_order=2,\n",
     "    highest_healpix_order=5,\n",
     "    pixel_threshold=100,\n",
     "    file_reader=\"csv\",\n",
@@ -279,6 +281,14 @@
    "source": [
     "tmp_dir.cleanup()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "006a2917",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -297,7 +307,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/src/lsdb/loaders/dataframe/from_dataframe.py
+++ b/src/lsdb/loaders/dataframe/from_dataframe.py
@@ -9,8 +9,8 @@ from lsdb.loaders.dataframe.margin_catalog_generator import MarginCatalogGenerat
 
 def from_dataframe(
     dataframe: pd.DataFrame,
-    lowest_order: int = 0,
-    highest_order: int = 5,
+    lowest_order: int = 3,
+    highest_order: int = 7,
     partition_size: int | None = None,
     threshold: int | None = None,
     margin_order: int | None = -1,
@@ -23,17 +23,17 @@ def from_dataframe(
     """Load a catalog from a Pandas Dataframe in CSV format.
 
     Args:
-        dataframe (pd.Dataframe): The catalog Pandas Dataframe
-        lowest_order (int): The lowest partition order
-        highest_order (int): The highest partition order
-        partition_size (int): The desired partition size, in number of rows
-        threshold (int): The maximum number of data points per pixel
-        margin_order (int): The order at which to generate the margin cache
+        dataframe (pd.Dataframe): The catalog Pandas Dataframe.
+        lowest_order (int): The lowest partition order. Defaults to 3.
+        highest_order (int): The highest partition order. Defaults to 7.
+        partition_size (int): The desired partition size, in number of rows.
+        threshold (int): The maximum number of data points per pixel.
+        margin_order (int): The order at which to generate the margin cache.
         margin_threshold (float): The size of the margin cache boundary, in arcseconds. If None,
             the margin cache is not generated. Defaults to 5 arcseconds.
         use_pyarrow_types (bool): If True, the data is backed by pyarrow, otherwise we keep the
             original data types. Defaults to True.
-        **kwargs: Arguments to pass to the creation of the catalog info
+        **kwargs: Arguments to pass to the creation of the catalog info.
 
     Returns:
         Catalog object loaded from the given parameters

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -259,7 +259,7 @@ def test_crossmatch_with_moc(small_sky_order1_catalog):
     pixels = [44, 45, 46]
     partitions = [small_sky_order1_catalog.get_partition(order, p).compute() for p in pixels]
     df = pd.concat(partitions)
-    subset_catalog = lsdb.from_dataframe(df)
+    subset_catalog = lsdb.from_dataframe(df, lowest_order=0, highest_order=5)
     assert subset_catalog.get_healpix_pixels() == [HealpixPixel(0, 11)]
     xmatched = small_sky_order1_catalog.crossmatch(subset_catalog)
     assert xmatched.get_healpix_pixels() == [HealpixPixel(order, p) for p in pixels]

--- a/tests/lsdb/loaders/dataframe/test_from_dataframe.py
+++ b/tests/lsdb/loaders/dataframe/test_from_dataframe.py
@@ -1,3 +1,5 @@
+import math
+
 import astropy.units as u
 import healpy as hp
 import numpy as np
@@ -11,7 +13,6 @@ from mocpy import MOC
 
 import lsdb
 from lsdb.catalog.margin_catalog import MarginCatalog
-from lsdb.loaders.dataframe.dataframe_catalog_loader import DataframeCatalogLoader
 
 
 def get_catalog_kwargs(catalog, **kwargs):
@@ -140,7 +141,9 @@ def test_partitions_obey_default_threshold_when_no_arguments_specified(
 ):
     """Tests that partitions are limited by the default threshold
     when no partition size or threshold is specified"""
-    default_threshold = DataframeCatalogLoader.DEFAULT_THRESHOLD
+    df_total_memory = small_sky_order1_df.memory_usage(deep=True).sum()
+    partition_memory = df_total_memory / len(small_sky_order1_df)
+    default_threshold = math.ceil((1 << 30) / partition_memory)
     # Read CSV file for the small sky order 1 catalog
     kwargs = get_catalog_kwargs(small_sky_order1_catalog, threshold=None, partition_size=None)
     catalog = lsdb.from_dataframe(small_sky_order1_df, margin_threshold=None, **kwargs)

--- a/tests/lsdb/loaders/dataframe/test_from_dataframe.py
+++ b/tests/lsdb/loaders/dataframe/test_from_dataframe.py
@@ -22,6 +22,7 @@ def get_catalog_kwargs(catalog, **kwargs):
     kwargs = {
         "catalog_name": catalog_info.catalog_name,
         "catalog_type": catalog_info.catalog_type,
+        "lowest_order": 0,
         "highest_order": 5,
         "threshold": 50,
         **kwargs,
@@ -159,6 +160,7 @@ def test_catalog_pixels_nested_ordering(small_sky_source_df):
         small_sky_source_df,
         catalog_name="small_sky_source",
         catalog_type="source",
+        lowest_order=0,
         highest_order=2,
         threshold=3_000,
         margin_threshold=None,
@@ -177,6 +179,7 @@ def test_from_dataframe_small_sky_source_with_margins(small_sky_source_df, small
         small_sky_source_df,
         ra_column="source_ra",
         dec_column="source_dec",
+        lowest_order=0,
         highest_order=2,
         threshold=3000,
         margin_order=8,


### PR DESCRIPTION
Provides a better threshold estimation in `from_dataframe` for when no partition size or threshold are provided, attempting to create partitions that in memory will be of roughly 1Gib. 

It also increases the lowest and highest order defaults to 3 and 7, respectively. Closes #213.