### PR TITLE
Support map_partitions ufunc with non data frame output

### DIFF
--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -179,7 +179,7 @@ class HealpixDataset(Dataset):
         meta: pd.DataFrame | pd.Series | Dict | Iterable | Tuple | None = None,
         include_pixel: bool = False,
         **kwargs,
-    ) -> Self:
+    ) -> Self | dd.core.Series:
         """Applies a function to each partition in the catalog.
 
         The ra and dec of each row is assumed to remain unchanged.
@@ -210,7 +210,7 @@ class HealpixDataset(Dataset):
 
         Returns:
             A new catalog with each partition replaced with the output of the function applied to the original
-            partition.
+            partition. If the function returns a non dataframe output, a dask Series will be returned.
         """
         if meta is None:
             if include_pixel:

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -223,6 +223,12 @@ class HealpixDataset(Dataset):
                     " the partitions in place will not work. If the function does not work for empty inputs, "
                     "please specify a `meta` argument."
                 )
+        if not isinstance(meta, pd.DataFrame):
+            warnings.warn(
+                "output of the function must be a DataFrame to generate an LSDB `Catalog`. `map_partitions` "
+                "will return a dask object instead of a Catalog.",
+                RuntimeWarning,
+            )
         if include_pixel:
             pixels = self.get_ordered_healpix_pixels()
 
@@ -234,7 +240,9 @@ class HealpixDataset(Dataset):
             output_ddf = self._ddf.map_partitions(apply_func, *args, meta=meta, **kwargs)
         else:
             output_ddf = self._ddf.map_partitions(func, *args, meta=meta, **kwargs)
-        return self.__class__(output_ddf, self._ddf_pixel_map, self.hc_structure)
+        if isinstance(meta, pd.DataFrame):
+            return self.__class__(output_ddf, self._ddf_pixel_map, self.hc_structure)
+        return output_ddf
 
     def prune_empty_partitions(self, persist: bool = False) -> Self:
         """Prunes the catalog of its empty partitions

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -531,6 +531,19 @@ def test_map_partitions_specify_meta(small_sky_order1_catalog):
     assert np.all(mapcomp["a"] == mapcomp["ra"] + 1)
 
 
+def test_map_partitions_non_df(small_sky_order1_catalog):
+    def get_col(df):
+        return df["ra"] + 1
+
+    with pytest.warns(RuntimeWarning, match="DataFrame"):
+        mapped = small_sky_order1_catalog.map_partitions(get_col)
+
+    assert not isinstance(mapped, Catalog)
+    assert isinstance(mapped, dd.core.Series)
+    mapcomp = mapped.compute()
+    assert np.all(mapcomp == small_sky_order1_catalog.compute()["ra"] + 1)
+
+
 def test_non_working_empty_raises(small_sky_order1_catalog):
     def add_col(df):
         if len(df) == 0:


### PR DESCRIPTION
Currently if the user returns a non data frame when calling map_partitions (e.g. returning a series) it uses this as the ddf in another catalog, which causes errors when the catalog expects a ddf but actually gets a series.

This updates the map_partitions method to check that the return type is a data frame. If the return type isn't, the raw dask collection is returned instead of creating the catalog.

Fixes #324 