### PR TITLE
Use healpix shim for healpy operations.

### DIFF
--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -5,8 +5,8 @@ from typing import Any, Callable, Dict, Iterable, List, Tuple
 
 import dask
 import dask.dataframe as dd
-import healpy as hp
 import hipscat as hc
+import hipscat.pixel_math.healpix_shim as hp
 import nested_dask as nd
 import nested_pandas as npd
 import numpy as np
@@ -363,7 +363,7 @@ class HealpixDataset(Dataset):
         self,
         func: Callable[[npd.NestedFrame, HealpixPixel], Any],
         order: int | None = None,
-        default_value: Any = hp.pixelfunc.UNSEEN,
+        default_value: Any = hp.unseen_pixel(),
         projection="moll",
         plotting_args: Dict | None = None,
         **kwargs,

--- a/src/lsdb/core/plotting/skymap.py
+++ b/src/lsdb/core/plotting/skymap.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, Dict
 
-import healpy as hp
+import hipscat.pixel_math.healpix_shim as hp
 import nested_pandas as npd
 import numpy as np
 from dask import delayed

--- a/src/lsdb/core/search/polygon_search.py
+++ b/src/lsdb/core/search/polygon_search.py
@@ -1,6 +1,6 @@
 from typing import List, Tuple
 
-import healpy as hp
+import hipscat.pixel_math.healpix_shim as hp
 import nested_pandas as npd
 import numpy as np
 from hipscat.catalog.catalog_info import CatalogInfo

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable, List, Sequence, Tuple
 
-import healpy as hp
+import hipscat.pixel_math.healpix_shim as hp
 import nested_dask as nd
 import nested_pandas as npd
 import numpy as np

--- a/src/lsdb/loaders/dataframe/margin_catalog_generator.py
+++ b/src/lsdb/loaders/dataframe/margin_catalog_generator.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Dict, List, Tuple
 
-import healpy as hp
 import hipscat as hc
+import hipscat.pixel_math.healpix_shim as hp
 import nested_dask as nd
 import nested_pandas as npd
 import numpy as np

--- a/tests/lsdb/loaders/dataframe/test_from_dataframe.py
+++ b/tests/lsdb/loaders/dataframe/test_from_dataframe.py
@@ -1,8 +1,8 @@
 import math
 
 import astropy.units as u
-import healpy as hp
 import hipscat as hc
+import hipscat.pixel_math.healpix_shim as hp
 import nested_dask as nd
 import nested_pandas as npd
 import numpy as np


### PR DESCRIPTION
Uses hipscat's wrapper around healpy functions, to hopefully ease the migration off healpy.

Related to: https://github.com/astronomy-commons/hipscat/issues/53