### PR TITLE
Allow `margin_cache` provided with PosixPath

### DIFF
--- a/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
+++ b/src/lsdb/loaders/hipscat/hipscat_catalog_loader.py
@@ -52,7 +52,7 @@ class HipscatCatalogLoader(AbstractCatalogLoader[Catalog]):
             if self.config.search_filter is not None:
                 # pylint: disable=protected-access
                 margin_catalog = margin_catalog.search(self.config.search_filter)
-        elif isinstance(self.config.margin_cache, str):
+        elif self.config.margin_cache is not None:
             margin_catalog = lsdb.read_hipscat(
                 path=self.config.margin_cache,
                 catalog_type=MarginCatalog,

--- a/src/lsdb/loaders/hipscat/hipscat_loading_config.py
+++ b/src/lsdb/loaders/hipscat/hipscat_loading_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Callable, List
 
 import pandas as pd
@@ -24,7 +25,7 @@ class HipscatLoadingConfig:
     columns: List[str] | None = None
     """Columns to load from the catalog. If not specified, all columns are loaded"""
 
-    margin_cache: MarginCatalog | FilePointer | None = None
+    margin_cache: MarginCatalog | FilePointer | Path | None = None
     """Margin cache for the catalog. It can be provided as a path for the margin on disk,
     or as a margin object instance. By default, it is None."""
 

--- a/src/lsdb/loaders/hipscat/read_hipscat.py
+++ b/src/lsdb/loaders/hipscat/read_hipscat.py
@@ -53,7 +53,7 @@ def read_hipscat(
         )
 
     Args:
-        path (FilePointer): The path that locates the root of the HiPSCat catalog
+        path (FilePointer | Path): The path that locates the root of the HiPSCat catalog
         catalog_type (Type[Dataset]): Default `None`. By default, the type of the catalog is loaded
             from the catalog info and the corresponding object type is returned. Python's type hints
             cannot allow a return type specified by a loaded value, so to use the correct return
@@ -71,18 +71,19 @@ def read_hipscat(
     Returns:
         Catalog object loaded from the given parameters
     """
+    path_str = str(path)
 
     # Creates a config object to store loading parameters from all keyword arguments.
     kwd_args = locals().copy()
     config_args = {field.name: kwd_args[field.name] for field in dataclasses.fields(HipscatLoadingConfig)}
     config = HipscatLoadingConfig(**config_args)
 
-    catalog_type_to_use = _get_dataset_class_from_catalog_info(path, storage_options=storage_options)
+    catalog_type_to_use = _get_dataset_class_from_catalog_info(path_str, storage_options=storage_options)
 
     if catalog_type is not None:
         catalog_type_to_use = catalog_type
 
-    loader = get_loader_for_type(catalog_type_to_use, path, config, storage_options=storage_options)
+    loader = get_loader_for_type(catalog_type_to_use, path_str, config, storage_options=storage_options)
     return loader.load_catalog()
 
 

--- a/src/lsdb/loaders/hipscat/read_hipscat.py
+++ b/src/lsdb/loaders/hipscat/read_hipscat.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+from pathlib import Path
 from typing import Any, Dict, List, Type, Union
 
 import hipscat as hc
@@ -27,11 +28,11 @@ dataset_class_for_catalog_type: Dict[CatalogType, Type[Dataset]] = {
 
 # pylint: disable=unused-argument
 def read_hipscat(
-    path: FilePointer,
+    path: FilePointer | Path,
     catalog_type: Type[CatalogTypeVar] | None = None,
     search_filter: AbstractSearch | None = None,
     columns: List[str] | None = None,
-    margin_cache: MarginCatalog | FilePointer | None = None,
+    margin_cache: MarginCatalog | FilePointer | Path | None = None,
     dtype_backend: str | None = "pyarrow",
     storage_options: dict | None = None,
     **kwargs,
@@ -60,8 +61,8 @@ def read_hipscat(
             the lsdb class for that catalog.
         search_filter (Type[AbstractSearch]): Default `None`. The filter method to be applied.
         columns (List[str]): Default `None`. The set of columns to filter the catalog on.
-        margin_cache (MarginCatalog | FilePointer): The margin cache for the main catalog, provided
-            as a path on disk or as an instance of the MarginCatalog object. Defaults to None.
+        margin_cache (MarginCatalog | FilePointer | Path): The margin cache for the main catalog,
+            provided as a path on disk or as an instance of the MarginCatalog object. Defaults to None.
         dtype_backend (str): Backend data type to apply to the catalog.
             Defaults to "pyarrow". If None, no type conversion is performed.
         storage_options (dict): Dictionary that contains abstract filesystem credentials

--- a/src/lsdb/loaders/hipscat/read_hipscat.pyi
+++ b/src/lsdb/loaders/hipscat/read_hipscat.pyi
@@ -13,6 +13,7 @@ For more information on stub files, view here: https://mypy.readthedocs.io/en/st
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import List, Type, overload
 
 from hipscat.io.file_io import FilePointer
@@ -27,7 +28,7 @@ def read_hipscat(
     path: FilePointer,
     search_filter: AbstractSearch | None = None,
     columns: List[str] | None = None,
-    margin_cache: MarginCatalog | FilePointer | None = None,
+    margin_cache: MarginCatalog | FilePointer | Path | None = None,
     dtype_backend: str | None = "pyarrow",
     storage_options: dict | None = None,
     **kwargs,
@@ -38,7 +39,7 @@ def read_hipscat(
     catalog_type: Type[CatalogTypeVar],
     search_filter: AbstractSearch | None = None,
     columns: List[str] | None = None,
-    margin_cache: MarginCatalog | FilePointer | None = None,
+    margin_cache: MarginCatalog | FilePointer | Path | None = None,
     dtype_backend: str | None = "pyarrow",
     storage_options: dict | None = None,
     **kwargs,

--- a/src/lsdb/loaders/hipscat/read_hipscat.pyi
+++ b/src/lsdb/loaders/hipscat/read_hipscat.pyi
@@ -25,7 +25,7 @@ from lsdb.loaders.hipscat.abstract_catalog_loader import CatalogTypeVar
 
 @overload
 def read_hipscat(
-    path: FilePointer,
+    path: FilePointer | Path,
     search_filter: AbstractSearch | None = None,
     columns: List[str] | None = None,
     margin_cache: MarginCatalog | FilePointer | Path | None = None,
@@ -35,7 +35,7 @@ def read_hipscat(
 ) -> Dataset | None: ...
 @overload
 def read_hipscat(
-    path: str,
+    path: FilePointer | Path,
     catalog_type: Type[CatalogTypeVar],
     search_filter: AbstractSearch | None = None,
     columns: List[str] | None = None,

--- a/tests/lsdb/loaders/hipscat/test_read_hipscat.py
+++ b/tests/lsdb/loaders/hipscat/test_read_hipscat.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import hipscat as hc
 import numpy as np
 import numpy.testing as npt
@@ -72,23 +74,38 @@ def test_read_hipscat_specify_wrong_catalog_type(small_sky_dir):
         lsdb.read_hipscat(small_sky_dir, catalog_type=int)
 
 
-def test_catalog_with_margin(
-    small_sky_xmatch_dir, small_sky_xmatch_margin_catalog, small_sky_xmatch_margin_dir
-):
-    # Provide the margin cache catalog object
+def test_catalog_with_margin_object(small_sky_xmatch_dir, small_sky_xmatch_margin_catalog):
     catalog = lsdb.read_hipscat(small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_catalog)
     assert isinstance(catalog, lsdb.Catalog)
+    assert isinstance(catalog.margin, lsdb.MarginCatalog)
     assert catalog.margin is small_sky_xmatch_margin_catalog
-    # Provide the margin cache catalog path
-    catalog_2 = lsdb.read_hipscat(small_sky_xmatch_dir, margin_cache=str(small_sky_xmatch_margin_dir))
-    assert isinstance(catalog_2, lsdb.Catalog)
-    # Which can also be provided with a Path object
-    catalog_3 = lsdb.read_hipscat(small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_dir)
-    assert isinstance(catalog_3, lsdb.Catalog)
-    # The catalogs obtained are identical
-    assert catalog.margin.hc_structure.catalog_info == catalog_2.margin.hc_structure.catalog_info
-    assert catalog.margin.get_healpix_pixels() == catalog_2.margin.get_healpix_pixels()
-    pd.testing.assert_frame_equal(catalog.margin.compute(), catalog_2.margin.compute())
+
+
+def test_catalog_with_margin_file_pointer(
+    small_sky_xmatch_dir, small_sky_xmatch_margin_dir, small_sky_xmatch_margin_catalog
+):
+    catalog = lsdb.read_hipscat(small_sky_xmatch_dir, margin_cache=str(small_sky_xmatch_margin_dir))
+    assert isinstance(catalog, lsdb.Catalog)
+    assert isinstance(catalog.margin, lsdb.MarginCatalog)
+    assert (
+        catalog.margin.hc_structure.catalog_info == small_sky_xmatch_margin_catalog.hc_structure.catalog_info
+    )
+    assert catalog.margin.get_healpix_pixels() == small_sky_xmatch_margin_catalog.get_healpix_pixels()
+    pd.testing.assert_frame_equal(catalog.margin.compute(), small_sky_xmatch_margin_catalog.compute())
+
+
+def test_catalog_with_margin_path(
+    small_sky_xmatch_dir, small_sky_xmatch_margin_dir, small_sky_xmatch_margin_catalog
+):
+    assert isinstance(small_sky_xmatch_margin_dir, Path)
+    catalog = lsdb.read_hipscat(small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_dir)
+    assert isinstance(catalog, lsdb.Catalog)
+    assert isinstance(catalog.margin, lsdb.MarginCatalog)
+    assert (
+        catalog.margin.hc_structure.catalog_info == small_sky_xmatch_margin_catalog.hc_structure.catalog_info
+    )
+    assert catalog.margin.get_healpix_pixels() == small_sky_xmatch_margin_catalog.get_healpix_pixels()
+    pd.testing.assert_frame_equal(catalog.margin.compute(), small_sky_xmatch_margin_catalog.compute())
 
 
 def test_catalog_without_margin_is_none(small_sky_xmatch_dir):

--- a/tests/lsdb/loaders/hipscat/test_read_hipscat.py
+++ b/tests/lsdb/loaders/hipscat/test_read_hipscat.py
@@ -6,6 +6,7 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 from hipscat.catalog.index.index_catalog import IndexCatalog
+from hipscat.io import get_file_pointer_from_path
 from hipscat.pixel_math import HealpixPixel
 from pandas.core.dtypes.base import ExtensionDtype
 
@@ -84,7 +85,8 @@ def test_catalog_with_margin_object(small_sky_xmatch_dir, small_sky_xmatch_margi
 def test_catalog_with_margin_file_pointer(
     small_sky_xmatch_dir, small_sky_xmatch_margin_dir, small_sky_xmatch_margin_catalog
 ):
-    catalog = lsdb.read_hipscat(small_sky_xmatch_dir, margin_cache=str(small_sky_xmatch_margin_dir))
+    small_sky_xmatch_margin_fp = get_file_pointer_from_path(str(small_sky_xmatch_margin_dir))
+    catalog = lsdb.read_hipscat(small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_fp)
     assert isinstance(catalog, lsdb.Catalog)
     assert isinstance(catalog.margin, lsdb.MarginCatalog)
     assert (


### PR DESCRIPTION
Allow `margin_cache` to be provided as a PosixPath object on `read_hipscat`. Closes #375. 