### PR TITLE
Replace dask dataframe with nested-dask

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,13 @@ dependencies = [
     # dask distributed eases the creation of parallel dask clients.
     # dask diagnostics is required to spin up the dashboard for profiling.
     "dask[complete]",
-    "nested-dask",
-    "hipscat>=0.3.8",
-    "pyarrow",
     "deprecated",
-    "scipy", # kdtree
+    "hipscat>=0.3.8",
     "lsst-sphgeom", # To handle spherical sky polygons
+    "nested-dask",
+    "nested-pandas",
+    "pyarrow",
+    "scipy", # kdtree
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     # dask distributed eases the creation of parallel dask clients.
     # dask diagnostics is required to spin up the dashboard for profiling.
     "dask[complete]",
+    "nested-dask",
     "hipscat>=0.3.8",
     "pyarrow",
     "deprecated",

--- a/src/lsdb/catalog/association_catalog.py
+++ b/src/lsdb/catalog/association_catalog.py
@@ -1,5 +1,5 @@
-import dask.dataframe as dd
 import hipscat as hc
+from nested_dask import NestedFrame
 
 from lsdb.catalog.dataset.healpix_dataset import HealpixDataset
 from lsdb.types import DaskDFPixelMap
@@ -18,7 +18,7 @@ class AssociationCatalog(HealpixDataset):
 
     def __init__(
         self,
-        ddf: dd.DataFrame,
+        ddf: NestedFrame,
         ddf_pixel_map: DaskDFPixelMap,
         hc_structure: hc.catalog.AssociationCatalog,
     ):

--- a/src/lsdb/catalog/association_catalog.py
+++ b/src/lsdb/catalog/association_catalog.py
@@ -1,5 +1,5 @@
 import hipscat as hc
-from nested_dask import NestedFrame
+import nested_dask as nd
 
 from lsdb.catalog.dataset.healpix_dataset import HealpixDataset
 from lsdb.types import DaskDFPixelMap
@@ -18,7 +18,7 @@ class AssociationCatalog(HealpixDataset):
 
     def __init__(
         self,
-        ddf: NestedFrame,
+        ddf: nd.NestedFrame,
         ddf_pixel_map: DaskDFPixelMap,
         hc_structure: hc.catalog.AssociationCatalog,
     ):

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -1,5 +1,6 @@
-import nested_pandas as npd
 from __future__ import annotations
+
+import nested_pandas as npd
 
 import dataclasses
 from typing import List, Tuple, Type

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 from typing import List, Tuple, Type
 
-import dask.dataframe as dd
+from nested_dask import NestedFrame
 import hipscat as hc
 import pandas as pd
 from hipscat.catalog.index.index_catalog import IndexCatalog as HCIndexCatalog
@@ -38,7 +38,7 @@ class Catalog(HealpixDataset):
 
     def __init__(
         self,
-        ddf: dd.DataFrame,
+        ddf: NestedFrame,
         ddf_pixel_map: DaskDFPixelMap,
         hc_structure: hc.catalog.Catalog,
         margin: MarginCatalog | None = None,
@@ -329,7 +329,7 @@ class Catalog(HealpixDataset):
         left_index: bool = False,
         right_index: bool = False,
         suffixes: Tuple[str, str] | None = None,
-    ) -> dd.DataFrame:
+    ) -> NestedFrame:
         """Performs the merge of two catalog Dataframes
 
         More information about pandas merge is available

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -8,8 +8,7 @@ import nested_pandas as npd
 import pandas as pd
 from hipscat.catalog.index.index_catalog import IndexCatalog as HCIndexCatalog
 from hipscat.pixel_math.polygon_filter import SphericalCoordinates
-from nested_dask import NestedFrame
-
+import nested_dask as nd
 from lsdb.catalog.association_catalog import AssociationCatalog
 from lsdb.catalog.dataset.healpix_dataset import HealpixDataset
 from lsdb.catalog.margin_catalog import MarginCatalog
@@ -43,7 +42,7 @@ class Catalog(HealpixDataset):
 
     def __init__(
         self,
-        ddf: NestedFrame,
+        ddf: nd.NestedFrame,
         ddf_pixel_map: DaskDFPixelMap,
         hc_structure: hc.catalog.Catalog,
         margin: MarginCatalog | None = None,

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -319,9 +319,9 @@ class Catalog(HealpixDataset):
             A new Catalog containing the points filtered to those matching the search parameters.
         """
         filtered_hc_structure = search.filter_hc_catalog(self.hc_structure)
-        ddf_partition_map, search_ddf = self._perform_search(filtered_hc_structure, search)
+        ddf_partition_map, search_ndf = self._perform_search(filtered_hc_structure, search)
         margin = self.margin.search(search) if self.margin is not None else None
-        return Catalog(search_ddf, ddf_partition_map, filtered_hc_structure, margin=margin)
+        return Catalog(search_ndf, ddf_partition_map, filtered_hc_structure, margin=margin)
 
     def merge(
         self,
@@ -333,7 +333,7 @@ class Catalog(HealpixDataset):
         left_index: bool = False,
         right_index: bool = False,
         suffixes: Tuple[str, str] | None = None,
-    ) -> NestedFrame:
+    ) -> nd.NestedFrame:
         """Performs the merge of two catalog Dataframes
 
         More information about pandas merge is available

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -455,7 +455,6 @@ class Catalog(HealpixDataset):
         other: Catalog,
         left_on: str | None = None,
         right_on: str | None = None,
-        suffixes: Tuple[str, str] | None = None,
         nested_column_name: str | None = None,
         output_catalog_name: str | None = None,
     ) -> Catalog:
@@ -469,20 +468,12 @@ class Catalog(HealpixDataset):
             other (Catalog): the right catalog to join to
             left_on (str): the name of the column in the left catalog to join on
             right_on (str): the name of the column in the right catalog to join on
-            through (AssociationCatalog): an association catalog that provides the alignment
-                between pixels and individual rows.
-            suffixes (Tuple[str,str]): suffixes to apply to the columns of each table
             output_catalog_name (str): The name of the resulting catalog to be stored in metadata
 
         Returns:
             A new catalog with the columns from each of the input catalogs with their respective suffixes
             added, and the rows merged on the specified columns.
         """
-        if suffixes is None:
-            suffixes = (f"_{self.name}", f"_{other.name}")
-
-        if len(suffixes) != 2:
-            raise ValueError("`suffixes` must be a tuple with two strings")
 
         if left_on is None or right_on is None:
             raise ValueError("Both of left_on and right_on")
@@ -494,7 +485,7 @@ class Catalog(HealpixDataset):
             raise ValueError("right_on must be a column in the right catalog")
 
         ddf, ddf_map, alignment = join_catalog_data_nested(
-            self, other, left_on, right_on, suffixes=suffixes, nested_column_name=nested_column_name
+            self, other, left_on, right_on, nested_column_name=nested_column_name
         )
 
         if output_catalog_name is None:
@@ -503,8 +494,6 @@ class Catalog(HealpixDataset):
         new_catalog_info = dataclasses.replace(
             self.hc_structure.catalog_info,
             catalog_name=output_catalog_name,
-            ra_column=self.hc_structure.catalog_info.ra_column + suffixes[0],
-            dec_column=self.hc_structure.catalog_info.dec_column + suffixes[0],
         )
         hc_catalog = hc.catalog.Catalog(new_catalog_info, alignment.pixel_tree)
         return Catalog(ddf, ddf_map, hc_catalog)

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -4,11 +4,12 @@ import dataclasses
 from typing import List, Tuple, Type
 
 import hipscat as hc
+import nested_dask as nd
 import nested_pandas as npd
 import pandas as pd
 from hipscat.catalog.index.index_catalog import IndexCatalog as HCIndexCatalog
 from hipscat.pixel_math.polygon_filter import SphericalCoordinates
-import nested_dask as nd
+
 from lsdb.catalog.association_catalog import AssociationCatalog
 from lsdb.catalog.dataset.healpix_dataset import HealpixDataset
 from lsdb.catalog.margin_catalog import MarginCatalog

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
-import nested_pandas as npd
-
 import dataclasses
 from typing import List, Tuple, Type
 
-from nested_dask import NestedFrame
 import hipscat as hc
+import nested_pandas as npd
 import pandas as pd
 from hipscat.catalog.index.index_catalog import IndexCatalog as HCIndexCatalog
 from hipscat.pixel_math.polygon_filter import SphericalCoordinates
+from nested_dask import NestedFrame
 
 from lsdb.catalog.association_catalog import AssociationCatalog
 from lsdb.catalog.dataset.healpix_dataset import HealpixDataset
@@ -21,9 +20,9 @@ from lsdb.core.search.abstract_search import AbstractSearch
 from lsdb.core.search.pixel_search import PixelSearch
 from lsdb.dask.crossmatch_catalog_data import crossmatch_catalog_data
 from lsdb.dask.join_catalog_data import (
+    join_catalog_data_nested,
     join_catalog_data_on,
     join_catalog_data_through,
-    join_catalog_data_nested,
 )
 from lsdb.dask.partition_indexer import PartitionIndexer
 from lsdb.io.schema import get_arrow_schema

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -465,7 +465,7 @@ class Catalog(HealpixDataset):
         The result is added as a nested dataframe column using
         `nested-dask <https://github.com/lincc-frameworks/nested-dask>`__, where the right catalog's columns
         are encoded within a column in the resulting dataframe. For more information, view the
-        `nested-dask documentation <https://nested-dask.readthedocs.io/en/latest/>`__
+        `nested-dask documentation <https://nested-dask.readthedocs.io/en/latest/>`__.
 
         The operation only joins data from matching partitions and their margin caches, and does not join rows
         that have a matching column value but are in separate partitions in the sky. For a more general join,

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -458,7 +458,7 @@ class Catalog(HealpixDataset):
         nested_column_name: str | None = None,
         output_catalog_name: str | None = None,
     ) -> Catalog:
-        """Perform a spatial join to another catalog by adding the other catalog a nested column
+        """Perform a spatial join to another catalog by adding the other catalog as a nested column
 
         Joins two catalogs together on a shared column value, merging rows where they match.
 

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -458,16 +458,25 @@ class Catalog(HealpixDataset):
         nested_column_name: str | None = None,
         output_catalog_name: str | None = None,
     ) -> Catalog:
-        """Perform a spatial join to another catalog
+        """Perform a spatial join to another catalog by adding the other catalog a nested column
 
-        Joins two catalogs together on a shared column value, merging rows where they match. The operation
-        only joins data from matching partitions, and does not join rows that have a matching column value but
-        are in separate partitions in the sky. For a more general join, see the `merge` function.
+        Joins two catalogs together on a shared column value, merging rows where they match.
+
+        The result is added as a nested dataframe column using
+        `nested-dask <https://github.com/lincc-frameworks/nested-dask>`__, where the right catalog's columns
+        are encoded within a column in the resulting dataframe. For more information, view the
+        `nested-dask documentation <https://nested-dask.readthedocs.io/en/latest/>`__
+
+        The operation only joins data from matching partitions and their margin caches, and does not join rows
+        that have a matching column value but are in separate partitions in the sky. For a more general join,
+        see the `merge` function.
 
         Args:
             other (Catalog): the right catalog to join to
             left_on (str): the name of the column in the left catalog to join on
             right_on (str): the name of the column in the right catalog to join on
+            nested_column_name (str): the name of the nested column in the resulting dataframe storing the
+                joined columns in the right catalog. (Default: name of right catalog)
             output_catalog_name (str): The name of the resulting catalog to be stored in metadata
 
         Returns:
@@ -476,7 +485,7 @@ class Catalog(HealpixDataset):
         """
 
         if left_on is None or right_on is None:
-            raise ValueError("Both of left_on and right_on")
+            raise ValueError("Both of left_on and right_on must be set")
 
         if left_on not in self._ddf.columns:
             raise ValueError("left_on must be a column in the left catalog")

--- a/src/lsdb/catalog/dataset/dataset.py
+++ b/src/lsdb/catalog/dataset/dataset.py
@@ -1,9 +1,9 @@
 from typing import List
 
-import dask.dataframe as dd
 import hipscat as hc
 import pandas as pd
 from dask.delayed import Delayed
+from nested_dask import NestedFrame
 
 
 class Dataset:
@@ -11,7 +11,7 @@ class Dataset:
 
     def __init__(
         self,
-        ddf: dd.DataFrame,
+        ddf: NestedFrame,
         hc_structure: hc.catalog.Dataset,
     ):
         """Initialise a Catalog object.

--- a/src/lsdb/catalog/dataset/dataset.py
+++ b/src/lsdb/catalog/dataset/dataset.py
@@ -2,7 +2,6 @@ from typing import List
 
 import hipscat as hc
 import nested_pandas as npd
-import pandas as pd
 from dask.delayed import Delayed
 from nested_dask import NestedFrame
 

--- a/src/lsdb/catalog/dataset/dataset.py
+++ b/src/lsdb/catalog/dataset/dataset.py
@@ -1,7 +1,7 @@
-import nested_pandas as npd
 from typing import List
 
 import hipscat as hc
+import nested_pandas as npd
 import pandas as pd
 from dask.delayed import Delayed
 from nested_dask import NestedFrame

--- a/src/lsdb/catalog/dataset/dataset.py
+++ b/src/lsdb/catalog/dataset/dataset.py
@@ -3,7 +3,7 @@ from typing import List
 import hipscat as hc
 import nested_pandas as npd
 from dask.delayed import Delayed
-from nested_dask import NestedFrame
+import nested_dask as nd
 
 
 class Dataset:
@@ -11,7 +11,7 @@ class Dataset:
 
     def __init__(
         self,
-        ddf: NestedFrame,
+        ddf: nd.NestedFrame,
         hc_structure: hc.catalog.Dataset,
     ):
         """Initialise a Catalog object.

--- a/src/lsdb/catalog/dataset/dataset.py
+++ b/src/lsdb/catalog/dataset/dataset.py
@@ -1,3 +1,4 @@
+import nested_pandas as npd
 from typing import List
 
 import hipscat as hc
@@ -34,7 +35,7 @@ class Dataset:
         data = self._ddf._repr_data().to_html(max_rows=5, show_dimensions=False, notebook=True)
         return f"<div><strong>lsdb Catalog {self.name}:</strong></div>{data}"
 
-    def compute(self) -> pd.DataFrame:
+    def compute(self) -> npd.NestedFrame:
         """Compute dask distributed dataframe to pandas dataframe"""
         return self._ddf.compute()
 

--- a/src/lsdb/catalog/dataset/dataset.py
+++ b/src/lsdb/catalog/dataset/dataset.py
@@ -1,9 +1,9 @@
 from typing import List
 
 import hipscat as hc
+import nested_dask as nd
 import nested_pandas as npd
 from dask.delayed import Delayed
-import nested_dask as nd
 
 
 class Dataset:

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -175,9 +175,9 @@ class HealpixDataset(Dataset):
 
         Args:
             func (Callable): The function applied to each partition, which will be called with:
-                `func(partition: npd.NestedFrame, *args, **kwargs)` with the additional args and kwargs passed to
-                the `map_partitions` function. If the `include_pixel` parameter is set, the function will be
-                called with the `healpix_pixel` as the second positional argument set to the healpix pixel
+                `func(partition: npd.NestedFrame, *args, **kwargs)` with the additional args and kwargs passed
+                to the `map_partitions` function. If the `include_pixel` parameter is set, the function will
+                be called with the `healpix_pixel` as the second positional argument set to the healpix pixel
                 of the partition as
                 `func(partition: npd.NestedFrame, healpix_pixel: HealpixPixel, *args, **kwargs)`
             *args: Additional positional arguments to call `func` with.
@@ -334,8 +334,8 @@ class HealpixDataset(Dataset):
         a given order
 
         Args:
-            func (Callable[[npd.NestedFrame, HealpixPixel], Any]): A function that takes a pandas DataFrame and
-                the HealpixPixel the partition is from and returns a value
+            func (Callable[[npd.NestedFrame, HealpixPixel], Any]): A function that takes a pandas DataFrame
+                and the HealpixPixel the partition is from and returns a value
             order (int | None): The HEALPix order to compute the skymap at. If None (default),
                 will compute for each partition in the catalog at their own orders. If a value
                 other than None, each partition will be grouped by pixel number at the order
@@ -371,8 +371,8 @@ class HealpixDataset(Dataset):
         """Plot a skymap of an aggregate function applied over each partition
 
         Args:
-            func (Callable[[npd.NestedFrame, HealpixPixel], Any]): A function that takes a pandas DataFrame and
-                the HealpixPixel the partition is from and returns a value
+            func (Callable[[npd.NestedFrame, HealpixPixel], Any]): A function that takes a pandas DataFrame
+                and the HealpixPixel the partition is from and returns a value
             order (int | None): The HEALPix order to compute the skymap at. If None (default),
                 will compute for each partition in the catalog at their own orders. If a value
                 other than None, each partition will be grouped by pixel number at the order

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -148,7 +148,7 @@ class HealpixDataset(Dataset):
         """
         filtered_pixels = metadata.get_healpix_pixels()
         if len(filtered_pixels) == 0:
-            return {}, NestedFrame.from_dask_dataframe(dd.from_pandas(self._ddf._meta))
+            return {}, NestedFrame.from_pandas(self._ddf._meta)
         target_partitions_indices = [self._ddf_pixel_map[pixel] for pixel in filtered_pixels]
         filtered_partitions_ddf = self._ddf.partitions[target_partitions_indices]
         if search.fine:
@@ -251,7 +251,7 @@ class HealpixDataset(Dataset):
         search_ddf = (
             self._ddf.partitions[non_empty_partitions]
             if len(non_empty_partitions) > 0
-            else NestedFrame.from_dask_dataframe(dd.from_pandas(self._ddf._meta, npartitions=1))
+            else NestedFrame.from_pandas(self._ddf._meta, npartitions=1)
         )
         ddf_partition_map = {pixel: i for i, pixel in enumerate(non_empty_pixels)}
         filtered_hc_structure = self.hc_structure.filter_from_pixel_list(non_empty_pixels)

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import nested_pandas as npd
+
 import warnings
 from typing import Any, Callable, Dict, Iterable, List, Tuple
 
@@ -162,7 +164,7 @@ class HealpixDataset(Dataset):
 
     def map_partitions(
         self,
-        func: Callable[..., pd.DataFrame],
+        func: Callable[..., npd.NestedFrame],
         *args,
         meta: pd.DataFrame | pd.Series | Dict | Iterable | Tuple | None = None,
         include_pixel: bool = False,
@@ -174,11 +176,11 @@ class HealpixDataset(Dataset):
 
         Args:
             func (Callable): The function applied to each partition, which will be called with:
-                `func(partition: pd.DataFrame, *args, **kwargs)` with the additional args and kwargs passed to
+                `func(partition: npd.NestedFrame, *args, **kwargs)` with the additional args and kwargs passed to
                 the `map_partitions` function. If the `include_pixel` parameter is set, the function will be
                 called with the `healpix_pixel` as the second positional argument set to the healpix pixel
                 of the partition as
-                `func(partition: pd.DataFrame, healpix_pixel: HealpixPixel, *args, **kwargs)`
+                `func(partition: npd.NestedFrame, healpix_pixel: HealpixPixel, *args, **kwargs)`
             *args: Additional positional arguments to call `func` with.
             meta (pd.DataFrame | pd.Series | Dict | Iterable | Tuple | None): An empty pandas DataFrame that
                 has columns matching the output of the function applied to a partition. Other types are
@@ -279,7 +281,7 @@ class HealpixDataset(Dataset):
 
     def skymap_data(
         self,
-        func: Callable[[pd.DataFrame, HealpixPixel], Any],
+        func: Callable[[npd.NestedFrame, HealpixPixel], Any],
         order: int | None = None,
         default_value: Any = 0.0,
         **kwargs,
@@ -287,7 +289,7 @@ class HealpixDataset(Dataset):
         """Perform a function on each partition of the catalog, returning a dict of values for each pixel.
 
         Args:
-            func (Callable[[pd.DataFrame, HealpixPixel], Any]): A function that takes a pandas
+            func (Callable[[npd.NestedFrame, HealpixPixel], Any]): A function that takes a pandas
                 DataFrame with the data in a partition, the HealpixPixel of the partition, and any other
                 keyword arguments and returns an aggregated value
             order (int | None): The HEALPix order to compute the skymap at. If None (default),
@@ -324,7 +326,7 @@ class HealpixDataset(Dataset):
 
     def skymap_histogram(
         self,
-        func: Callable[[pd.DataFrame, HealpixPixel], Any],
+        func: Callable[[npd.NestedFrame, HealpixPixel], Any],
         order: int | None = None,
         default_value: Any = 0.0,
         **kwargs,
@@ -333,7 +335,7 @@ class HealpixDataset(Dataset):
         a given order
 
         Args:
-            func (Callable[[pd.DataFrame], HealpixPixel, Any]): A function that takes a pandas DataFrame and
+            func (Callable[[npd.NestedFrame, HealpixPixel], Any]): A function that takes a pandas DataFrame and
                 the HealpixPixel the partition is from and returns a value
             order (int | None): The HEALPix order to compute the skymap at. If None (default),
                 will compute for each partition in the catalog at their own orders. If a value
@@ -360,7 +362,7 @@ class HealpixDataset(Dataset):
 
     def skymap(
         self,
-        func: Callable[[pd.DataFrame, HealpixPixel], Any],
+        func: Callable[[npd.NestedFrame, HealpixPixel], Any],
         order: int | None = None,
         default_value: Any = hp.pixelfunc.UNSEEN,
         projection="moll",
@@ -370,7 +372,7 @@ class HealpixDataset(Dataset):
         """Plot a skymap of an aggregate function applied over each partition
 
         Args:
-            func (Callable[[pd.DataFrame], HealpixPixel, Any]): A function that takes a pandas DataFrame and
+            func (Callable[[npd.NestedFrame, HealpixPixel], Any]): A function that takes a pandas DataFrame and
                 the HealpixPixel the partition is from and returns a value
             order (int | None): The HEALPix order to compute the skymap at. If None (default),
                 will compute for each partition in the catalog at their own orders. If a value

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-import nested_pandas as npd
-
 import warnings
 from typing import Any, Callable, Dict, Iterable, List, Tuple
 
 import dask
 import dask.dataframe as dd
-from nested_dask import NestedFrame
 import healpy as hp
 import hipscat as hc
+import nested_pandas as npd
 import numpy as np
 import pandas as pd
 from dask.delayed import Delayed, delayed
@@ -18,6 +16,7 @@ from hipscat.inspection import plot_pixel_list
 from hipscat.inspection.visualize_catalog import get_projection_method
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.healpix_pixel_function import get_pixel_argsort
+from nested_dask import NestedFrame
 from typing_extensions import Self
 
 from lsdb import io

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -7,6 +7,7 @@ import dask
 import dask.dataframe as dd
 import healpy as hp
 import hipscat as hc
+import nested_dask as nd
 import nested_pandas as npd
 import numpy as np
 import pandas as pd
@@ -16,7 +17,6 @@ from hipscat.inspection import plot_pixel_list
 from hipscat.inspection.visualize_catalog import get_projection_method
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.healpix_pixel_function import get_pixel_argsort
-import nested_dask as nd
 from typing_extensions import Self
 
 from lsdb import io

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -126,8 +126,8 @@ class HealpixDataset(Dataset):
             A catalog that contains the data from the original catalog that complies
             with the query expression
         """
-        ddf = self._ddf.query(expr)
-        return self.__class__(ddf, self._ddf_pixel_map, self.hc_structure)
+        ndf = self._ddf.query(expr)
+        return self.__class__(ndf, self._ddf_pixel_map, self.hc_structure)
 
     def _perform_search(
         self,

--- a/src/lsdb/catalog/margin_catalog.py
+++ b/src/lsdb/catalog/margin_catalog.py
@@ -1,5 +1,5 @@
 import hipscat as hc
-from nested_dask import NestedFrame
+import nested_dask as nd
 
 from lsdb.catalog.dataset.healpix_dataset import HealpixDataset
 from lsdb.core.search.abstract_search import AbstractSearch
@@ -19,7 +19,7 @@ class MarginCatalog(HealpixDataset):
 
     def __init__(
         self,
-        ddf: NestedFrame,
+        ddf: nd.NestedFrame,
         ddf_pixel_map: DaskDFPixelMap,
         hc_structure: hc.catalog.MarginCatalog,
     ):

--- a/src/lsdb/catalog/margin_catalog.py
+++ b/src/lsdb/catalog/margin_catalog.py
@@ -1,5 +1,5 @@
-import dask.dataframe as dd
 import hipscat as hc
+from nested_dask import NestedFrame
 
 from lsdb.catalog.dataset.healpix_dataset import HealpixDataset
 from lsdb.core.search.abstract_search import AbstractSearch
@@ -19,7 +19,7 @@ class MarginCatalog(HealpixDataset):
 
     def __init__(
         self,
-        ddf: dd.DataFrame,
+        ddf: NestedFrame,
         ddf_pixel_map: DaskDFPixelMap,
         hc_structure: hc.catalog.MarginCatalog,
     ):

--- a/src/lsdb/catalog/margin_catalog.py
+++ b/src/lsdb/catalog/margin_catalog.py
@@ -38,5 +38,5 @@ class MarginCatalog(HealpixDataset):
             A new Catalog containing the points filtered to those matching the search parameters.
         """
         filtered_hc_structure = search.filter_hc_catalog(self.hc_structure)
-        ddf_partition_map, search_ddf = self._perform_search(filtered_hc_structure, search)
-        return self.__class__(search_ddf, ddf_partition_map, filtered_hc_structure)
+        ddf_partition_map, search_ndf = self._perform_search(filtered_hc_structure, search)
+        return self.__class__(search_ndf, ddf_partition_map, filtered_hc_structure)

--- a/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
+++ b/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import nested_pandas as npd
-
 from abc import ABC
 from typing import TYPE_CHECKING, Tuple
 
+import nested_pandas as npd
 import numpy as np
 import numpy.typing as npt
 import pandas as pd

--- a/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
+++ b/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import nested_pandas as npd
+
 from abc import ABC
 from typing import TYPE_CHECKING, Tuple
 
@@ -34,8 +36,8 @@ class AbstractCrossmatchAlgorithm(ABC):
 
     The class will have been initialized with the following parameters, which the
     crossmatch function should use:
-        - left: pd.DataFrame,
-        - right: pd.DataFrame,
+        - left: npd.NestedFrame,
+        - right: npd.NestedFrame,
         - left_order: int,
         - left_pixel: int,
         - right_order: int,
@@ -56,8 +58,8 @@ class AbstractCrossmatchAlgorithm(ABC):
 
     def __init__(
         self,
-        left: pd.DataFrame,
-        right: pd.DataFrame,
+        left: npd.NestedFrame,
+        right: npd.NestedFrame,
         left_order: int,
         left_pixel: int,
         right_order: int,
@@ -97,7 +99,7 @@ class AbstractCrossmatchAlgorithm(ABC):
         self.right_margin_catalog_info = right_margin_catalog_info
         self.suffixes = suffixes
 
-    def crossmatch(self, **kwargs) -> pd.DataFrame:
+    def crossmatch(self, **kwargs) -> npd.NestedFrame:
         """Perform a crossmatch"""
         l_inds, r_inds, extra_cols = self.perform_crossmatch(**kwargs)
         if not len(l_inds) == len(r_inds) == len(extra_cols):
@@ -159,7 +161,7 @@ class AbstractCrossmatchAlgorithm(ABC):
         dataframe.rename(columns=columns_renamed, inplace=True)
 
     @classmethod
-    def _append_extra_columns(cls, dataframe: pd.DataFrame, extra_columns: pd.DataFrame | None = None):
+    def _append_extra_columns(cls, dataframe: npd.NestedFrame, extra_columns: pd.DataFrame | None = None):
         """Adds crossmatch extra columns to the resulting Dataframe."""
         if cls.extra_columns is None:
             return
@@ -187,7 +189,7 @@ class AbstractCrossmatchAlgorithm(ABC):
         left_idx: npt.NDArray[np.int64],
         right_idx: npt.NDArray[np.int64],
         extra_cols: pd.DataFrame,
-    ) -> pd.DataFrame:
+    ) -> npd.NestedFrame:
         """Creates a df containing the crossmatch result from matching indices and additional columns
 
         Args:
@@ -216,4 +218,4 @@ class AbstractCrossmatchAlgorithm(ABC):
         out.set_index(HIPSCAT_ID_COLUMN, inplace=True)
         extra_cols.index = out.index
         self._append_extra_columns(out, extra_cols)
-        return out
+        return npd.NestedFrame(out)

--- a/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
+++ b/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
@@ -137,10 +137,10 @@ class AbstractCrossmatchAlgorithm(ABC):
         This must accept any additional arguments the `crossmatch` method accepts.
         """
         # Check that we have the appropriate columns in our dataset.
-        if left._ddf.index.name != HIPSCAT_ID_COLUMN:
-            raise ValueError(f"index of left table must be {HIPSCAT_ID_COLUMN}")
-        if right._ddf.index.name != HIPSCAT_ID_COLUMN:
-            raise ValueError(f"index of right table must be {HIPSCAT_ID_COLUMN}")
+        # if left._ddf.index.name != HIPSCAT_ID_COLUMN:
+        #     raise ValueError(f"index of left table must be {HIPSCAT_ID_COLUMN}")
+        # if right._ddf.index.name != HIPSCAT_ID_COLUMN:
+        #     raise ValueError(f"index of right table must be {HIPSCAT_ID_COLUMN}")
         column_names = left._ddf.columns
         if left.hc_structure.catalog_info.ra_column not in column_names:
             raise ValueError(f"left table must have column {left.hc_structure.catalog_info.ra_column}")

--- a/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
+++ b/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
@@ -137,10 +137,10 @@ class AbstractCrossmatchAlgorithm(ABC):
         This must accept any additional arguments the `crossmatch` method accepts.
         """
         # Check that we have the appropriate columns in our dataset.
-        # if left._ddf.index.name != HIPSCAT_ID_COLUMN:
-        #     raise ValueError(f"index of left table must be {HIPSCAT_ID_COLUMN}")
-        # if right._ddf.index.name != HIPSCAT_ID_COLUMN:
-        #     raise ValueError(f"index of right table must be {HIPSCAT_ID_COLUMN}")
+        if left._ddf.index.name != HIPSCAT_ID_COLUMN:
+            raise ValueError(f"index of left table must be {HIPSCAT_ID_COLUMN}")
+        if right._ddf.index.name != HIPSCAT_ID_COLUMN:
+            raise ValueError(f"index of right table must be {HIPSCAT_ID_COLUMN}")
         column_names = left._ddf.columns
         if left.hc_structure.catalog_info.ra_column not in column_names:
             raise ValueError(f"left table must have column {left.hc_structure.catalog_info.ra_column}")

--- a/src/lsdb/core/plotting/skymap.py
+++ b/src/lsdb/core/plotting/skymap.py
@@ -5,7 +5,6 @@ from typing import Any, Callable, Dict
 import healpy as hp
 import nested_pandas as npd
 import numpy as np
-import pandas as pd
 from dask import delayed
 from hipscat.pixel_math import HealpixPixel, hipscat_id_to_healpix
 

--- a/src/lsdb/core/plotting/skymap.py
+++ b/src/lsdb/core/plotting/skymap.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import nested_pandas as npd
-
 from typing import Any, Callable, Dict
 
 import healpy as hp
+import nested_pandas as npd
 import numpy as np
 import pandas as pd
 from dask import delayed

--- a/src/lsdb/core/plotting/skymap.py
+++ b/src/lsdb/core/plotting/skymap.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import nested_pandas as npd
+
 from typing import Any, Callable, Dict
 
 import healpy as hp
@@ -11,8 +13,8 @@ from hipscat.pixel_math import HealpixPixel, hipscat_id_to_healpix
 
 @delayed
 def perform_inner_skymap(
-    partition: pd.DataFrame,
-    func: Callable[[pd.DataFrame, HealpixPixel], Any],
+    partition: npd.NestedFrame,
+    func: Callable[[npd.NestedFrame, HealpixPixel], Any],
     pixel: HealpixPixel,
     target_order: int,
     default_value: Any = 0,

--- a/src/lsdb/core/search/abstract_search.py
+++ b/src/lsdb/core/search/abstract_search.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import nested_pandas as npd
-
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
+import nested_pandas as npd
 import pandas as pd
 from hipscat.catalog.catalog_info import CatalogInfo
 from mocpy import MOC

--- a/src/lsdb/core/search/abstract_search.py
+++ b/src/lsdb/core/search/abstract_search.py
@@ -4,7 +4,6 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 import nested_pandas as npd
-import pandas as pd
 from hipscat.catalog.catalog_info import CatalogInfo
 from mocpy import MOC
 

--- a/src/lsdb/core/search/abstract_search.py
+++ b/src/lsdb/core/search/abstract_search.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import nested_pandas as npd
+
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
@@ -40,5 +42,5 @@ class AbstractSearch(ABC):
         )
 
     @abstractmethod
-    def search_points(self, frame: pd.DataFrame, metadata: CatalogInfo) -> pd.DataFrame:
+    def search_points(self, frame: npd.NestedFrame, metadata: CatalogInfo) -> npd.NestedFrame:
         """Determine the search results within a data frame"""

--- a/src/lsdb/core/search/box_search.py
+++ b/src/lsdb/core/search/box_search.py
@@ -4,7 +4,6 @@ from typing import Tuple
 
 import nested_pandas as npd
 import numpy as np
-import pandas as pd
 from hipscat.catalog.catalog_info import CatalogInfo
 from hipscat.pixel_math.box_filter import generate_box_moc, wrap_ra_angles
 from hipscat.pixel_math.validators import validate_box_search

--- a/src/lsdb/core/search/box_search.py
+++ b/src/lsdb/core/search/box_search.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import nested_pandas as npd
+
 from typing import Tuple
 
 import numpy as np
@@ -34,21 +36,21 @@ class BoxSearch(AbstractSearch):
     def generate_search_moc(self, max_order: int) -> MOC:
         return generate_box_moc(self.ra, self.dec, max_order)
 
-    def search_points(self, frame: pd.DataFrame, metadata: CatalogInfo) -> pd.DataFrame:
+    def search_points(self, frame: npd.NestedFrame, metadata: CatalogInfo) -> npd.NestedFrame:
         """Determine the search results within a data frame"""
         return box_filter(frame, self.ra, self.dec, metadata)
 
 
 def box_filter(
-    data_frame: pd.DataFrame,
+    data_frame: npd.NestedFrame,
     ra: Tuple[float, float] | None,
     dec: Tuple[float, float] | None,
     metadata: CatalogInfo,
-):
+) -> npd.NestedFrame:
     """Filters a dataframe to only include points within the specified box region.
 
     Args:
-        data_frame (pd.DataFrame): DataFrame containing points in the sky
+        data_frame (npd.NestedFrame): DataFrame containing points in the sky
         ra (Tuple[float, float]): Right ascension range, in degrees
         dec (Tuple[float, float]): Declination range, in degrees
         metadata (hc.catalog.Catalog): hipscat `Catalog` with catalog_info that matches `data_frame`

--- a/src/lsdb/core/search/box_search.py
+++ b/src/lsdb/core/search/box_search.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import nested_pandas as npd
-
 from typing import Tuple
 
+import nested_pandas as npd
 import numpy as np
 import pandas as pd
 from hipscat.catalog.catalog_info import CatalogInfo

--- a/src/lsdb/core/search/cone_search.py
+++ b/src/lsdb/core/search/cone_search.py
@@ -1,5 +1,4 @@
 import nested_pandas as npd
-import pandas as pd
 from astropy.coordinates import SkyCoord
 from hipscat.catalog.catalog_info import CatalogInfo
 from hipscat.pixel_math.cone_filter import generate_cone_moc

--- a/src/lsdb/core/search/cone_search.py
+++ b/src/lsdb/core/search/cone_search.py
@@ -1,3 +1,4 @@
+import nested_pandas as npd
 import pandas as pd
 from astropy.coordinates import SkyCoord
 from hipscat.catalog.catalog_info import CatalogInfo
@@ -26,16 +27,16 @@ class ConeSearch(AbstractSearch):
     def generate_search_moc(self, max_order: int) -> MOC:
         return generate_cone_moc(self.ra, self.dec, self.radius_arcsec, max_order)
 
-    def search_points(self, frame: pd.DataFrame, metadata: CatalogInfo) -> pd.DataFrame:
+    def search_points(self, frame: npd.NestedFrame, metadata: CatalogInfo) -> npd.NestedFrame:
         """Determine the search results within a data frame"""
         return cone_filter(frame, self.ra, self.dec, self.radius_arcsec, metadata)
 
 
-def cone_filter(data_frame: pd.DataFrame, ra, dec, radius_arcsec, metadata: CatalogInfo):
+def cone_filter(data_frame: npd.NestedFrame, ra, dec, radius_arcsec, metadata: CatalogInfo):
     """Filters a dataframe to only include points within the specified cone
 
     Args:
-        data_frame (pd.DataFrame): DataFrame containing points in the sky
+        data_frame (npd.NestedFrame): DataFrame containing points in the sky
         ra (float): Right Ascension of the center of the cone in degrees
         dec (float): Declination of the center of the cone in degrees
         radius_arcsec (float): Radius of the cone in arcseconds

--- a/src/lsdb/core/search/index_search.py
+++ b/src/lsdb/core/search/index_search.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import nested_pandas as npd
+
 from typing import TYPE_CHECKING
 
 import pandas as pd
@@ -29,6 +31,6 @@ class IndexSearch(AbstractSearch):
         healpix_pixels = self.catalog_index.loc_partitions(self.ids)
         return hc_structure.filter_from_pixel_list(healpix_pixels)
 
-    def search_points(self, frame: pd.DataFrame, _) -> pd.DataFrame:
+    def search_points(self, frame: npd.NestedFrame, _) -> npd.NestedFrame:
         """Determine the search results within a data frame"""
         return frame[frame[self.catalog_index.catalog_info.indexing_column].isin(self.ids)]

--- a/src/lsdb/core/search/index_search.py
+++ b/src/lsdb/core/search/index_search.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import nested_pandas as npd
-
 from typing import TYPE_CHECKING
 
+import nested_pandas as npd
 import pandas as pd
 from hipscat.catalog.index.index_catalog import IndexCatalog
 

--- a/src/lsdb/core/search/index_search.py
+++ b/src/lsdb/core/search/index_search.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import nested_pandas as npd
-import pandas as pd
 from hipscat.catalog.index.index_catalog import IndexCatalog
 
 from lsdb.core.search.abstract_search import AbstractSearch

--- a/src/lsdb/core/search/order_search.py
+++ b/src/lsdb/core/search/order_search.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pandas as pd
+import nested_pandas as npd
 
 from lsdb.core.search.abstract_search import AbstractSearch
 
@@ -32,6 +33,6 @@ class OrderSearch(AbstractSearch):
         pixels = [p for p in hc_structure.get_healpix_pixels() if self.min_order <= p.order <= max_order]
         return hc_structure.filter_from_pixel_list(pixels)
 
-    def search_points(self, frame: pd.DataFrame, _) -> pd.DataFrame:
+    def search_points(self, frame: npd.NestedFrame, _) -> npd.NestedFrame:
         """Determine the search results within a data frame."""
         return frame

--- a/src/lsdb/core/search/order_search.py
+++ b/src/lsdb/core/search/order_search.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import nested_pandas as npd
-import pandas as pd
 
 from lsdb.core.search.abstract_search import AbstractSearch
 

--- a/src/lsdb/core/search/order_search.py
+++ b/src/lsdb/core/search/order_search.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pandas as pd
 import nested_pandas as npd
+import pandas as pd
 
 from lsdb.core.search.abstract_search import AbstractSearch
 

--- a/src/lsdb/core/search/pixel_search.py
+++ b/src/lsdb/core/search/pixel_search.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, List, Tuple
 
 import nested_pandas as npd
-import pandas as pd
 from hipscat.pixel_math import HealpixPixel
 
 from lsdb.core.search.abstract_search import AbstractSearch

--- a/src/lsdb/core/search/pixel_search.py
+++ b/src/lsdb/core/search/pixel_search.py
@@ -1,3 +1,4 @@
+import nested_pandas as npd
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Tuple
@@ -25,5 +26,5 @@ class PixelSearch(AbstractSearch):
     def filter_hc_catalog(self, hc_structure: HCCatalogTypeVar) -> HCCatalogTypeVar:
         return hc_structure.filter_from_pixel_list(self.pixels)
 
-    def search_points(self, frame: pd.DataFrame, _) -> pd.DataFrame:
+    def search_points(self, frame: npd.NestedFrame, _) -> npd.NestedFrame:
         return frame

--- a/src/lsdb/core/search/pixel_search.py
+++ b/src/lsdb/core/search/pixel_search.py
@@ -1,8 +1,8 @@
-import nested_pandas as npd
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Tuple
 
+import nested_pandas as npd
 import pandas as pd
 from hipscat.pixel_math import HealpixPixel
 

--- a/src/lsdb/core/search/polygon_search.py
+++ b/src/lsdb/core/search/polygon_search.py
@@ -1,3 +1,4 @@
+import nested_pandas as npd
 from typing import List, Tuple
 
 import healpy as hp
@@ -34,7 +35,7 @@ class PolygonSearch(AbstractSearch):
         return polygon_filter(frame, self.polygon, metadata)
 
 
-def polygon_filter(data_frame: pd.DataFrame, polygon: ConvexPolygon, metadata: CatalogInfo):
+def polygon_filter(data_frame: npd.NestedFrame, polygon: ConvexPolygon, metadata: CatalogInfo):
     """Filters a dataframe to only include points within the specified polygon.
 
     Args:

--- a/src/lsdb/core/search/polygon_search.py
+++ b/src/lsdb/core/search/polygon_search.py
@@ -30,16 +30,18 @@ class PolygonSearch(AbstractSearch):
     def generate_search_moc(self, max_order: int) -> MOC:
         return generate_polygon_moc(self.vertices_xyz, max_order)
 
-    def search_points(self, frame: pd.DataFrame, metadata: CatalogInfo) -> pd.DataFrame:
+    def search_points(self, frame: npd.NestedFrame, metadata: CatalogInfo) -> npd.NestedFrame:
         """Determine the search results within a data frame"""
         return polygon_filter(frame, self.polygon, metadata)
 
 
-def polygon_filter(data_frame: npd.NestedFrame, polygon: ConvexPolygon, metadata: CatalogInfo):
+def polygon_filter(
+    data_frame: npd.NestedFrame, polygon: ConvexPolygon, metadata: CatalogInfo
+) -> npd.NestedFrame:
     """Filters a dataframe to only include points within the specified polygon.
 
     Args:
-        data_frame (pd.DataFrame): DataFrame containing points in the sky
+        data_frame (npd.NestedFrame): DataFrame containing points in the sky
         polygon (ConvexPolygon): Convex spherical polygon of interest, used to filter points
         metadata (hc.catalog.Catalog): hipscat `Catalog` with catalog_info that matches `dataframe`
 

--- a/src/lsdb/core/search/polygon_search.py
+++ b/src/lsdb/core/search/polygon_search.py
@@ -3,7 +3,6 @@ from typing import List, Tuple
 import healpy as hp
 import nested_pandas as npd
 import numpy as np
-import pandas as pd
 from hipscat.catalog.catalog_info import CatalogInfo
 from hipscat.pixel_math.polygon_filter import CartesianCoordinates, SphericalCoordinates, generate_polygon_moc
 from hipscat.pixel_math.validators import validate_declination_values, validate_polygon

--- a/src/lsdb/core/search/polygon_search.py
+++ b/src/lsdb/core/search/polygon_search.py
@@ -1,7 +1,7 @@
-import nested_pandas as npd
 from typing import List, Tuple
 
 import healpy as hp
+import nested_pandas as npd
 import numpy as np
 import pandas as pd
 from hipscat.catalog.catalog_info import CatalogInfo

--- a/src/lsdb/dask/crossmatch_catalog_data.py
+++ b/src/lsdb/dask/crossmatch_catalog_data.py
@@ -4,8 +4,8 @@ import warnings
 from typing import TYPE_CHECKING, Tuple, Type
 
 import dask
-from hipscat.pixel_tree import PixelAlignment
 import nested_dask as nd
+from hipscat.pixel_tree import PixelAlignment
 
 from lsdb.core.crossmatch.abstract_crossmatch_algorithm import AbstractCrossmatchAlgorithm
 from lsdb.core.crossmatch.crossmatch_algorithms import (

--- a/src/lsdb/dask/crossmatch_catalog_data.py
+++ b/src/lsdb/dask/crossmatch_catalog_data.py
@@ -4,7 +4,6 @@ import warnings
 from typing import TYPE_CHECKING, Tuple, Type
 
 import dask
-import dask.dataframe as dd
 from hipscat.pixel_tree import PixelAlignment
 from nested_dask import NestedFrame
 

--- a/src/lsdb/dask/crossmatch_catalog_data.py
+++ b/src/lsdb/dask/crossmatch_catalog_data.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Tuple, Type
 import dask
 import dask.dataframe as dd
 from hipscat.pixel_tree import PixelAlignment
+from nested_dask import NestedFrame
 
 from lsdb.core.crossmatch.abstract_crossmatch_algorithm import AbstractCrossmatchAlgorithm
 from lsdb.core.crossmatch.crossmatch_algorithms import (
@@ -81,7 +82,7 @@ def crossmatch_catalog_data(
         Type[AbstractCrossmatchAlgorithm] | BuiltInCrossmatchAlgorithm
     ) = BuiltInCrossmatchAlgorithm.KD_TREE,
     **kwargs,
-) -> Tuple[dd.DataFrame, DaskDFPixelMap, PixelAlignment]:
+) -> Tuple[NestedFrame, DaskDFPixelMap, PixelAlignment]:
     """Cross-matches the data from two catalogs
 
     Args:

--- a/src/lsdb/dask/crossmatch_catalog_data.py
+++ b/src/lsdb/dask/crossmatch_catalog_data.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Tuple, Type
 
 import dask
 from hipscat.pixel_tree import PixelAlignment
-from nested_dask import NestedFrame
+import nested_dask as nd
 
 from lsdb.core.crossmatch.abstract_crossmatch_algorithm import AbstractCrossmatchAlgorithm
 from lsdb.core.crossmatch.crossmatch_algorithms import (
@@ -81,7 +81,7 @@ def crossmatch_catalog_data(
         Type[AbstractCrossmatchAlgorithm] | BuiltInCrossmatchAlgorithm
     ) = BuiltInCrossmatchAlgorithm.KD_TREE,
     **kwargs,
-) -> Tuple[NestedFrame, DaskDFPixelMap, PixelAlignment]:
+) -> Tuple[nd.NestedFrame, DaskDFPixelMap, PixelAlignment]:
     """Cross-matches the data from two catalogs
 
     Args:

--- a/src/lsdb/dask/join_catalog_data.py
+++ b/src/lsdb/dask/join_catalog_data.py
@@ -13,7 +13,7 @@ from hipscat.catalog.margin_cache import MarginCacheCatalogInfo
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
 from hipscat.pixel_tree import PixelAlignment
-from nested_dask import NestedFrame
+import nested_dask as nd
 from nested_pandas.series.packer import pack_flat
 
 from lsdb.catalog.association_catalog import AssociationCatalog
@@ -230,7 +230,7 @@ def perform_join_through(
 
 def join_catalog_data_on(
     left: Catalog, right: Catalog, left_on: str, right_on: str, suffixes: Tuple[str, str]
-) -> Tuple[NestedFrame, DaskDFPixelMap, PixelAlignment]:
+) -> Tuple[nd.NestedFrame, DaskDFPixelMap, PixelAlignment]:
     """Joins two catalogs spatially on a specified column
 
     Args:
@@ -275,7 +275,7 @@ def join_catalog_data_nested(
     left_on: str,
     right_on: str,
     nested_column_name: str | None = None,
-) -> Tuple[NestedFrame, DaskDFPixelMap, PixelAlignment]:
+) -> Tuple[nd.NestedFrame, DaskDFPixelMap, PixelAlignment]:
     """Joins two catalogs spatially on a specified column, adding the right as a nested column with nested
     dask
 
@@ -321,7 +321,7 @@ def join_catalog_data_nested(
 
 def join_catalog_data_through(
     left: Catalog, right: Catalog, association: AssociationCatalog, suffixes: Tuple[str, str]
-) -> Tuple[NestedFrame, DaskDFPixelMap, PixelAlignment]:
+) -> Tuple[nd.NestedFrame, DaskDFPixelMap, PixelAlignment]:
     """Joins two catalogs with an association table
 
     Args:

--- a/src/lsdb/dask/join_catalog_data.py
+++ b/src/lsdb/dask/join_catalog_data.py
@@ -6,8 +6,6 @@ import warnings
 from typing import TYPE_CHECKING, List, Tuple
 
 import dask
-import dask.dataframe as dd
-import pandas as pd
 from hipscat.catalog.association_catalog import AssociationCatalogInfo
 from hipscat.catalog.catalog_info import CatalogInfo
 from hipscat.catalog.margin_cache import MarginCacheCatalogInfo
@@ -38,12 +36,12 @@ if TYPE_CHECKING:
 NON_JOINING_ASSOCIATION_COLUMNS = ["Norder", "Dir", "Npix", "join_Norder", "join_Dir", "join_Npix"]
 
 
-def rename_columns_with_suffixes(left: pd.DataFrame, right: pd.DataFrame, suffixes: Tuple[str, str]):
+def rename_columns_with_suffixes(left: npd.NestedFrame, right: npd.NestedFrame, suffixes: Tuple[str, str]):
     """Renames two dataframes with the suffixes specified
 
     Args:
-        left (pd.DataFrame): the left dataframe to apply the first suffix to
-        right (pd.DataFrame): the right dataframe to apply the second suffix to
+        left (npd.NestedFrame): the left dataframe to apply the first suffix to
+        right (npd.NestedFrame): the right dataframe to apply the second suffix to
         suffixes (Tuple[str, str]): the pair of suffixes to apply to the dataframes
 
     Returns:
@@ -59,9 +57,9 @@ def rename_columns_with_suffixes(left: pd.DataFrame, right: pd.DataFrame, suffix
 # pylint: disable=too-many-arguments, unused-argument
 @dask.delayed
 def perform_join_on(
-    left: pd.DataFrame,
-    right: pd.DataFrame,
-    right_margin: pd.DataFrame,
+    left: npd.NestedFrame,
+    right: npd.NestedFrame,
+    right_margin: npd.NestedFrame,
     left_pixel: HealpixPixel,
     right_pixel: HealpixPixel,
     right_margin_pixel: HealpixPixel,
@@ -76,9 +74,9 @@ def perform_join_on(
     """Performs a join on two catalog partitions
 
     Args:
-        left (pd.DataFrame): the left partition to merge
-        right (pd.DataFrame): the right partition to merge
-        right_margin (pd.DataFrame): the right margin partition to merge
+        left (npd.NestedFrame): the left partition to merge
+        right (npd.NestedFrame): the right partition to merge
+        right_margin (npd.NestedFrame): the right margin partition to merge
         left_pixel (HealpixPixel): the HEALPix pixel of the left partition
         right_pixel (HealpixPixel): the HEALPix pixel of the right partition
         right_margin_pixel (HealpixPixel): the HEALPix pixel of the right margin partition
@@ -109,9 +107,9 @@ def perform_join_on(
 # pylint: disable=too-many-arguments, unused-argument
 @dask.delayed
 def perform_join_nested(
-    left: pd.DataFrame,
-    right: pd.DataFrame,
-    right_margin: pd.DataFrame,
+    left: npd.NestedFrame,
+    right: npd.NestedFrame,
+    right_margin: npd.NestedFrame,
     left_pixel: HealpixPixel,
     right_pixel: HealpixPixel,
     right_margin_pixel: HealpixPixel,
@@ -127,9 +125,9 @@ def perform_join_nested(
     """Performs a join on two catalog partitions
 
     Args:
-        left (pd.DataFrame): the left partition to merge
-        right (pd.DataFrame): the right partition to merge
-        right_margin (pd.DataFrame): the right margin partition to merge
+        left (npd.NestedFrame): the left partition to merge
+        right (npd.NestedFrame): the right partition to merge
+        right_margin (npd.NestedFrame): the right margin partition to merge
         left_pixel (HealpixPixel): the HEALPix pixel of the left partition
         right_pixel (HealpixPixel): the HEALPix pixel of the right partition
         right_margin_pixel (HealpixPixel): the HEALPix pixel of the right margin partition
@@ -161,10 +159,10 @@ def perform_join_nested(
 # pylint: disable=too-many-arguments, unused-argument
 @dask.delayed
 def perform_join_through(
-    left: pd.DataFrame,
-    right: pd.DataFrame,
-    right_margin: pd.DataFrame,
-    through: pd.DataFrame,
+    left: npd.NestedFrame,
+    right: npd.NestedFrame,
+    right_margin: npd.NestedFrame,
+    through: npd.NestedFrame,
     left_pixel: HealpixPixel,
     right_pixel: HealpixPixel,
     right_margin_pixel: HealpixPixel,
@@ -179,10 +177,10 @@ def perform_join_through(
     """Performs a join on two catalog partitions through an association catalog
 
     Args:
-        left (pd.DataFrame): the left partition to merge
-        right (pd.DataFrame): the right partition to merge
-        right_margin (pd.DataFrame): the right margin partition to merge
-        through (pd.DataFrame): the association column partition to merge with
+        left (npd.NestedFrame): the left partition to merge
+        right (npd.NestedFrame): the right partition to merge
+        right_margin (npd.NestedFrame): the right margin partition to merge
+        through (npd.NestedFrame): the association column partition to merge with
         left_pixel (HealpixPixel): the HEALPix pixel of the left partition
         right_pixel (HealpixPixel): the HEALPix pixel of the right partition
         right_margin_pixel (HealpixPixel): the HEALPix pixel of the right margin partition

--- a/src/lsdb/dask/join_catalog_data.py
+++ b/src/lsdb/dask/join_catalog_data.py
@@ -276,14 +276,16 @@ def join_catalog_data_nested(
     right_on: str,
     nested_column_name: str | None = None,
 ) -> Tuple[NestedFrame, DaskDFPixelMap, PixelAlignment]:
-    """Joins two catalogs spatially on a specified column
+    """Joins two catalogs spatially on a specified column, adding the right as a nested column with nested
+    dask
 
     Args:
         left (lsdb.Catalog): the left catalog to join
         right (lsdb.Catalog): the right catalog to join
         left_on (str): the column to join on from the left partition
         right_on (str): the column to join on from the right partition
-        suffixes (Tuple[str,str]): the suffixes to apply to each partition's column names
+        nested_column_name (str): the name of the nested column in the final output, if None, defaults to
+            name of the right catalog
 
     Returns:
         A tuple of the dask dataframe with the result of the join, the pixel map from HEALPix

--- a/src/lsdb/dask/join_catalog_data.py
+++ b/src/lsdb/dask/join_catalog_data.py
@@ -6,6 +6,7 @@ import warnings
 from typing import TYPE_CHECKING, List, Tuple
 
 import dask
+import nested_pandas as npd
 from hipscat.catalog.association_catalog import AssociationCatalogInfo
 from hipscat.catalog.catalog_info import CatalogInfo
 from hipscat.catalog.margin_cache import MarginCacheCatalogInfo
@@ -14,7 +15,6 @@ from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
 from hipscat.pixel_tree import PixelAlignment
 from nested_dask import NestedFrame
 from nested_pandas.series.packer import pack_flat
-import nested_pandas as npd
 
 from lsdb.catalog.association_catalog import AssociationCatalog
 from lsdb.dask.merge_catalog_functions import (
@@ -24,8 +24,8 @@ from lsdb.dask.merge_catalog_functions import (
     construct_catalog_args,
     filter_by_hipscat_index_to_pixel,
     generate_meta_df_for_joined_tables,
-    get_healpix_pixels_from_alignment,
     generate_meta_df_for_nested_tables,
+    get_healpix_pixels_from_alignment,
 )
 from lsdb.types import DaskDFPixelMap
 

--- a/src/lsdb/dask/join_catalog_data.py
+++ b/src/lsdb/dask/join_catalog_data.py
@@ -6,6 +6,7 @@ import warnings
 from typing import TYPE_CHECKING, List, Tuple
 
 import dask
+import nested_dask as nd
 import nested_pandas as npd
 from hipscat.catalog.association_catalog import AssociationCatalogInfo
 from hipscat.catalog.catalog_info import CatalogInfo
@@ -13,7 +14,6 @@ from hipscat.catalog.margin_cache import MarginCacheCatalogInfo
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
 from hipscat.pixel_tree import PixelAlignment
-import nested_dask as nd
 from nested_pandas.series.packer import pack_flat
 
 from lsdb.catalog.association_catalog import AssociationCatalog

--- a/src/lsdb/dask/join_catalog_data.py
+++ b/src/lsdb/dask/join_catalog_data.py
@@ -14,6 +14,7 @@ from hipscat.catalog.margin_cache import MarginCacheCatalogInfo
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
 from hipscat.pixel_tree import PixelAlignment
+from nested_dask import NestedFrame
 
 from lsdb.catalog.association_catalog import AssociationCatalog
 from lsdb.dask.merge_catalog_functions import (
@@ -177,7 +178,7 @@ def perform_join_through(
 
 def join_catalog_data_on(
     left: Catalog, right: Catalog, left_on: str, right_on: str, suffixes: Tuple[str, str]
-) -> Tuple[dd.DataFrame, DaskDFPixelMap, PixelAlignment]:
+) -> Tuple[NestedFrame, DaskDFPixelMap, PixelAlignment]:
     """Joins two catalogs spatially on a specified column
 
     Args:
@@ -218,7 +219,7 @@ def join_catalog_data_on(
 
 def join_catalog_data_through(
     left: Catalog, right: Catalog, association: AssociationCatalog, suffixes: Tuple[str, str]
-) -> Tuple[dd.DataFrame, DaskDFPixelMap, PixelAlignment]:
+) -> Tuple[NestedFrame, DaskDFPixelMap, PixelAlignment]:
     """Joins two catalogs with an association table
 
     Args:

--- a/src/lsdb/dask/join_catalog_data.py
+++ b/src/lsdb/dask/join_catalog_data.py
@@ -121,7 +121,8 @@ def perform_join_nested(
     right_columns: List[str],
     right_name: str,
 ):
-    """Performs a join on two catalog partitions
+    """Performs a join on two catalog partitions by adding the right catalog a nested column using
+    nested-pandas
 
     Args:
         left (npd.NestedFrame): the left partition to merge
@@ -136,6 +137,7 @@ def perform_join_nested(
         left_on (str): the column to join on from the left partition
         right_on (str): the column to join on from the right partition
         right_columns (List[str]): the columns to include from the right margin partition
+        right_name (str): the name of the nested column in the resulting df to join the right catalog into
 
     Returns:
         A dataframe with the result of merging the left and right partitions on the specified columns
@@ -181,10 +183,11 @@ def perform_join_through(
         right_pixel (HealpixPixel): the HEALPix pixel of the right partition
         right_margin_pixel (HealpixPixel): the HEALPix pixel of the right margin partition
         through_pixel (HealpixPixel): the HEALPix pixel of the association partition
-        left_catalog (hc.Catalog): the hipscat structure of the left catalog
-        right_catalog (hc.Catalog): the hipscat structure of the right catalog
-        right_margin_catalog (hc.Catalog): the hipscat structure of the right margin catalog
-        assoc_catalog (hc.AssociationCatalog): the hipscat structure of the association catalog
+        left_catalog_info (hc.CatalogInfo): the hipscat structure of the left catalog
+        right_catalog_info (hc.CatalogInfo): the hipscat structure of the right catalog
+        right_margin_catalog_info (hc.MarginCacheCatalogInfo): the hipscat structure of the right margin
+            catalog
+        assoc_catalog_info (hc.AssociationCatalogInfo): the hipscat structure of the association catalog
         suffixes (Tuple[str,str]): the suffixes to apply to each partition's column names
         right_columns (List[str]): the columns to include from the right margin partition
 

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -14,7 +14,7 @@ from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN, healpix_to_hipscat_
 from hipscat.pixel_tree import PixelAlignment, PixelAlignmentType, align_trees
 from hipscat.pixel_tree.moc_utils import copy_moc
 from hipscat.pixel_tree.pixel_alignment import align_with_mocs
-from nested_dask import NestedFrame
+import nested_dask as nd
 
 from lsdb.dask.divisions import get_pixels_divisions
 from lsdb.types import DaskDFPixelMap
@@ -178,7 +178,7 @@ def filter_by_hipscat_index_to_pixel(dataframe: npd.NestedFrame, order: int, pix
 
 def construct_catalog_args(
     partitions: List[Delayed], meta_df: npd.NestedFrame, alignment: PixelAlignment
-) -> Tuple[NestedFrame, DaskDFPixelMap, PixelAlignment]:
+) -> Tuple[nd.NestedFrame, DaskDFPixelMap, PixelAlignment]:
     """Constructs the arguments needed to create a catalog from a list of delayed partitions
 
     Args:
@@ -195,7 +195,7 @@ def construct_catalog_args(
     # create dask df from delayed partitions
     divisions = get_pixels_divisions(list(partition_map.keys()))
     partitions = partitions if len(partitions) > 0 else [delayed(meta_df.copy())]
-    ddf = NestedFrame.from_delayed(partitions, meta=meta_df, divisions=divisions, verify_meta=True)
+    ddf = nd.NestedFrame.from_delayed(partitions, meta=meta_df, divisions=divisions, verify_meta=True)
     return ddf, partition_map, alignment
 
 

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -262,26 +262,30 @@ def generate_meta_df_for_joined_tables(
 def generate_meta_df_for_nested_tables(
     catalogs: Sequence[Catalog],
     nested_catalog: Catalog,
-    nested_name: str,
+    nested_column_name: str,
     join_column_name: str,
     extra_columns: pd.DataFrame | None = None,
     index_name: str = HIPSCAT_ID_COLUMN,
     index_type: npt.DTypeLike = np.uint64,
 ) -> npd.NestedFrame:
-    """Generates a Dask meta DataFrame that would result from joining two catalogs
+    """Generates a Dask meta DataFrame that would result from joining two catalogs, adding the right as a
+    nested frame
 
-    Creates an empty dataframe with the columns of each catalog appended with a suffix. Allows specifying
-    extra columns that should also be added, and the name of the index of the resulting dataframe.
+    Creates an empty dataframe with the columns of the left catalog, and a nested column with the right
+    catalog. Allows specifying extra columns that should also be added, and the name of the index of the
+    resulting dataframe.
 
     Args:
         catalogs (Sequence[lsdb.Catalog]): The catalogs to merge together
-        suffixes (Sequence[Str]): The column suffixes to apply each catalog
+        nested_catalog (Catalog): The catalog to add as a nested column
+        nested_column_name (str): The name of the nested column
+        join_column_name (str): The name of the column in the right catalog to join on
         extra_columns (pd.Dataframe): Any additional columns to the merged catalogs
         index_name (str): The name of the index in the resulting DataFrame
         index_type (npt.DTypeLike): The type of the index in the resulting DataFrame
 
     Returns:
-        An empty dataframe with the columns of each catalog with their respective suffix, and any extra
+        An empty dataframe with the right catalog joined to the left as a nested column, and any extra
         columns specified, with the index name set.
     """
     meta = {}
@@ -301,7 +305,7 @@ def generate_meta_df_for_nested_tables(
     nested_catalog_meta = nested_catalog._ddf._meta.copy().iloc[:0].drop(join_column_name, axis=1)
 
     # Use nested-pandas to make the resulting meta with the nested catalog meta as a nested column
-    return npd.NestedFrame(meta_df).add_nested(nested_catalog_meta, nested_name)
+    return npd.NestedFrame(meta_df).add_nested(nested_catalog_meta, nested_column_name)
 
 
 def get_partition_map_from_alignment_pixels(join_pixels: pd.DataFrame) -> DaskDFPixelMap:

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -294,8 +294,13 @@ def generate_meta_df_for_nested_tables(
         meta.update(extra_columns)
     index = pd.Index(pd.Series(dtype=index_type), name=index_name)
     meta_df = pd.DataFrame(meta, index)
+
+    # make an empty copy of the nested catalog, removing the column that will be joined on (and removed from
+    # the eventual dataframe)
     # pylint: disable=protected-access
     nested_catalog_meta = nested_catalog._ddf._meta.copy().iloc[:0].drop(join_column_name, axis=1)
+
+    # Use nested-pandas to make the resulting meta with the nested catalog meta as a nested column
     return npd.NestedFrame(meta_df).add_nested(nested_catalog_meta, nested_name)
 
 

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, List, Sequence, Tuple, cast
+from typing import TYPE_CHECKING, Callable, List, Sequence, Tuple
 
-import dask.dataframe as dd
 import healpy as hp
 import nested_pandas as npd
 import numpy as np
@@ -295,6 +294,7 @@ def generate_meta_df_for_nested_tables(
         meta.update(extra_columns)
     index = pd.Index(pd.Series(dtype=index_type), name=index_name)
     meta_df = pd.DataFrame(meta, index)
+    # pylint: disable=protected-access
     nested_catalog_meta = nested_catalog._ddf._meta.copy().iloc[:0].drop(join_column_name, axis=1)
     return npd.NestedFrame(meta_df).add_nested(nested_catalog_meta, nested_name)
 

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Callable, List, Sequence, Tuple
 
 import healpy as hp
+import nested_dask as nd
 import nested_pandas as npd
 import numpy as np
 import numpy.typing as npt
@@ -14,7 +15,6 @@ from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN, healpix_to_hipscat_
 from hipscat.pixel_tree import PixelAlignment, PixelAlignmentType, align_trees
 from hipscat.pixel_tree.moc_utils import copy_moc
 from hipscat.pixel_tree.pixel_alignment import align_with_mocs
-import nested_dask as nd
 
 from lsdb.dask.divisions import get_pixels_divisions
 from lsdb.types import DaskDFPixelMap

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -263,7 +263,6 @@ def generate_meta_df_for_joined_tables(
 
 def generate_meta_df_for_nested_tables(
     catalogs: Sequence[Catalog],
-    suffixes: Sequence[str],
     nested_catalog: Catalog,
     nested_name: str,
     join_column_name: str,
@@ -289,9 +288,9 @@ def generate_meta_df_for_nested_tables(
     """
     meta = {}
     # Construct meta for crossmatched catalog columns
-    for table, suffix in zip(catalogs, suffixes):
+    for table in catalogs:
         for name, col_type in table.dtypes.items():
-            meta[name + suffix] = pd.Series(dtype=col_type)
+            meta[name] = pd.Series(dtype=col_type)
     # Construct meta for crossmatch result columns
     if extra_columns is not None:
         meta.update(extra_columns)

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Callable, List, Sequence, Tuple, cast
 
 import dask.dataframe as dd
 import healpy as hp
+import nested_pandas as npd
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
@@ -15,7 +16,6 @@ from hipscat.pixel_tree import PixelAlignment, PixelAlignmentType, align_trees
 from hipscat.pixel_tree.moc_utils import copy_moc
 from hipscat.pixel_tree.pixel_alignment import align_with_mocs
 from nested_dask import NestedFrame
-import nested_pandas as npd
 
 from lsdb.dask.divisions import get_pixels_divisions
 from lsdb.types import DaskDFPixelMap

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -196,8 +196,7 @@ def construct_catalog_args(
     # create dask df from delayed partitions
     divisions = get_pixels_divisions(list(partition_map.keys()))
     partitions = partitions if len(partitions) > 0 else [delayed(meta_df.copy())]
-    ddf = dd.from_delayed(partitions, meta=meta_df, divisions=divisions, verify_meta=True)
-    ddf = NestedFrame.from_dask_dataframe(ddf)
+    ddf = NestedFrame.from_delayed(partitions, meta=meta_df, divisions=divisions, verify_meta=True)
     return ddf, partition_map, alignment
 
 

--- a/src/lsdb/io/to_hipscat.py
+++ b/src/lsdb/io/to_hipscat.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, Union
 
 import dask
 import hipscat as hc
-import pandas as pd
+import nested_pandas as npd
 from hipscat.catalog.healpix_dataset.healpix_dataset import HealpixDataset as HCHealpixDataset
 from hipscat.io import FilePointer
 from hipscat.pixel_math import HealpixPixel
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 @dask.delayed
 def perform_write(
-    df: pd.DataFrame,
+    df: npd.NestedFrame,
     hp_pixel: HealpixPixel,
     base_catalog_dir: FilePointer,
     storage_options: dict | None = None,
@@ -31,7 +31,7 @@ def perform_write(
     To be used as a dask delayed method as part of a dask task graph.
 
     Args:
-        df (pd.DataFrame): dataframe to write to file
+        df (npd.NestedFrame): dataframe to write to file
         hp_pixel (HealpixPixel): HEALPix pixel of file to be written
         base_catalog_dir (FilePointer): Location of the base catalog directory to write to
         storage_options (dict): fsspec storage options

--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Tuple
 
 import astropy.units as u
 import hipscat as hc
+import nested_dask as nd
 import nested_pandas as npd
 import numpy as np
 import pandas as pd
@@ -17,7 +18,6 @@ from hipscat.pixel_math import HealpixPixel, generate_histogram
 from hipscat.pixel_math.healpix_pixel_function import get_pixel_argsort
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN, compute_hipscat_id, healpix_to_hipscat_id
 from mocpy import MOC
-import nested_dask as nd
 
 from lsdb.catalog.catalog import Catalog
 from lsdb.io.schema import get_arrow_schema

--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -1,3 +1,4 @@
+import nested_pandas as npd
 from __future__ import annotations
 
 import dataclasses
@@ -68,7 +69,7 @@ class DataframeCatalogLoader:
                 automatically inferred from the provided DataFrame using `pa.Schema.from_pandas`.
             **kwargs: Arguments to pass to the creation of the catalog info.
         """
-        self.dataframe = dataframe
+        self.dataframe = npd.NestedFrame(dataframe)
         self.lowest_order = lowest_order
         self.highest_order = highest_order
         self.drop_empty_siblings = drop_empty_siblings
@@ -190,7 +191,7 @@ class DataframeCatalogLoader:
             to the respective Pandas Dataframes and the total number of rows.
         """
         # Dataframes for each destination HEALPix pixel
-        pixel_dfs: List[pd.DataFrame] = []
+        pixel_dfs: List[npd.NestedFrame] = []
 
         # Mapping HEALPix pixels to the respective Dataframe indices
         ddf_pixel_map: Dict[HealpixPixel, int] = {}

--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -17,6 +17,7 @@ from hipscat.pixel_math import HealpixPixel, generate_histogram
 from hipscat.pixel_math.healpix_pixel_function import get_pixel_argsort
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN, compute_hipscat_id, healpix_to_hipscat_id
 from mocpy import MOC
+from nested_dask import NestedFrame
 
 from lsdb.catalog.catalog import Catalog
 from lsdb.io.schema import get_arrow_schema
@@ -177,7 +178,7 @@ class DataframeCatalogLoader:
 
     def _generate_dask_df_and_map(
         self, pixel_list: List[HealpixPixel]
-    ) -> Tuple[dd.DataFrame, DaskDFPixelMap, int]:
+    ) -> Tuple[NestedFrame, DaskDFPixelMap, int]:
         """Load Dask DataFrame from HEALPix pixel Dataframes and
         generate a mapping of HEALPix pixels to HEALPix Dataframes
 

--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -6,7 +6,6 @@ import warnings
 from typing import Dict, List, Tuple
 
 import astropy.units as u
-import dask.dataframe as dd
 import hipscat as hc
 import nested_pandas as npd
 import numpy as np

--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -1,4 +1,3 @@
-import nested_pandas as npd
 from __future__ import annotations
 
 import dataclasses
@@ -9,6 +8,7 @@ from typing import Dict, List, Tuple
 import astropy.units as u
 import dask.dataframe as dd
 import hipscat as hc
+import nested_pandas as npd
 import numpy as np
 import pandas as pd
 import pyarrow as pa

--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -17,7 +17,7 @@ from hipscat.pixel_math import HealpixPixel, generate_histogram
 from hipscat.pixel_math.healpix_pixel_function import get_pixel_argsort
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN, compute_hipscat_id, healpix_to_hipscat_id
 from mocpy import MOC
-from nested_dask import NestedFrame
+import nested_dask as nd
 
 from lsdb.catalog.catalog import Catalog
 from lsdb.io.schema import get_arrow_schema
@@ -178,7 +178,7 @@ class DataframeCatalogLoader:
 
     def _generate_dask_df_and_map(
         self, pixel_list: List[HealpixPixel]
-    ) -> Tuple[NestedFrame, DaskDFPixelMap, int]:
+    ) -> Tuple[nd.NestedFrame, DaskDFPixelMap, int]:
         """Load Dask DataFrame from HEALPix pixel Dataframes and
         generate a mapping of HEALPix pixels to HEALPix Dataframes
 

--- a/src/lsdb/loaders/dataframe/from_dataframe_utils.py
+++ b/src/lsdb/loaders/dataframe/from_dataframe_utils.py
@@ -8,14 +8,13 @@ from dask import delayed
 from hipscat.catalog import PartitionInfo
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
-from nested_dask import NestedFrame
-
+import nested_dask as nd
 from lsdb.dask.divisions import get_pixels_divisions
 
 
 def _generate_dask_dataframe(
     pixel_dfs: List[npd.NestedFrame], pixels: List[HealpixPixel], use_pyarrow_types: bool = True
-) -> Tuple[NestedFrame, int]:
+) -> Tuple[nd.NestedFrame, int]:
     """Create the Dask Dataframe from the list of HEALPix pixel Dataframes
 
     Args:
@@ -30,7 +29,7 @@ def _generate_dask_dataframe(
     schema = pixel_dfs[0].iloc[:0, :].copy() if len(pixels) > 0 else []
     delayed_dfs = [delayed(df) for df in pixel_dfs]
     divisions = get_pixels_divisions(pixels)
-    ddf = NestedFrame.from_delayed(delayed_dfs, meta=schema, divisions=divisions)
+    ddf = nd.NestedFrame.from_delayed(delayed_dfs, meta=schema, divisions=divisions)
     return ddf, len(ddf)
 
 

--- a/src/lsdb/loaders/dataframe/from_dataframe_utils.py
+++ b/src/lsdb/loaders/dataframe/from_dataframe_utils.py
@@ -1,3 +1,4 @@
+import nested_pandas as npd
 from typing import List, Tuple
 
 import dask.dataframe as dd
@@ -14,7 +15,7 @@ from lsdb.dask.divisions import get_pixels_divisions
 
 
 def _generate_dask_dataframe(
-    pixel_dfs: List[pd.DataFrame], pixels: List[HealpixPixel], use_pyarrow_types: bool = True
+    pixel_dfs: List[npd.NestedFrame], pixels: List[HealpixPixel], use_pyarrow_types: bool = True
 ) -> Tuple[NestedFrame, int]:
     """Create the Dask Dataframe from the list of HEALPix pixel Dataframes
 
@@ -55,7 +56,9 @@ def _convert_dtypes_to_pyarrow(df: pd.DataFrame) -> pd.DataFrame:
     return pd.DataFrame(new_series, index=df_index, copy=False)
 
 
-def _append_partition_information_to_dataframe(dataframe: pd.DataFrame, pixel: HealpixPixel) -> pd.DataFrame:
+def _append_partition_information_to_dataframe(
+    dataframe: npd.NestedFrame, pixel: HealpixPixel
+) -> npd.NestedFrame:
     """Append partitioning information to a HEALPix dataframe
 
     Args:
@@ -113,7 +116,7 @@ def _format_margin_partition_dataframe(dataframe: pd.DataFrame) -> pd.DataFrame:
     return _order_partition_dataframe_columns(dataframe)
 
 
-def _order_partition_dataframe_columns(dataframe: pd.DataFrame) -> pd.DataFrame:
+def _order_partition_dataframe_columns(dataframe: npd.NestedFrame) -> npd.NestedFrame:
     """Reorder columns of a partition dataframe so that pixel information
     always appears in the same sequence
 

--- a/src/lsdb/loaders/dataframe/from_dataframe_utils.py
+++ b/src/lsdb/loaders/dataframe/from_dataframe_utils.py
@@ -1,7 +1,7 @@
-import nested_pandas as npd
 from typing import List, Tuple
 
 import dask.dataframe as dd
+import nested_pandas as npd
 import numpy as np
 import pandas as pd
 import pyarrow as pa
@@ -82,7 +82,7 @@ def _append_partition_information_to_dataframe(
     return _order_partition_dataframe_columns(dataframe)
 
 
-def _format_margin_partition_dataframe(dataframe: pd.DataFrame) -> pd.DataFrame:
+def _format_margin_partition_dataframe(dataframe: npd.NestedFrame) -> npd.NestedFrame:
     """Finalizes the dataframe for a margin catalog partition
 
     Args:

--- a/src/lsdb/loaders/dataframe/from_dataframe_utils.py
+++ b/src/lsdb/loaders/dataframe/from_dataframe_utils.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Tuple, cast
 
 import dask.dataframe as dd
 import nested_pandas as npd
@@ -20,7 +20,7 @@ def _generate_dask_dataframe(
     """Create the Dask Dataframe from the list of HEALPix pixel Dataframes
 
     Args:
-        pixel_dfs (List[pd.DataFrame]): The list of HEALPix pixel Dataframes
+        pixel_dfs (List[npd.NestedFrame]): The list of HEALPix pixel Dataframes
         pixels (List[HealpixPixel]): The list of HEALPix pixels in the catalog
         use_pyarrow_types (bool): If True, use pyarrow types. Defaults to True.
 
@@ -34,6 +34,7 @@ def _generate_dask_dataframe(
     ddf = dd.from_delayed(delayed_dfs, meta=schema, divisions=divisions)
     ddf = ddf if isinstance(ddf, dd.DataFrame) else ddf.to_frame()
     ddf = NestedFrame.from_dask_dataframe(ddf)
+    ddf = cast(NestedFrame, ddf)
     return ddf, len(ddf)
 
 

--- a/src/lsdb/loaders/dataframe/from_dataframe_utils.py
+++ b/src/lsdb/loaders/dataframe/from_dataframe_utils.py
@@ -1,6 +1,5 @@
-from typing import List, Tuple, cast
+from typing import List, Tuple
 
-import dask.dataframe as dd
 import nested_pandas as npd
 import numpy as np
 import pandas as pd
@@ -31,10 +30,7 @@ def _generate_dask_dataframe(
     schema = pixel_dfs[0].iloc[:0, :].copy() if len(pixels) > 0 else []
     delayed_dfs = [delayed(df) for df in pixel_dfs]
     divisions = get_pixels_divisions(pixels)
-    ddf = dd.from_delayed(delayed_dfs, meta=schema, divisions=divisions)
-    ddf = ddf if isinstance(ddf, dd.DataFrame) else ddf.to_frame()
-    ddf = NestedFrame.from_dask_dataframe(ddf)
-    ddf = cast(NestedFrame, ddf)
+    ddf = NestedFrame.from_delayed(delayed_dfs, meta=schema, divisions=divisions)
     return ddf, len(ddf)
 
 

--- a/src/lsdb/loaders/dataframe/from_dataframe_utils.py
+++ b/src/lsdb/loaders/dataframe/from_dataframe_utils.py
@@ -1,5 +1,6 @@
 from typing import List, Tuple
 
+import nested_dask as nd
 import nested_pandas as npd
 import numpy as np
 import pandas as pd
@@ -8,7 +9,7 @@ from dask import delayed
 from hipscat.catalog import PartitionInfo
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
-import nested_dask as nd
+
 from lsdb.dask.divisions import get_pixels_divisions
 
 

--- a/src/lsdb/loaders/dataframe/from_dataframe_utils.py
+++ b/src/lsdb/loaders/dataframe/from_dataframe_utils.py
@@ -8,13 +8,14 @@ from dask import delayed
 from hipscat.catalog import PartitionInfo
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
+from nested_dask import NestedFrame
 
 from lsdb.dask.divisions import get_pixels_divisions
 
 
 def _generate_dask_dataframe(
     pixel_dfs: List[pd.DataFrame], pixels: List[HealpixPixel], use_pyarrow_types: bool = True
-) -> Tuple[dd.DataFrame, int]:
+) -> Tuple[NestedFrame, int]:
     """Create the Dask Dataframe from the list of HEALPix pixel Dataframes
 
     Args:
@@ -31,6 +32,7 @@ def _generate_dask_dataframe(
     divisions = get_pixels_divisions(pixels)
     ddf = dd.from_delayed(delayed_dfs, meta=schema, divisions=divisions)
     ddf = ddf if isinstance(ddf, dd.DataFrame) else ddf.to_frame()
+    ddf = NestedFrame.from_dask_dataframe(ddf)
     return ddf, len(ddf)
 
 

--- a/src/lsdb/loaders/dataframe/margin_catalog_generator.py
+++ b/src/lsdb/loaders/dataframe/margin_catalog_generator.py
@@ -1,3 +1,4 @@
+import nested_pandas as npd
 from __future__ import annotations
 
 from typing import Dict, List, Tuple
@@ -84,7 +85,7 @@ class MarginCatalogGenerator:
         margin_structure = hc.catalog.MarginCatalog(margin_catalog_info, margin_pixels, schema=self.schema)
         return MarginCatalog(ddf, ddf_pixel_map, margin_structure)
 
-    def _get_margins(self) -> Tuple[List[HealpixPixel], List[pd.DataFrame]]:
+    def _get_margins(self) -> Tuple[List[HealpixPixel], List[npd.NestedFrame]]:
         """Generates the list of pixels that have margin data, and the dataframes with the margin data for
         each partition
 

--- a/src/lsdb/loaders/dataframe/margin_catalog_generator.py
+++ b/src/lsdb/loaders/dataframe/margin_catalog_generator.py
@@ -12,6 +12,7 @@ from hipscat.catalog import CatalogType
 from hipscat.catalog.margin_cache import MarginCacheCatalogInfo
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.healpix_pixel_function import get_pixel_argsort
+from nested_dask import NestedFrame
 
 from lsdb import Catalog
 from lsdb.catalog.margin_catalog import MarginCatalog
@@ -101,7 +102,7 @@ class MarginCatalogGenerator:
 
     def _generate_dask_df_and_map(
         self, pixels: List[HealpixPixel], partitions: List[pd.DataFrame]
-    ) -> Tuple[dd.DataFrame, Dict[HealpixPixel, int], int]:
+    ) -> Tuple[NestedFrame, Dict[HealpixPixel, int], int]:
         """Create the Dask Dataframe containing the data points in the margins
         for the catalog as well as the mapping of those HEALPix to Dataframes
 

--- a/src/lsdb/loaders/dataframe/margin_catalog_generator.py
+++ b/src/lsdb/loaders/dataframe/margin_catalog_generator.py
@@ -1,11 +1,10 @@
-import nested_pandas as npd
 from __future__ import annotations
 
 from typing import Dict, List, Tuple
 
-import dask.dataframe as dd
 import healpy as hp
 import hipscat as hc
+import nested_pandas as npd
 import numpy as np
 import pandas as pd
 from hipscat import pixel_math
@@ -41,7 +40,7 @@ class MarginCatalogGenerator:
             margin_threshold (float): The size of the margin cache boundary, in arcseconds
             use_pyarrow_types (bool): If True, use pyarrow types. Defaults to True.
         """
-        self.dataframe = catalog.compute().copy()
+        self.dataframe: npd.NestedFrame = catalog.compute().copy()
         self.hc_structure = catalog.hc_structure
         self.margin_threshold = margin_threshold
         self.margin_order = self._set_margin_order(margin_order)
@@ -165,7 +164,7 @@ class MarginCatalogGenerator:
         Returns:
             A dictionary mapping each margin pixel to the respective DataFrame.
         """
-        margin_pixel_df_map: Dict[HealpixPixel, pd.DataFrame] = {}
+        margin_pixel_df_map: Dict[HealpixPixel, npd.NestedFrame] = {}
         self.dataframe["margin_pixel"] = hp.ang2pix(
             2**self.margin_order,
             self.dataframe[self.hc_structure.catalog_info.ra_column].to_numpy(),
@@ -185,7 +184,9 @@ class MarginCatalogGenerator:
                     margin_pixel_df_map[margin_pixel] = df
         return margin_pixel_df_map
 
-    def _get_data_in_margin(self, partition_df: pd.DataFrame, margin_pixel: HealpixPixel) -> pd.DataFrame:
+    def _get_data_in_margin(
+        self, partition_df: npd.NestedFrame, margin_pixel: HealpixPixel
+    ) -> npd.NestedFrame:
         """Calculate the margin boundaries for the HEALPix and include the points
         on the margin according to the specified threshold
 

--- a/src/lsdb/loaders/dataframe/margin_catalog_generator.py
+++ b/src/lsdb/loaders/dataframe/margin_catalog_generator.py
@@ -12,7 +12,7 @@ from hipscat.catalog import CatalogType
 from hipscat.catalog.margin_cache import MarginCacheCatalogInfo
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.healpix_pixel_function import get_pixel_argsort
-from nested_dask import NestedFrame
+import nested_dask as nd
 
 from lsdb import Catalog
 from lsdb.catalog.margin_catalog import MarginCatalog
@@ -102,7 +102,7 @@ class MarginCatalogGenerator:
 
     def _generate_dask_df_and_map(
         self, pixels: List[HealpixPixel], partitions: List[pd.DataFrame]
-    ) -> Tuple[NestedFrame, Dict[HealpixPixel, int], int]:
+    ) -> Tuple[nd.NestedFrame, Dict[HealpixPixel, int], int]:
         """Create the Dask Dataframe containing the data points in the margins
         for the catalog as well as the mapping of those HEALPix to Dataframes
 

--- a/src/lsdb/loaders/dataframe/margin_catalog_generator.py
+++ b/src/lsdb/loaders/dataframe/margin_catalog_generator.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Tuple
 
 import healpy as hp
 import hipscat as hc
+import nested_dask as nd
 import nested_pandas as npd
 import numpy as np
 import pandas as pd
@@ -12,7 +13,6 @@ from hipscat.catalog import CatalogType
 from hipscat.catalog.margin_cache import MarginCacheCatalogInfo
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.healpix_pixel_function import get_pixel_argsort
-import nested_dask as nd
 
 from lsdb import Catalog
 from lsdb.catalog.margin_catalog import MarginCatalog

--- a/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
@@ -4,6 +4,7 @@ from abc import abstractmethod
 from typing import Generic, List, Tuple, Type
 
 import hipscat as hc
+import nested_dask as nd
 import nested_pandas as npd
 import numpy as np
 import pyarrow as pa
@@ -11,7 +12,7 @@ from hipscat.catalog.healpix_dataset.healpix_dataset import HealpixDataset as HC
 from hipscat.io.file_io import file_io
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.healpix_pixel_function import get_pixel_argsort
-import nested_dask as nd
+
 from lsdb.catalog.catalog import DaskDFPixelMap
 from lsdb.dask.divisions import get_pixels_divisions
 from lsdb.loaders.hipscat.hipscat_loading_config import HipscatLoadingConfig

--- a/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import Generic, List, Tuple, Type
 
-import dask.dataframe as dd
 import hipscat as hc
 import nested_pandas as npd
 import numpy as np

--- a/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
@@ -81,19 +81,17 @@ class AbstractCatalogLoader(Generic[CatalogTypeVar]):
     ) -> NestedFrame:
         dask_meta_schema = self._create_dask_meta_schema(catalog.schema)
         if len(paths) > 0:
-            return NestedFrame.from_dask_dataframe(
-                dd.from_map(
-                    file_io.read_parquet_file_to_pandas,
-                    paths,
-                    columns=self.config.columns,
-                    divisions=divisions,
-                    meta=dask_meta_schema,
-                    schema=catalog.schema,
-                    storage_options=self.storage_options,
-                    **self._get_kwargs(),
-                )
+            return NestedFrame.from_map(
+                file_io.read_parquet_file_to_pandas,
+                paths,
+                columns=self.config.columns,
+                divisions=divisions,
+                meta=dask_meta_schema,
+                schema=catalog.schema,
+                storage_options=self.storage_options,
+                **self._get_kwargs(),
             )
-        return NestedFrame.from_dask_dataframe(dd.from_pandas(dask_meta_schema, npartitions=1))
+        return NestedFrame.from_pandas(dask_meta_schema, npartitions=1)
 
     def _create_dask_meta_schema(self, schema: pa.Schema) -> npd.NestedFrame:
         """Creates the Dask meta DataFrame from the HiPSCat catalog schema."""

--- a/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/abstract_catalog_loader.py
@@ -1,4 +1,3 @@
-import nested_pandas as npd
 from __future__ import annotations
 
 from abc import abstractmethod
@@ -6,6 +5,7 @@ from typing import Generic, List, Tuple, Type
 
 import dask.dataframe as dd
 import hipscat as hc
+import nested_pandas as npd
 import numpy as np
 import pyarrow as pa
 from hipscat.catalog.healpix_dataset.healpix_dataset import HealpixDataset as HCHealpixDataset

--- a/src/lsdb/loaders/hipscat/association_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/association_catalog_loader.py
@@ -1,4 +1,3 @@
-import dask.dataframe as dd
 import hipscat as hc
 from nested_dask import NestedFrame
 

--- a/src/lsdb/loaders/hipscat/association_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/association_catalog_loader.py
@@ -24,5 +24,5 @@ class AssociationCatalogLoader(AbstractCatalogLoader[AssociationCatalog]):
 
     def _load_empty_dask_df_and_map(self, hc_catalog):
         dask_meta_schema = self._create_dask_meta_schema(hc_catalog.schema)
-        ddf = NestedFrame.from_dask_dataframe(dd.from_pandas(dask_meta_schema, npartitions=1))
+        ddf = NestedFrame.from_pandas(dask_meta_schema, npartitions=1)
         return ddf, {}

--- a/src/lsdb/loaders/hipscat/association_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/association_catalog_loader.py
@@ -1,5 +1,6 @@
 import hipscat as hc
 import nested_dask as nd
+
 from lsdb.catalog.association_catalog import AssociationCatalog
 from lsdb.loaders.hipscat.abstract_catalog_loader import AbstractCatalogLoader
 

--- a/src/lsdb/loaders/hipscat/association_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/association_catalog_loader.py
@@ -1,6 +1,5 @@
 import hipscat as hc
-from nested_dask import NestedFrame
-
+import nested_dask as nd
 from lsdb.catalog.association_catalog import AssociationCatalog
 from lsdb.loaders.hipscat.abstract_catalog_loader import AbstractCatalogLoader
 
@@ -23,5 +22,5 @@ class AssociationCatalogLoader(AbstractCatalogLoader[AssociationCatalog]):
 
     def _load_empty_dask_df_and_map(self, hc_catalog):
         dask_meta_schema = self._create_dask_meta_schema(hc_catalog.schema)
-        ddf = NestedFrame.from_pandas(dask_meta_schema, npartitions=1)
+        ddf = nd.NestedFrame.from_pandas(dask_meta_schema, npartitions=1)
         return ddf, {}

--- a/src/lsdb/loaders/hipscat/association_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/association_catalog_loader.py
@@ -1,5 +1,6 @@
 import dask.dataframe as dd
 import hipscat as hc
+from nested_dask import NestedFrame
 
 from lsdb.catalog.association_catalog import AssociationCatalog
 from lsdb.loaders.hipscat.abstract_catalog_loader import AbstractCatalogLoader
@@ -23,5 +24,5 @@ class AssociationCatalogLoader(AbstractCatalogLoader[AssociationCatalog]):
 
     def _load_empty_dask_df_and_map(self, hc_catalog):
         dask_meta_schema = self._create_dask_meta_schema(hc_catalog.schema)
-        ddf = dd.from_pandas(dask_meta_schema, npartitions=1)
+        ddf = NestedFrame.from_dask_dataframe(dd.from_pandas(dask_meta_schema, npartitions=1))
         return ddf, {}

--- a/tests/lsdb/catalog/test_association_catalog.py
+++ b/tests/lsdb/catalog/test_association_catalog.py
@@ -1,6 +1,6 @@
 import hipscat as hc
 import pandas as pd
-from nested_dask import NestedFrame
+import nested_dask as nd
 
 import lsdb
 from lsdb.catalog.association_catalog import AssociationCatalog
@@ -9,7 +9,7 @@ from lsdb.catalog.association_catalog import AssociationCatalog
 def test_load_association(small_sky_to_xmatch_dir):
     small_sky_to_xmatch = lsdb.read_hipscat(small_sky_to_xmatch_dir)
     assert isinstance(small_sky_to_xmatch, AssociationCatalog)
-    assert isinstance(small_sky_to_xmatch._ddf, NestedFrame)
+    assert isinstance(small_sky_to_xmatch._ddf, nd.NestedFrame)
     assert small_sky_to_xmatch.get_healpix_pixels() == small_sky_to_xmatch.hc_structure.get_healpix_pixels()
     assert repr(small_sky_to_xmatch) == repr(small_sky_to_xmatch._ddf)
     for healpix_pixel in small_sky_to_xmatch.get_healpix_pixels():
@@ -28,5 +28,5 @@ def test_load_association(small_sky_to_xmatch_dir):
 def test_load_soft_association(small_sky_to_xmatch_soft_dir):
     small_sky_to_xmatch_soft = lsdb.read_hipscat(small_sky_to_xmatch_soft_dir)
     assert isinstance(small_sky_to_xmatch_soft, AssociationCatalog)
-    assert isinstance(small_sky_to_xmatch_soft._ddf, NestedFrame)
+    assert isinstance(small_sky_to_xmatch_soft._ddf, nd.NestedFrame)
     assert len(small_sky_to_xmatch_soft.compute()) == 0

--- a/tests/lsdb/catalog/test_association_catalog.py
+++ b/tests/lsdb/catalog/test_association_catalog.py
@@ -1,5 +1,6 @@
 import hipscat as hc
 import pandas as pd
+from nested_dask import NestedFrame
 
 import lsdb
 from lsdb.catalog.association_catalog import AssociationCatalog
@@ -8,6 +9,7 @@ from lsdb.catalog.association_catalog import AssociationCatalog
 def test_load_association(small_sky_to_xmatch_dir):
     small_sky_to_xmatch = lsdb.read_hipscat(small_sky_to_xmatch_dir)
     assert isinstance(small_sky_to_xmatch, AssociationCatalog)
+    assert isinstance(small_sky_to_xmatch._ddf, NestedFrame)
     assert small_sky_to_xmatch.get_healpix_pixels() == small_sky_to_xmatch.hc_structure.get_healpix_pixels()
     assert repr(small_sky_to_xmatch) == repr(small_sky_to_xmatch._ddf)
     for healpix_pixel in small_sky_to_xmatch.get_healpix_pixels():
@@ -26,4 +28,5 @@ def test_load_association(small_sky_to_xmatch_dir):
 def test_load_soft_association(small_sky_to_xmatch_soft_dir):
     small_sky_to_xmatch_soft = lsdb.read_hipscat(small_sky_to_xmatch_soft_dir)
     assert isinstance(small_sky_to_xmatch_soft, AssociationCatalog)
+    assert isinstance(small_sky_to_xmatch_soft._ddf, NestedFrame)
     assert len(small_sky_to_xmatch_soft.compute()) == 0

--- a/tests/lsdb/catalog/test_association_catalog.py
+++ b/tests/lsdb/catalog/test_association_catalog.py
@@ -1,6 +1,6 @@
 import hipscat as hc
-import pandas as pd
 import nested_dask as nd
+import pandas as pd
 
 import lsdb
 from lsdb.catalog.association_catalog import AssociationCatalog

--- a/tests/lsdb/catalog/test_box_search.py
+++ b/tests/lsdb/catalog/test_box_search.py
@@ -1,8 +1,8 @@
+import nested_dask as nd
 import nested_pandas as npd
 import numpy as np
 import pytest
 from hipscat.pixel_math.validators import ValidatorsErrors
-import nested_dask as nd
 
 
 def test_box_search_ra_filters_correct_points(small_sky_order1_catalog, assert_divisions_are_correct):

--- a/tests/lsdb/catalog/test_box_search.py
+++ b/tests/lsdb/catalog/test_box_search.py
@@ -1,11 +1,15 @@
+import nested_pandas as npd
 import numpy as np
 import pytest
 from hipscat.pixel_math.validators import ValidatorsErrors
+from nested_dask import NestedFrame
 
 
 def test_box_search_ra_filters_correct_points(small_sky_order1_catalog, assert_divisions_are_correct):
     ra_search_catalog = small_sky_order1_catalog.box_search(ra=(280, 300))
+    assert isinstance(ra_search_catalog._ddf, NestedFrame)
     ra_search_df = ra_search_catalog.compute()
+    assert isinstance(ra_search_df, npd.NestedFrame)
     ra_values = ra_search_df[small_sky_order1_catalog.hc_structure.catalog_info.ra_column]
     assert len(ra_search_df) < len(small_sky_order1_catalog.compute())
     assert all(280 <= ra <= 300 for ra in ra_values)

--- a/tests/lsdb/catalog/test_box_search.py
+++ b/tests/lsdb/catalog/test_box_search.py
@@ -2,12 +2,12 @@ import nested_pandas as npd
 import numpy as np
 import pytest
 from hipscat.pixel_math.validators import ValidatorsErrors
-from nested_dask import NestedFrame
+import nested_dask as nd
 
 
 def test_box_search_ra_filters_correct_points(small_sky_order1_catalog, assert_divisions_are_correct):
     ra_search_catalog = small_sky_order1_catalog.box_search(ra=(280, 300))
-    assert isinstance(ra_search_catalog._ddf, NestedFrame)
+    assert isinstance(ra_search_catalog._ddf, nd.NestedFrame)
     ra_search_df = ra_search_catalog.compute()
     assert isinstance(ra_search_df, npd.NestedFrame)
     ra_values = ra_search_df[small_sky_order1_catalog.hc_structure.catalog_info.ra_column]

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -1,9 +1,9 @@
-import nested_pandas as npd
 from pathlib import Path
 
 import dask.array as da
 import dask.dataframe as dd
 import healpy as hp
+import nested_pandas as npd
 import numpy as np
 import pandas as pd
 import pytest

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -1,3 +1,4 @@
+import nested_pandas as npd
 from pathlib import Path
 
 import dask.array as da
@@ -7,6 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from hipscat.pixel_math import HealpixPixel, hipscat_id_to_healpix
+from nested_dask import NestedFrame
 
 import lsdb
 from lsdb import Catalog
@@ -46,13 +48,16 @@ def test_get_catalog_partition_gets_correct_partition(small_sky_order1_catalog):
         pixel = HealpixPixel(order=hp_order, pixel=hp_pixel)
         partition_index = small_sky_order1_catalog._ddf_pixel_map[pixel]
         ddf_partition = small_sky_order1_catalog._ddf.partitions[partition_index]
-        dd.utils.assert_eq(partition, ddf_partition)
+        assert isinstance(partition, NestedFrame)
+        assert isinstance(partition.compute(), npd.NestedFrame)
+        pd.testing.assert_frame_equal(partition.compute(), ddf_partition.compute())
 
 
 def test_head(small_sky_order1_catalog):
     # By default, head returns 5 rows
     expected_df = small_sky_order1_catalog._ddf.partitions[0].compute()[:5]
     head_df = small_sky_order1_catalog.head()
+    assert isinstance(head_df, npd.NestedFrame)
     assert len(head_df) == 5
     pd.testing.assert_frame_equal(expected_df, head_df)
     # But we can also specify the number of rows we desire
@@ -101,22 +106,20 @@ def test_query(small_sky_order1_catalog):
     ]
     # Simple query, with no value injection or backticks
     result_catalog = small_sky_order1_catalog.query("ra > 300 and dec < -50")
+    assert isinstance(result_catalog._ddf, NestedFrame)
     pd.testing.assert_frame_equal(result_catalog._ddf.compute(), expected_ddf.compute())
     # Query with value injection
     ra, dec = 300, -50
     result_catalog = small_sky_order1_catalog.query(f"ra > {ra} and dec < {dec}")
+    assert isinstance(result_catalog._ddf, NestedFrame)
     pd.testing.assert_frame_equal(result_catalog._ddf.compute(), expected_ddf.compute())
     # Query with backticks (for invalid Python variables names)
     new_columns = {"ra": "right ascension"}
     expected_ddf = expected_ddf.rename(columns=new_columns)
     small_sky_order1_catalog._ddf = small_sky_order1_catalog._ddf.rename(columns=new_columns)
     result_catalog = small_sky_order1_catalog.query("`right ascension` > 300 and dec < -50")
+    assert isinstance(result_catalog._ddf, NestedFrame)
     pd.testing.assert_frame_equal(result_catalog._ddf.compute(), expected_ddf.compute())
-
-
-def test_query_no_arguments(small_sky_order1_catalog):
-    with pytest.raises(ValueError):
-        small_sky_order1_catalog.query(None)
 
 
 def test_query_margin(small_sky_xmatch_with_margin):
@@ -132,11 +135,13 @@ def test_query_margin(small_sky_xmatch_with_margin):
     assert result_catalog.margin is not None
     pd.testing.assert_frame_equal(result_catalog.compute(), expected_ddf.compute())
     pd.testing.assert_frame_equal(result_catalog.margin.compute(), expected_margin_ddf.compute())
+    assert isinstance(result_catalog.margin._ddf, NestedFrame)
 
 
 def test_assign_no_arguments(small_sky_order1_catalog):
     result_catalog = small_sky_order1_catalog.assign()
     pd.testing.assert_frame_equal(result_catalog._ddf.compute(), small_sky_order1_catalog._ddf.compute())
+    assert isinstance(result_catalog._ddf, NestedFrame)
 
 
 def test_assign_with_callable(small_sky_order1_catalog):
@@ -145,6 +150,7 @@ def test_assign_with_callable(small_sky_order1_catalog):
     expected_ddf = small_sky_order1_catalog._ddf.copy()
     expected_ddf["squared_ra_err"] = expected_ddf["ra_error"] ** 2
     pd.testing.assert_frame_equal(result_catalog.compute(), expected_ddf.compute())
+    assert isinstance(result_catalog._ddf, NestedFrame)
 
 
 def test_assign_with_series(small_sky_order1_catalog):
@@ -155,6 +161,7 @@ def test_assign_with_series(small_sky_order1_catalog):
     expected_ddf = small_sky_order1_catalog._ddf.copy()
     expected_ddf["new_column"] = squared_ra_err
     pd.testing.assert_frame_equal(result_catalog.compute(), expected_ddf.compute())
+    assert isinstance(result_catalog._ddf, NestedFrame)
 
 
 def test_assign_with_multiple_columns(small_sky_order1_catalog):
@@ -260,6 +267,8 @@ def test_prune_empty_partitions(small_sky_order1_catalog):
     _, non_empty_partitions = pruned_catalog._get_non_empty_partitions()
     assert pruned_catalog._ddf.npartitions - len(non_empty_partitions) == 0
     pd.testing.assert_frame_equal(catalog.compute(), pruned_catalog.compute())
+    assert isinstance(pruned_catalog._ddf, NestedFrame)
+    assert isinstance(pruned_catalog.compute(), npd.NestedFrame)
 
 
 def test_prune_empty_partitions_with_none_to_remove(small_sky_order1_catalog):
@@ -467,6 +476,8 @@ def test_square_bracket_columns(small_sky_order1_catalog):
     column_subset = small_sky_order1_catalog[columns]
     assert all(column_subset.columns == columns)
     assert isinstance(column_subset, Catalog)
+    assert isinstance(column_subset._ddf, NestedFrame)
+    assert isinstance(column_subset.compute(), npd.NestedFrame)
     pd.testing.assert_frame_equal(column_subset.compute(), small_sky_order1_catalog.compute()[columns])
     assert np.all(
         column_subset.compute().index.to_numpy() == small_sky_order1_catalog.compute().index.to_numpy()
@@ -484,6 +495,8 @@ def test_square_bracket_column(small_sky_order1_catalog):
 def test_square_bracket_filter(small_sky_order1_catalog):
     filtered_id = small_sky_order1_catalog[small_sky_order1_catalog["id"] > 750]
     assert isinstance(filtered_id, Catalog)
+    assert isinstance(filtered_id._ddf, NestedFrame)
+    assert isinstance(filtered_id.compute(), npd.NestedFrame)
     ss_computed = small_sky_order1_catalog.compute()
     pd.testing.assert_frame_equal(filtered_id.compute(), ss_computed[ss_computed["id"] > 750])
     assert np.all(
@@ -498,9 +511,11 @@ def test_map_partitions(small_sky_order1_catalog):
 
     mapped = small_sky_order1_catalog.map_partitions(add_col)
     assert isinstance(mapped, Catalog)
+    assert isinstance(mapped._ddf, NestedFrame)
     assert "a" in mapped.columns
     assert mapped.dtypes["a"] == mapped.dtypes["ra"]
     mapcomp = mapped.compute()
+    assert isinstance(mapcomp, npd.NestedFrame)
     assert np.all(mapcomp["a"] == mapcomp["ra"] + 1)
 
 
@@ -562,10 +577,14 @@ def test_square_bracket_single_partition(small_sky_order1_catalog):
     index = 1
     subset = small_sky_order1_catalog.partitions[index]
     assert isinstance(subset, Catalog)
+    assert isinstance(subset._ddf, NestedFrame)
     assert 1 == len(subset._ddf_pixel_map)
     pixel = subset.get_healpix_pixels()[0]
     assert index == small_sky_order1_catalog.get_partition_index(pixel.order, pixel.pixel)
-    dd.assert_eq(small_sky_order1_catalog._ddf.partitions[index], subset._ddf)
+    pd.testing.assert_frame_equal(
+        small_sky_order1_catalog._ddf.partitions[index].compute(), subset._ddf.compute()
+    )
+    assert isinstance(subset.compute(), npd.NestedFrame)
 
 
 def test_square_bracket_multiple_partitions(small_sky_order1_catalog):
@@ -577,7 +596,7 @@ def test_square_bracket_multiple_partitions(small_sky_order1_catalog):
         original_index = small_sky_order1_catalog.get_partition_index(pixel.order, pixel.pixel)
         original_partition = small_sky_order1_catalog._ddf.partitions[original_index]
         subset_partition = subset._ddf.partitions[partition_index]
-        dd.assert_eq(original_partition, subset_partition)
+        pd.testing.assert_frame_equal(original_partition.compute(), subset_partition.compute())
 
 
 def test_square_bracket_slice_partitions(small_sky_order1_catalog):
@@ -586,8 +605,8 @@ def test_square_bracket_slice_partitions(small_sky_order1_catalog):
     assert 2 == len(subset._ddf_pixel_map)
     subset_2 = small_sky_order1_catalog.partitions[0:2]
     assert isinstance(subset, Catalog)
-    dd.assert_eq(subset_2._ddf, subset._ddf)
+    pd.testing.assert_frame_equal(subset_2.compute(), subset.compute())
     assert subset_2.get_healpix_pixels() == subset.get_healpix_pixels()
     subset_3 = small_sky_order1_catalog.partitions[0:2:1]
     assert subset_3.get_healpix_pixels() == subset.get_healpix_pixels()
-    dd.assert_eq(subset_3._ddf, subset._ddf)
+    pd.testing.assert_frame_equal(subset_3.compute(), subset.compute())

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -71,8 +71,8 @@ def test_head_rows_less_than_requested(small_sky_order1_catalog):
     schema = small_sky_order1_catalog.dtypes
     two_rows = small_sky_order1_catalog._ddf.partitions[0].compute()[:2]
     tiny_df = pd.DataFrame(data=two_rows, columns=schema.index, dtype=schema.to_numpy())
-    altered_ddf = dd.from_pandas(tiny_df, npartitions=1)
-    catalog = lsdb.Catalog(altered_ddf, {}, small_sky_order1_catalog.hc_structure)
+    altered_ndf = nd.NestedFrame.from_pandas(tiny_df, npartitions=1)
+    catalog = lsdb.Catalog(altered_ndf, {}, small_sky_order1_catalog.hc_structure)
     # The head only contains two values
     assert len(catalog.head()) == 2
 
@@ -82,8 +82,8 @@ def test_head_first_partition_is_empty(small_sky_order1_catalog):
     schema = small_sky_order1_catalog.dtypes
     empty_df = pd.DataFrame(columns=schema.index, dtype=schema.to_numpy())
     empty_ddf = dd.from_pandas(empty_df, npartitions=1)
-    altered_ddf = dd.concat([empty_ddf, small_sky_order1_catalog._ddf])
-    catalog = lsdb.Catalog(altered_ddf, {}, small_sky_order1_catalog.hc_structure)
+    altered_ndf = nd.NestedFrame.from_dask_dataframe(dd.concat([empty_ddf, small_sky_order1_catalog._ddf]))
+    catalog = lsdb.Catalog(altered_ndf, {}, small_sky_order1_catalog.hc_structure)
     # The first partition is empty
     first_partition_df = catalog._ddf.partitions[0].compute()
     assert len(first_partition_df) == 0

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -3,12 +3,12 @@ from pathlib import Path
 import dask.array as da
 import dask.dataframe as dd
 import healpy as hp
+import nested_dask as nd
 import nested_pandas as npd
 import numpy as np
 import pandas as pd
 import pytest
 from hipscat.pixel_math import HealpixPixel, hipscat_id_to_healpix
-import nested_dask as nd
 
 import lsdb
 from lsdb import Catalog

--- a/tests/lsdb/catalog/test_cone_search.py
+++ b/tests/lsdb/catalog/test_cone_search.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 from astropy.coordinates import SkyCoord
 from hipscat.pixel_math.validators import ValidatorsErrors
-from nested_dask import NestedFrame
+import nested_dask as nd
 
 
 def test_cone_search_filters_correct_points(small_sky_order1_catalog, assert_divisions_are_correct):
@@ -13,7 +13,7 @@ def test_cone_search_filters_correct_points(small_sky_order1_catalog, assert_div
     radius = radius_degrees * 3600
     center_coord = SkyCoord(ra, dec, unit="deg")
     cone_search_catalog = small_sky_order1_catalog.cone_search(ra, dec, radius)
-    assert isinstance(cone_search_catalog._ddf, NestedFrame)
+    assert isinstance(cone_search_catalog._ddf, nd.NestedFrame)
     cone_search_df = cone_search_catalog.compute()
     assert isinstance(cone_search_df, npd.NestedFrame)
     for _, row in small_sky_order1_catalog.compute().iterrows():

--- a/tests/lsdb/catalog/test_cone_search.py
+++ b/tests/lsdb/catalog/test_cone_search.py
@@ -1,9 +1,9 @@
+import nested_dask as nd
 import nested_pandas as npd
 import pandas as pd
 import pytest
 from astropy.coordinates import SkyCoord
 from hipscat.pixel_math.validators import ValidatorsErrors
-import nested_dask as nd
 
 
 def test_cone_search_filters_correct_points(small_sky_order1_catalog, assert_divisions_are_correct):

--- a/tests/lsdb/catalog/test_cone_search.py
+++ b/tests/lsdb/catalog/test_cone_search.py
@@ -1,7 +1,9 @@
+import nested_pandas as npd
 import pandas as pd
 import pytest
 from astropy.coordinates import SkyCoord
 from hipscat.pixel_math.validators import ValidatorsErrors
+from nested_dask import NestedFrame
 
 
 def test_cone_search_filters_correct_points(small_sky_order1_catalog, assert_divisions_are_correct):
@@ -11,7 +13,9 @@ def test_cone_search_filters_correct_points(small_sky_order1_catalog, assert_div
     radius = radius_degrees * 3600
     center_coord = SkyCoord(ra, dec, unit="deg")
     cone_search_catalog = small_sky_order1_catalog.cone_search(ra, dec, radius)
+    assert isinstance(cone_search_catalog._ddf, NestedFrame)
     cone_search_df = cone_search_catalog.compute()
+    assert isinstance(cone_search_df, npd.NestedFrame)
     for _, row in small_sky_order1_catalog.compute().iterrows():
         row_ra = row[small_sky_order1_catalog.hc_structure.catalog_info.ra_column]
         row_dec = row[small_sky_order1_catalog.hc_structure.catalog_info.dec_column]

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -1,9 +1,11 @@
+import nested_pandas as npd
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
+from nested_dask import NestedFrame
 
 import lsdb
 from lsdb import Catalog
@@ -17,9 +19,12 @@ class TestCrossmatch:
     @staticmethod
     def test_kdtree_crossmatch(algo, small_sky_catalog, small_sky_xmatch_catalog, xmatch_correct):
         with pytest.warns(RuntimeWarning, match="Results may be incomplete and/or inaccurate"):
-            xmatched = small_sky_catalog.crossmatch(
+            xmatched_cat = small_sky_catalog.crossmatch(
                 small_sky_xmatch_catalog, algorithm=algo, radius_arcsec=0.01 * 3600
-            ).compute()
+            )
+            assert isinstance(xmatched_cat, NestedFrame)
+            xmatched = xmatched_cat.compute()
+        assert isinstance(xmatched._ddf, npd.NestedFrame)
         assert len(xmatched) == len(xmatch_correct)
         for _, correct_row in xmatch_correct.iterrows():
             assert correct_row["ss_id"] in xmatched["id_small_sky"].to_numpy()

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -5,7 +5,7 @@ import pyarrow as pa
 import pytest
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
-from nested_dask import NestedFrame
+import nested_dask as nd
 
 import lsdb
 from lsdb import Catalog
@@ -22,7 +22,7 @@ class TestCrossmatch:
             xmatched_cat = small_sky_catalog.crossmatch(
                 small_sky_xmatch_catalog, algorithm=algo, radius_arcsec=0.01 * 3600
             )
-            assert isinstance(xmatched_cat._ddf, NestedFrame)
+            assert isinstance(xmatched_cat._ddf, nd.NestedFrame)
             xmatched = xmatched_cat.compute()
         assert isinstance(xmatched, npd.NestedFrame)
         assert len(xmatched) == len(xmatch_correct)

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -22,9 +22,9 @@ class TestCrossmatch:
             xmatched_cat = small_sky_catalog.crossmatch(
                 small_sky_xmatch_catalog, algorithm=algo, radius_arcsec=0.01 * 3600
             )
-            assert isinstance(xmatched_cat, NestedFrame)
+            assert isinstance(xmatched_cat._ddf, NestedFrame)
             xmatched = xmatched_cat.compute()
-        assert isinstance(xmatched._ddf, npd.NestedFrame)
+        assert isinstance(xmatched, npd.NestedFrame)
         assert len(xmatched) == len(xmatch_correct)
         for _, correct_row in xmatch_correct.iterrows():
             assert correct_row["ss_id"] in xmatched["id_small_sky"].to_numpy()

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -1,3 +1,4 @@
+import nested_dask as nd
 import nested_pandas as npd
 import numpy as np
 import pandas as pd
@@ -5,7 +6,6 @@ import pyarrow as pa
 import pytest
 from hipscat.pixel_math import HealpixPixel
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
-import nested_dask as nd
 
 import lsdb
 from lsdb import Catalog

--- a/tests/lsdb/catalog/test_index_search.py
+++ b/tests/lsdb/catalog/test_index_search.py
@@ -1,13 +1,13 @@
 import nested_pandas as npd
 from hipscat.catalog.index.index_catalog import IndexCatalog
-from nested_dask import NestedFrame
+import nested_dask as nd
 
 
 def test_index_search(small_sky_order1_catalog, small_sky_order1_id_index_dir, assert_divisions_are_correct):
     catalog_index = IndexCatalog.read_from_hipscat(small_sky_order1_id_index_dir)
     # Searching for an object that does not exist
     index_search_catalog = small_sky_order1_catalog.index_search([900], catalog_index)
-    assert isinstance(index_search_catalog._ddf, NestedFrame)
+    assert isinstance(index_search_catalog._ddf, nd.NestedFrame)
     index_search_df = index_search_catalog.compute()
     assert isinstance(index_search_df, npd.NestedFrame)
     assert len(index_search_df) == 0

--- a/tests/lsdb/catalog/test_index_search.py
+++ b/tests/lsdb/catalog/test_index_search.py
@@ -1,6 +1,6 @@
+import nested_dask as nd
 import nested_pandas as npd
 from hipscat.catalog.index.index_catalog import IndexCatalog
-import nested_dask as nd
 
 
 def test_index_search(small_sky_order1_catalog, small_sky_order1_id_index_dir, assert_divisions_are_correct):

--- a/tests/lsdb/catalog/test_index_search.py
+++ b/tests/lsdb/catalog/test_index_search.py
@@ -1,11 +1,15 @@
+import nested_pandas as npd
 from hipscat.catalog.index.index_catalog import IndexCatalog
+from nested_dask import NestedFrame
 
 
 def test_index_search(small_sky_order1_catalog, small_sky_order1_id_index_dir, assert_divisions_are_correct):
     catalog_index = IndexCatalog.read_from_hipscat(small_sky_order1_id_index_dir)
     # Searching for an object that does not exist
     index_search_catalog = small_sky_order1_catalog.index_search([900], catalog_index)
+    assert isinstance(index_search_catalog._ddf, NestedFrame)
     index_search_df = index_search_catalog.compute()
+    assert isinstance(index_search_df, npd.NestedFrame)
     assert len(index_search_df) == 0
     assert_divisions_are_correct(index_search_catalog)
     # Searching for an object that exists

--- a/tests/lsdb/catalog/test_join.py
+++ b/tests/lsdb/catalog/test_join.py
@@ -1,7 +1,9 @@
+import nested_pandas as npd
 import numpy as np
 import pandas as pd
 import pytest
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
+from nested_dask import NestedFrame
 
 
 def test_small_sky_join_small_sky_order1(
@@ -12,6 +14,7 @@ def test_small_sky_join_small_sky_order1(
         joined = small_sky_catalog.join(
             small_sky_order1_catalog, left_on="id", right_on="id", suffixes=suffixes
         )
+        assert isinstance(joined._ddf, NestedFrame)
     for col_name, dtype in small_sky_catalog.dtypes.items():
         assert (col_name + suffixes[0], dtype) in joined.dtypes.items()
     for col_name, dtype in small_sky_order1_catalog.dtypes.items():
@@ -20,6 +23,7 @@ def test_small_sky_join_small_sky_order1(
     assert joined._ddf.index.dtype == np.uint64
 
     joined_compute = joined.compute()
+    assert isinstance(joined_compute, npd.NestedFrame)
     small_sky_compute = small_sky_catalog.compute()
     small_sky_order1_compute = small_sky_order1_catalog.compute()
     assert len(joined_compute) == len(small_sky_compute)
@@ -68,8 +72,10 @@ def test_join_association(small_sky_catalog, small_sky_xmatch_catalog, small_sky
         joined = small_sky_catalog.join(
             small_sky_xmatch_catalog, through=small_sky_to_xmatch_catalog, suffixes=suffixes
         )
+        assert isinstance(joined._ddf, NestedFrame)
     assert joined._ddf.npartitions == len(small_sky_to_xmatch_catalog.hc_structure.join_info.data_frame)
     joined_data = joined.compute()
+    assert isinstance(joined_data, npd.NestedFrame)
     association_data = small_sky_to_xmatch_catalog.compute()
     assert len(joined_data) == len(association_data)
 

--- a/tests/lsdb/catalog/test_join.py
+++ b/tests/lsdb/catalog/test_join.py
@@ -188,7 +188,6 @@ def test_join_source_margin_soft(
 
 
 def test_join_nested(small_sky_catalog, small_sky_order1_source_with_margin, assert_divisions_are_correct):
-    suffixes = ("_a", "_b")
     joined = small_sky_catalog.join_nested(
         small_sky_order1_source_with_margin,
         left_on="id",
@@ -205,10 +204,10 @@ def test_join_nested(small_sky_catalog, small_sky_order1_source_with_margin, ass
     source_compute = small_sky_order1_source_with_margin.compute()
     assert isinstance(joined_compute, npd.NestedFrame)
     for _, row in joined_compute.iterrows():
-        id = row["id"]
+        row_id = row["id"]
         pd.testing.assert_frame_equal(
             row["sources"].sort_values("source_ra").reset_index(drop=True),
-            pd.DataFrame(source_compute[source_compute["object_id"] == id].set_index("object_id"))
+            pd.DataFrame(source_compute[source_compute["object_id"] == row_id].set_index("object_id"))
             .sort_values("source_ra")
             .reset_index(drop=True),
             check_dtype=False,

--- a/tests/lsdb/catalog/test_join.py
+++ b/tests/lsdb/catalog/test_join.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
-from nested_dask import NestedFrame
+import nested_dask as nd
 
 
 def test_small_sky_join_small_sky_order1(
@@ -14,7 +14,7 @@ def test_small_sky_join_small_sky_order1(
         joined = small_sky_catalog.join(
             small_sky_order1_catalog, left_on="id", right_on="id", suffixes=suffixes
         )
-        assert isinstance(joined._ddf, NestedFrame)
+        assert isinstance(joined._ddf, nd.NestedFrame)
     for col_name, dtype in small_sky_catalog.dtypes.items():
         assert (col_name + suffixes[0], dtype) in joined.dtypes.items()
     for col_name, dtype in small_sky_order1_catalog.dtypes.items():
@@ -72,7 +72,7 @@ def test_join_association(small_sky_catalog, small_sky_xmatch_catalog, small_sky
         joined = small_sky_catalog.join(
             small_sky_xmatch_catalog, through=small_sky_to_xmatch_catalog, suffixes=suffixes
         )
-        assert isinstance(joined._ddf, NestedFrame)
+        assert isinstance(joined._ddf, nd.NestedFrame)
     assert joined._ddf.npartitions == len(small_sky_to_xmatch_catalog.hc_structure.join_info.data_frame)
     joined_data = joined.compute()
     assert isinstance(joined_data, npd.NestedFrame)

--- a/tests/lsdb/catalog/test_join.py
+++ b/tests/lsdb/catalog/test_join.py
@@ -207,6 +207,11 @@ def test_join_nested(small_sky_catalog, small_sky_order1_source_with_margin, ass
     for _, row in joined_compute.iterrows():
         id = row["id"]
         pd.testing.assert_frame_equal(
-            row["sources"],
-            pd.DataFrame(source_compute[source_compute["object_id"] == id].set_index("object_id")),
+            row["sources"].sort_values("source_ra").reset_index(drop=True),
+            pd.DataFrame(source_compute[source_compute["object_id"] == id].set_index("object_id"))
+            .sort_values("source_ra")
+            .reset_index(drop=True),
+            check_dtype=False,
+            check_column_type=False,
+            check_index_type=False,
         )

--- a/tests/lsdb/catalog/test_join.py
+++ b/tests/lsdb/catalog/test_join.py
@@ -1,9 +1,9 @@
+import nested_dask as nd
 import nested_pandas as npd
 import numpy as np
 import pandas as pd
 import pytest
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
-import nested_dask as nd
 
 
 def test_small_sky_join_small_sky_order1(

--- a/tests/lsdb/catalog/test_margin_catalog.py
+++ b/tests/lsdb/catalog/test_margin_catalog.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
 import hipscat as hc
-import pandas as pd
 import nested_dask as nd
+import pandas as pd
 
 import lsdb
 from lsdb.catalog.margin_catalog import MarginCatalog

--- a/tests/lsdb/catalog/test_margin_catalog.py
+++ b/tests/lsdb/catalog/test_margin_catalog.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import hipscat as hc
 import pandas as pd
-from nested_dask import NestedFrame
+import nested_dask as nd
 
 import lsdb
 from lsdb.catalog.margin_catalog import MarginCatalog
@@ -11,7 +11,7 @@ from lsdb.catalog.margin_catalog import MarginCatalog
 def test_read_margin_catalog(small_sky_xmatch_margin_dir):
     margin = lsdb.read_hipscat(small_sky_xmatch_margin_dir)
     assert isinstance(margin, MarginCatalog)
-    assert isinstance(margin._ddf, NestedFrame)
+    assert isinstance(margin._ddf, nd.NestedFrame)
     hc_margin = hc.catalog.MarginCatalog.read_from_hipscat(small_sky_xmatch_margin_dir)
     assert margin.hc_structure.catalog_info == hc_margin.catalog_info
     assert margin.hc_structure.get_healpix_pixels() == hc_margin.get_healpix_pixels()

--- a/tests/lsdb/catalog/test_margin_catalog.py
+++ b/tests/lsdb/catalog/test_margin_catalog.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import hipscat as hc
 import pandas as pd
+from nested_dask import NestedFrame
 
 import lsdb
 from lsdb.catalog.margin_catalog import MarginCatalog
@@ -10,6 +11,7 @@ from lsdb.catalog.margin_catalog import MarginCatalog
 def test_read_margin_catalog(small_sky_xmatch_margin_dir):
     margin = lsdb.read_hipscat(small_sky_xmatch_margin_dir)
     assert isinstance(margin, MarginCatalog)
+    assert isinstance(margin._ddf, NestedFrame)
     hc_margin = hc.catalog.MarginCatalog.read_from_hipscat(small_sky_xmatch_margin_dir)
     assert margin.hc_structure.catalog_info == hc_margin.catalog_info
     assert margin.hc_structure.get_healpix_pixels() == hc_margin.get_healpix_pixels()

--- a/tests/lsdb/catalog/test_merge.py
+++ b/tests/lsdb/catalog/test_merge.py
@@ -1,6 +1,6 @@
+import nested_dask as nd
 import pandas as pd
 import pytest
-import nested_dask as nd
 
 
 @pytest.mark.parametrize("how", ["left", "right", "inner", "outer"])

--- a/tests/lsdb/catalog/test_merge.py
+++ b/tests/lsdb/catalog/test_merge.py
@@ -10,10 +10,10 @@ def test_catalog_merge_on_indices(small_sky_catalog, small_sky_order1_catalog, h
     small_sky_catalog._ddf = small_sky_catalog._ddf.set_index("id")
     small_sky_order1_catalog._ddf = small_sky_order1_catalog._ddf.set_index("id")
     # The wrapper outputs the same result as the underlying pandas merge
-    merged_ddf = small_sky_catalog.merge(small_sky_order1_catalog, **kwargs)
-    assert isinstance(merged_ddf, nd.NestedFrame)
+    merged_ndf = small_sky_catalog.merge(small_sky_order1_catalog, **kwargs)
+    assert isinstance(merged_ndf, nd.NestedFrame)
     expected_df = small_sky_catalog._ddf.merge(small_sky_order1_catalog._ddf, **kwargs)
-    pd.testing.assert_frame_equal(expected_df.compute(), merged_ddf.compute())
+    pd.testing.assert_frame_equal(expected_df.compute(), merged_ndf.compute())
 
 
 @pytest.mark.parametrize("how", ["left", "right", "inner", "outer"])

--- a/tests/lsdb/catalog/test_merge.py
+++ b/tests/lsdb/catalog/test_merge.py
@@ -1,6 +1,7 @@
 import dask.dataframe as dd
 import pandas as pd
 import pytest
+from nested_dask import NestedFrame
 
 
 @pytest.mark.parametrize("how", ["left", "right", "inner", "outer"])
@@ -11,7 +12,7 @@ def test_catalog_merge_on_indices(small_sky_catalog, small_sky_order1_catalog, h
     small_sky_order1_catalog._ddf = small_sky_order1_catalog._ddf.set_index("id")
     # The wrapper outputs the same result as the underlying pandas merge
     merged_ddf = small_sky_catalog.merge(small_sky_order1_catalog, **kwargs)
-    assert isinstance(merged_ddf, dd.DataFrame)
+    assert isinstance(merged_ddf, NestedFrame)
     expected_df = small_sky_catalog._ddf.merge(small_sky_order1_catalog._ddf, **kwargs)
     pd.testing.assert_frame_equal(expected_df.compute(), merged_ddf.compute())
 
@@ -24,7 +25,7 @@ def test_catalog_merge_on_columns(small_sky_catalog, small_sky_order1_catalog, h
     small_sky_order1_catalog._ddf = small_sky_order1_catalog._ddf.reset_index()
     # The wrapper outputs the same result as the underlying pandas merge
     merged_ddf = small_sky_catalog.merge(small_sky_order1_catalog, **kwargs)
-    assert isinstance(merged_ddf, dd.DataFrame)
+    assert isinstance(merged_ddf, NestedFrame)
     expected_df = small_sky_catalog._ddf.merge(small_sky_order1_catalog._ddf, **kwargs)
     pd.testing.assert_frame_equal(expected_df.compute(), merged_ddf.compute())
 
@@ -38,7 +39,7 @@ def test_catalog_merge_on_index_and_column(small_sky_catalog, small_sky_order1_c
     small_sky_order1_catalog._ddf = small_sky_order1_catalog._ddf.reset_index()
     # The wrapper outputs the same result as the underlying pandas merge
     merged_ddf = small_sky_catalog.merge(small_sky_order1_catalog, **kwargs)
-    assert isinstance(merged_ddf, dd.DataFrame)
+    assert isinstance(merged_ddf, NestedFrame)
     expected_df = small_sky_catalog._ddf.merge(small_sky_order1_catalog._ddf, **kwargs)
     pd.testing.assert_frame_equal(expected_df.compute(), merged_ddf.compute())
 
@@ -52,7 +53,7 @@ def test_catalog_merge_invalid_suffixes(small_sky_catalog, small_sky_order1_cata
 
 def test_catalog_merge_no_suffixes(small_sky_catalog, small_sky_order1_catalog):
     merged_ddf = small_sky_catalog.merge(small_sky_order1_catalog, how="inner", on="id")
-    assert isinstance(merged_ddf, dd.DataFrame)
+    assert isinstance(merged_ddf, NestedFrame)
     # Get the columns with the same name in both catalogs
     non_join_columns_left = small_sky_catalog._ddf.columns.drop("id")
     non_join_columns_right = small_sky_order1_catalog._ddf.columns.drop("id")

--- a/tests/lsdb/catalog/test_merge.py
+++ b/tests/lsdb/catalog/test_merge.py
@@ -1,4 +1,3 @@
-import dask.dataframe as dd
 import pandas as pd
 import pytest
 from nested_dask import NestedFrame

--- a/tests/lsdb/catalog/test_merge.py
+++ b/tests/lsdb/catalog/test_merge.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import pytest
-from nested_dask import NestedFrame
+import nested_dask as nd
 
 
 @pytest.mark.parametrize("how", ["left", "right", "inner", "outer"])
@@ -11,7 +11,7 @@ def test_catalog_merge_on_indices(small_sky_catalog, small_sky_order1_catalog, h
     small_sky_order1_catalog._ddf = small_sky_order1_catalog._ddf.set_index("id")
     # The wrapper outputs the same result as the underlying pandas merge
     merged_ddf = small_sky_catalog.merge(small_sky_order1_catalog, **kwargs)
-    assert isinstance(merged_ddf, NestedFrame)
+    assert isinstance(merged_ddf, nd.NestedFrame)
     expected_df = small_sky_catalog._ddf.merge(small_sky_order1_catalog._ddf, **kwargs)
     pd.testing.assert_frame_equal(expected_df.compute(), merged_ddf.compute())
 
@@ -24,7 +24,7 @@ def test_catalog_merge_on_columns(small_sky_catalog, small_sky_order1_catalog, h
     small_sky_order1_catalog._ddf = small_sky_order1_catalog._ddf.reset_index()
     # The wrapper outputs the same result as the underlying pandas merge
     merged_ddf = small_sky_catalog.merge(small_sky_order1_catalog, **kwargs)
-    assert isinstance(merged_ddf, NestedFrame)
+    assert isinstance(merged_ddf, nd.NestedFrame)
     expected_df = small_sky_catalog._ddf.merge(small_sky_order1_catalog._ddf, **kwargs)
     pd.testing.assert_frame_equal(expected_df.compute(), merged_ddf.compute())
 
@@ -38,7 +38,7 @@ def test_catalog_merge_on_index_and_column(small_sky_catalog, small_sky_order1_c
     small_sky_order1_catalog._ddf = small_sky_order1_catalog._ddf.reset_index()
     # The wrapper outputs the same result as the underlying pandas merge
     merged_ddf = small_sky_catalog.merge(small_sky_order1_catalog, **kwargs)
-    assert isinstance(merged_ddf, NestedFrame)
+    assert isinstance(merged_ddf, nd.NestedFrame)
     expected_df = small_sky_catalog._ddf.merge(small_sky_order1_catalog._ddf, **kwargs)
     pd.testing.assert_frame_equal(expected_df.compute(), merged_ddf.compute())
 
@@ -52,7 +52,7 @@ def test_catalog_merge_invalid_suffixes(small_sky_catalog, small_sky_order1_cata
 
 def test_catalog_merge_no_suffixes(small_sky_catalog, small_sky_order1_catalog):
     merged_ddf = small_sky_catalog.merge(small_sky_order1_catalog, how="inner", on="id")
-    assert isinstance(merged_ddf, NestedFrame)
+    assert isinstance(merged_ddf, nd.NestedFrame)
     # Get the columns with the same name in both catalogs
     non_join_columns_left = small_sky_catalog._ddf.columns.drop("id")
     non_join_columns_right = small_sky_order1_catalog._ddf.columns.drop("id")

--- a/tests/lsdb/catalog/test_order_search.py
+++ b/tests/lsdb/catalog/test_order_search.py
@@ -1,11 +1,13 @@
 import pandas as pd
 import pytest
+from nested_dask import NestedFrame
 
 from lsdb.core.search import OrderSearch
 
 
 def test_order_search_filters_correct_pixels(small_sky_source_catalog, assert_divisions_are_correct):
     order_search_catalog = small_sky_source_catalog.order_search(min_order=1, max_order=1)
+    assert isinstance(order_search_catalog._ddf, NestedFrame)
     pixel_orders = [pixel.order for pixel in order_search_catalog.get_healpix_pixels()]
     assert all(order == 1 for order in pixel_orders)
     assert_divisions_are_correct(order_search_catalog)

--- a/tests/lsdb/catalog/test_order_search.py
+++ b/tests/lsdb/catalog/test_order_search.py
@@ -1,6 +1,6 @@
+import nested_dask as nd
 import pandas as pd
 import pytest
-import nested_dask as nd
 
 from lsdb.core.search import OrderSearch
 

--- a/tests/lsdb/catalog/test_order_search.py
+++ b/tests/lsdb/catalog/test_order_search.py
@@ -1,13 +1,13 @@
 import pandas as pd
 import pytest
-from nested_dask import NestedFrame
+import nested_dask as nd
 
 from lsdb.core.search import OrderSearch
 
 
 def test_order_search_filters_correct_pixels(small_sky_source_catalog, assert_divisions_are_correct):
     order_search_catalog = small_sky_source_catalog.order_search(min_order=1, max_order=1)
-    assert isinstance(order_search_catalog._ddf, NestedFrame)
+    assert isinstance(order_search_catalog._ddf, nd.NestedFrame)
     pixel_orders = [pixel.order for pixel in order_search_catalog.get_healpix_pixels()]
     assert all(order == 1 for order in pixel_orders)
     assert_divisions_are_correct(order_search_catalog)

--- a/tests/lsdb/catalog/test_pixel_search.py
+++ b/tests/lsdb/catalog/test_pixel_search.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from hipscat.pixel_math import HealpixPixel
+from nested_dask import NestedFrame
 
 from lsdb.core.search.pixel_search import PixelSearch
 
@@ -7,6 +8,7 @@ from lsdb.core.search.pixel_search import PixelSearch
 def test_pixel_search(small_sky_catalog, small_sky_order1_catalog):
     # Searching for pixels at a higher order
     catalog = small_sky_catalog.pixel_search([(1, 44), (1, 45)])
+    assert isinstance(catalog._ddf, NestedFrame)
     assert 1 == len(catalog._ddf_pixel_map)
     assert [HealpixPixel(0, 11)] == catalog.get_healpix_pixels()
     # Searching for pixels at a lower order

--- a/tests/lsdb/catalog/test_pixel_search.py
+++ b/tests/lsdb/catalog/test_pixel_search.py
@@ -1,6 +1,6 @@
+import nested_dask as nd
 import pandas as pd
 from hipscat.pixel_math import HealpixPixel
-import nested_dask as nd
 
 from lsdb.core.search.pixel_search import PixelSearch
 

--- a/tests/lsdb/catalog/test_pixel_search.py
+++ b/tests/lsdb/catalog/test_pixel_search.py
@@ -1,6 +1,6 @@
 import pandas as pd
 from hipscat.pixel_math import HealpixPixel
-from nested_dask import NestedFrame
+import nested_dask as nd
 
 from lsdb.core.search.pixel_search import PixelSearch
 
@@ -8,7 +8,7 @@ from lsdb.core.search.pixel_search import PixelSearch
 def test_pixel_search(small_sky_catalog, small_sky_order1_catalog):
     # Searching for pixels at a higher order
     catalog = small_sky_catalog.pixel_search([(1, 44), (1, 45)])
-    assert isinstance(catalog._ddf, NestedFrame)
+    assert isinstance(catalog._ddf, nd.NestedFrame)
     assert 1 == len(catalog._ddf_pixel_map)
     assert [HealpixPixel(0, 11)] == catalog.get_healpix_pixels()
     # Searching for pixels at a lower order

--- a/tests/lsdb/catalog/test_polygon_search.py
+++ b/tests/lsdb/catalog/test_polygon_search.py
@@ -1,9 +1,9 @@
+import nested_dask as nd
 import nested_pandas as npd
 import numpy as np
 import numpy.testing as npt
 import pytest
 from hipscat.pixel_math.validators import ValidatorsErrors
-import nested_dask as nd
 
 from lsdb.core.search.polygon_search import get_cartesian_polygon
 

--- a/tests/lsdb/catalog/test_polygon_search.py
+++ b/tests/lsdb/catalog/test_polygon_search.py
@@ -3,7 +3,7 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 from hipscat.pixel_math.validators import ValidatorsErrors
-from nested_dask import NestedFrame
+import nested_dask as nd
 
 from lsdb.core.search.polygon_search import get_cartesian_polygon
 
@@ -12,7 +12,7 @@ def test_polygon_search_filters_correct_points(small_sky_order1_catalog, assert_
     vertices = [(300, -50), (300, -55), (272, -55), (272, -50)]
     polygon, _ = get_cartesian_polygon(vertices)
     polygon_search_catalog = small_sky_order1_catalog.polygon_search(vertices)
-    assert isinstance(polygon_search_catalog._ddf, NestedFrame)
+    assert isinstance(polygon_search_catalog._ddf, nd.NestedFrame)
     polygon_search_df = polygon_search_catalog.compute()
     assert isinstance(polygon_search_df, npd.NestedFrame)
     ra_values_radians = np.radians(

--- a/tests/lsdb/catalog/test_polygon_search.py
+++ b/tests/lsdb/catalog/test_polygon_search.py
@@ -1,7 +1,9 @@
+import nested_pandas as npd
 import numpy as np
 import numpy.testing as npt
 import pytest
 from hipscat.pixel_math.validators import ValidatorsErrors
+from nested_dask import NestedFrame
 
 from lsdb.core.search.polygon_search import get_cartesian_polygon
 
@@ -10,7 +12,9 @@ def test_polygon_search_filters_correct_points(small_sky_order1_catalog, assert_
     vertices = [(300, -50), (300, -55), (272, -55), (272, -50)]
     polygon, _ = get_cartesian_polygon(vertices)
     polygon_search_catalog = small_sky_order1_catalog.polygon_search(vertices)
+    assert isinstance(polygon_search_catalog._ddf, NestedFrame)
     polygon_search_df = polygon_search_catalog.compute()
+    assert isinstance(polygon_search_df, npd.NestedFrame)
     ra_values_radians = np.radians(
         polygon_search_df[small_sky_order1_catalog.hc_structure.catalog_info.ra_column]
     )

--- a/tests/lsdb/loaders/dataframe/test_from_dataframe.py
+++ b/tests/lsdb/loaders/dataframe/test_from_dataframe.py
@@ -12,7 +12,7 @@ from hipscat.catalog import CatalogType
 from hipscat.pixel_math.healpix_pixel_function import get_pixel_argsort
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
 from mocpy import MOC
-from nested_dask import NestedFrame
+import nested_dask as nd
 
 import lsdb
 from lsdb.catalog.margin_catalog import MarginCatalog
@@ -42,7 +42,7 @@ def test_from_dataframe(
     # Read CSV file for the small sky order 1 catalog
     catalog = lsdb.from_dataframe(small_sky_order1_df, margin_threshold=None, **kwargs)
     assert isinstance(catalog, lsdb.Catalog)
-    assert isinstance(catalog._ddf, NestedFrame)
+    assert isinstance(catalog._ddf, nd.NestedFrame)
     # Catalogs have the same information
     assert catalog.hc_structure.catalog_info == small_sky_order1_catalog.hc_structure.catalog_info
     # Index is set to hipscat index
@@ -224,7 +224,7 @@ def test_from_dataframe_small_sky_source_with_margins(small_sky_source_df, small
 
     assert catalog.margin is not None
     assert isinstance(catalog.margin, MarginCatalog)
-    assert isinstance(catalog.margin._ddf, NestedFrame)
+    assert isinstance(catalog.margin._ddf, nd.NestedFrame)
     assert catalog.margin.get_healpix_pixels() == small_sky_source_margin_catalog.get_healpix_pixels()
 
     # The points of this margin catalog are present in one partition only

--- a/tests/lsdb/loaders/dataframe/test_from_dataframe.py
+++ b/tests/lsdb/loaders/dataframe/test_from_dataframe.py
@@ -1,9 +1,9 @@
-import nested_pandas as npd
 import math
 
 import astropy.units as u
 import healpy as hp
 import hipscat as hc
+import nested_pandas as npd
 import numpy as np
 import numpy.testing as npt
 import pandas as pd

--- a/tests/lsdb/loaders/dataframe/test_from_dataframe.py
+++ b/tests/lsdb/loaders/dataframe/test_from_dataframe.py
@@ -3,6 +3,7 @@ import math
 import astropy.units as u
 import healpy as hp
 import hipscat as hc
+import nested_dask as nd
 import nested_pandas as npd
 import numpy as np
 import numpy.testing as npt
@@ -12,7 +13,6 @@ from hipscat.catalog import CatalogType
 from hipscat.pixel_math.healpix_pixel_function import get_pixel_argsort
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
 from mocpy import MOC
-import nested_dask as nd
 
 import lsdb
 from lsdb.catalog.margin_catalog import MarginCatalog

--- a/tests/lsdb/loaders/hipscat/test_read_hipscat.py
+++ b/tests/lsdb/loaders/hipscat/test_read_hipscat.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import hipscat as hc
+import nested_dask as nd
 import nested_pandas as npd
 import numpy as np
 import numpy.testing as npt
@@ -9,7 +10,6 @@ import pytest
 from hipscat.catalog.index.index_catalog import IndexCatalog
 from hipscat.io import get_file_pointer_from_path
 from hipscat.pixel_math import HealpixPixel
-import nested_dask as nd
 from pandas.core.dtypes.base import ExtensionDtype
 
 import lsdb

--- a/tests/lsdb/loaders/hipscat/test_read_hipscat.py
+++ b/tests/lsdb/loaders/hipscat/test_read_hipscat.py
@@ -9,7 +9,7 @@ import pytest
 from hipscat.catalog.index.index_catalog import IndexCatalog
 from hipscat.io import get_file_pointer_from_path
 from hipscat.pixel_math import HealpixPixel
-from nested_dask import NestedFrame
+import nested_dask as nd
 from pandas.core.dtypes.base import ExtensionDtype
 
 import lsdb
@@ -19,7 +19,7 @@ from lsdb.core.search import BoxSearch, ConeSearch, IndexSearch, OrderSearch, Po
 def test_read_hipscat(small_sky_order1_dir, small_sky_order1_hipscat_catalog, assert_divisions_are_correct):
     catalog = lsdb.read_hipscat(small_sky_order1_dir)
     assert isinstance(catalog, lsdb.Catalog)
-    assert isinstance(catalog._ddf, NestedFrame)
+    assert isinstance(catalog._ddf, nd.NestedFrame)
     assert catalog.hc_structure.catalog_base_dir == small_sky_order1_hipscat_catalog.catalog_base_dir
     assert catalog.get_healpix_pixels() == small_sky_order1_hipscat_catalog.get_healpix_pixels()
     assert len(catalog.compute().columns) == 8
@@ -69,7 +69,7 @@ def test_parquet_data_in_partitions_match_files(small_sky_order1_dir, small_sky_
 def test_read_hipscat_specify_catalog_type(small_sky_catalog, small_sky_dir):
     catalog = lsdb.read_hipscat(small_sky_dir, catalog_type=lsdb.Catalog)
     assert isinstance(catalog, lsdb.Catalog)
-    assert isinstance(catalog._ddf, NestedFrame)
+    assert isinstance(catalog._ddf, nd.NestedFrame)
     pd.testing.assert_frame_equal(catalog.compute(), small_sky_catalog.compute())
     assert catalog.get_healpix_pixels() == small_sky_catalog.get_healpix_pixels()
     assert catalog.hc_structure.catalog_info == small_sky_catalog.hc_structure.catalog_info
@@ -85,9 +85,9 @@ def test_catalog_with_margin_object(small_sky_xmatch_dir, small_sky_xmatch_margi
     catalog = lsdb.read_hipscat(small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_catalog)
     assert isinstance(catalog, lsdb.Catalog)
     assert isinstance(catalog.margin, lsdb.MarginCatalog)
-    assert isinstance(catalog._ddf, NestedFrame)
+    assert isinstance(catalog._ddf, nd.NestedFrame)
     assert catalog.margin is small_sky_xmatch_margin_catalog
-    assert isinstance(catalog.margin._ddf, NestedFrame)
+    assert isinstance(catalog.margin._ddf, nd.NestedFrame)
 
 
 def test_catalog_with_margin_file_pointer(
@@ -97,8 +97,8 @@ def test_catalog_with_margin_file_pointer(
     catalog = lsdb.read_hipscat(small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_fp)
     assert isinstance(catalog, lsdb.Catalog)
     assert isinstance(catalog.margin, lsdb.MarginCatalog)
-    assert isinstance(catalog._ddf, NestedFrame)
-    assert isinstance(catalog.margin._ddf, NestedFrame)
+    assert isinstance(catalog._ddf, nd.NestedFrame)
+    assert isinstance(catalog.margin._ddf, nd.NestedFrame)
     assert (
         catalog.margin.hc_structure.catalog_info == small_sky_xmatch_margin_catalog.hc_structure.catalog_info
     )
@@ -113,8 +113,8 @@ def test_catalog_with_margin_path(
     catalog = lsdb.read_hipscat(small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_dir)
     assert isinstance(catalog, lsdb.Catalog)
     assert isinstance(catalog.margin, lsdb.MarginCatalog)
-    assert isinstance(catalog._ddf, NestedFrame)
-    assert isinstance(catalog.margin._ddf, NestedFrame)
+    assert isinstance(catalog._ddf, nd.NestedFrame)
+    assert isinstance(catalog.margin._ddf, nd.NestedFrame)
     assert (
         catalog.margin.hc_structure.catalog_info == small_sky_xmatch_margin_catalog.hc_structure.catalog_info
     )
@@ -233,7 +233,7 @@ def test_read_hipscat_with_backend(small_sky_dir):
     catalog = lsdb.read_hipscat(small_sky_dir, dtype_backend=None)
     assert all(isinstance(col_type, np.dtype) for col_type in catalog.dtypes)
 
-    assert isinstance(catalog._ddf, NestedFrame)
+    assert isinstance(catalog._ddf, nd.NestedFrame)
     assert isinstance(catalog.compute(), npd.NestedFrame)
 
 

--- a/tests/lsdb/loaders/hipscat/test_read_hipscat.py
+++ b/tests/lsdb/loaders/hipscat/test_read_hipscat.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
-import nested_pandas as npd
 import hipscat as hc
+import nested_pandas as npd
 import numpy as np
 import numpy.testing as npt
 import pandas as pd


### PR DESCRIPTION
Replaces usage of dask.dataframe with nested_dask.NestedFrame, and pd.DataFrame with nested_pandas.NestedFrame. Adds `join_nested` method to catalog to join another catalog as a nested column.

Closes #367