### PR TITLE
Explode kwargs for ra and dec in `from_dataframe`

### DIFF
--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -37,6 +37,9 @@ class DataframeCatalogLoader:
     def __init__(
         self,
         dataframe: pd.DataFrame,
+        *,
+        ra_column: str = "ra",
+        dec_column: str = "dec",
         lowest_order: int = 0,
         highest_order: int = 7,
         drop_empty_siblings: bool = False,
@@ -52,6 +55,8 @@ class DataframeCatalogLoader:
 
         Args:
             dataframe (pd.Dataframe): Catalog Pandas Dataframe.
+            ra_column (str): The name of the right ascension column. Defaults to ra.
+            dec_column (str): The name of the declination column. Defaults to dec.
             lowest_order (int): The lowest partition order. Defaults to 3.
             highest_order (int): The highest partition order. Defaults to 7.
             drop_empty_siblings (bool): When determining final partitionining,
@@ -73,7 +78,7 @@ class DataframeCatalogLoader:
         self.highest_order = highest_order
         self.drop_empty_siblings = drop_empty_siblings
         self.threshold = self._calculate_threshold(partition_size, threshold)
-        self.catalog_info = self._create_catalog_info(**kwargs)
+        self.catalog_info = self._create_catalog_info(ra_column=ra_column, dec_column=dec_column, **kwargs)
         self.should_generate_moc = should_generate_moc
         self.moc_max_order = moc_max_order
         self.use_pyarrow_types = use_pyarrow_types

--- a/src/lsdb/loaders/dataframe/from_dataframe.py
+++ b/src/lsdb/loaders/dataframe/from_dataframe.py
@@ -12,6 +12,8 @@ from lsdb.loaders.dataframe.margin_catalog_generator import MarginCatalogGenerat
 def from_dataframe(
     dataframe: pd.DataFrame,
     *,
+    ra_column: str = "ra",
+    dec_column: str = "dec",
     lowest_order: int = 0,
     highest_order: int = 7,
     drop_empty_siblings: bool = False,
@@ -33,6 +35,8 @@ def from_dataframe(
 
     Args:
         dataframe (pd.Dataframe): The catalog Pandas Dataframe.
+        ra_column (str): The name of the right ascension column. Defaults to ra.
+        dec_column (str): The name of the declination column. Defaults to dec.
         lowest_order (int): The lowest partition order. Defaults to 0.
         highest_order (int): The highest partition order. Defaults to 7.
         drop_empty_siblings (bool): When determining final partitionining,
@@ -57,6 +61,8 @@ def from_dataframe(
     """
     catalog = DataframeCatalogLoader(
         dataframe,
+        ra_column=ra_column,
+        dec_column=dec_column,
         lowest_order=lowest_order,
         highest_order=highest_order,
         drop_empty_siblings=drop_empty_siblings,

--- a/src/lsdb/loaders/dataframe/margin_catalog_generator.py
+++ b/src/lsdb/loaders/dataframe/margin_catalog_generator.py
@@ -45,7 +45,6 @@ class MarginCatalogGenerator:
         self.margin_threshold = margin_threshold
         self.margin_order = self._set_margin_order(margin_order)
         self.use_pyarrow_types = use_pyarrow_types
-        self.schema = catalog.hc_structure.schema
 
     def _set_margin_order(self, margin_order: int | None) -> int:
         """Calculate the order of the margin cache to be generated. If not provided
@@ -81,7 +80,9 @@ class MarginCatalogGenerator:
         ddf, ddf_pixel_map, total_rows = self._generate_dask_df_and_map(pixels, partitions)
         margin_pixels = list(ddf_pixel_map.keys())
         margin_catalog_info = self._create_catalog_info(total_rows)
-        margin_structure = hc.catalog.MarginCatalog(margin_catalog_info, margin_pixels, schema=self.schema)
+        margin_structure = hc.catalog.MarginCatalog(
+            margin_catalog_info, margin_pixels, schema=self.hc_structure.schema
+        )
         return MarginCatalog(ddf, ddf_pixel_map, margin_structure)
 
     def _get_margins(self) -> Tuple[List[HealpixPixel], List[npd.NestedFrame]]:
@@ -220,6 +221,8 @@ class MarginCatalogGenerator:
         return MarginCacheCatalogInfo(
             catalog_name=f"{catalog_name}_margin",
             catalog_type=CatalogType.MARGIN,
+            ra_column=self.hc_structure.catalog_info.ra_column,
+            dec_column=self.hc_structure.catalog_info.dec_column,
             total_rows=total_rows,
             primary_catalog=catalog_name,
             margin_threshold=self.margin_threshold,

--- a/tests/lsdb/catalog/test_polygon_search.py
+++ b/tests/lsdb/catalog/test_polygon_search.py
@@ -1,3 +1,5 @@
+import sys
+
 import nested_dask as nd
 import nested_pandas as npd
 import numpy as np
@@ -80,6 +82,7 @@ def test_polygon_search_invalid_dec(small_sky_order1_catalog):
         small_sky_order1_catalog.polygon_search(vertices)
 
 
+@pytest.mark.skipif(sys.platform == "darwin", reason="Test skipped on macOS")
 def test_polygon_search_invalid_shape(small_sky_order1_catalog):
     """The polygon is not convex, so the shape is invalid"""
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
Explode kwargs in `from_dataframe` to improve visibility of the ra and dec column arguments. Also add a conditional test skip when checking for invalid polygon shapes because of a HEALPy bus error on macOS. Closes #432.