### PR TITLE
Use Alignment moc in crossmatch/join operations

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,4 +10,4 @@ sphinx-autoapi
 sphinx-copybutton
 sphinx-book-theme
 sphinx-design
-git+https://github.com/astronomy-commons/hipscat.git@main
+git+https://github.com/astronomy-commons/hipscat.git@development

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -223,7 +223,9 @@ class Catalog(HealpixDataset):
             dec_column=self.hc_structure.catalog_info.dec_column + suffixes[0],
             total_rows=None,
         )
-        hc_catalog = hc.catalog.Catalog(new_catalog_info, alignment.pixel_tree, schema=get_arrow_schema(ddf))
+        hc_catalog = hc.catalog.Catalog(
+            new_catalog_info, alignment.pixel_tree, schema=get_arrow_schema(ddf), moc=alignment.moc
+        )
         return Catalog(ddf, ddf_map, hc_catalog)
 
     def cone_search(self, ra: float, dec: float, radius_arcsec: float, fine: bool = True) -> Catalog:
@@ -441,7 +443,9 @@ class Catalog(HealpixDataset):
             dec_column=self.hc_structure.catalog_info.dec_column + suffixes[0],
             total_rows=None,
         )
-        hc_catalog = hc.catalog.Catalog(new_catalog_info, alignment.pixel_tree, schema=get_arrow_schema(ddf))
+        hc_catalog = hc.catalog.Catalog(
+            new_catalog_info, alignment.pixel_tree, schema=get_arrow_schema(ddf), moc=alignment.moc
+        )
         return Catalog(ddf, ddf_map, hc_catalog)
 
     def join(
@@ -492,7 +496,7 @@ class Catalog(HealpixDataset):
                 total_rows=None,
             )
             hc_catalog = hc.catalog.Catalog(
-                new_catalog_info, alignment.pixel_tree, schema=get_arrow_schema(ddf)
+                new_catalog_info, alignment.pixel_tree, schema=get_arrow_schema(ddf), moc=alignment.moc
             )
             return Catalog(ddf, ddf_map, hc_catalog)
         if left_on is None or right_on is None:
@@ -515,7 +519,9 @@ class Catalog(HealpixDataset):
             dec_column=self.hc_structure.catalog_info.dec_column + suffixes[0],
             total_rows=None,
         )
-        hc_catalog = hc.catalog.Catalog(new_catalog_info, alignment.pixel_tree, schema=get_arrow_schema(ddf))
+        hc_catalog = hc.catalog.Catalog(
+            new_catalog_info, alignment.pixel_tree, schema=get_arrow_schema(ddf), moc=alignment.moc
+        )
         return Catalog(ddf, ddf_map, hc_catalog)
 
     def join_nested(
@@ -573,7 +579,9 @@ class Catalog(HealpixDataset):
             catalog_name=output_catalog_name,
             total_rows=None,
         )
-        hc_catalog = hc.catalog.Catalog(new_catalog_info, alignment.pixel_tree)
+        hc_catalog = hc.catalog.Catalog(
+            new_catalog_info, alignment.pixel_tree, schema=get_arrow_schema(ddf), moc=alignment.moc
+        )
         return Catalog(ddf, ddf_map, hc_catalog)
 
     def nest_lists(

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -12,6 +12,7 @@ from lsdb import Catalog
 from lsdb.core.crossmatch.abstract_crossmatch_algorithm import AbstractCrossmatchAlgorithm
 from lsdb.core.crossmatch.bounded_kdtree_match import BoundedKdTreeCrossmatch
 from lsdb.core.crossmatch.kdtree_match import KdTreeCrossmatch
+from lsdb.dask.merge_catalog_functions import align_catalogs
 
 
 @pytest.mark.parametrize("algo", [KdTreeCrossmatch])
@@ -24,6 +25,10 @@ class TestCrossmatch:
             )
             assert isinstance(xmatched_cat._ddf, nd.NestedFrame)
             xmatched = xmatched_cat.compute()
+        alignment = align_catalogs(small_sky_catalog, small_sky_xmatch_catalog)
+        assert xmatched_cat.hc_structure.moc == alignment.moc
+        assert xmatched_cat.get_healpix_pixels() == alignment.pixel_tree.get_healpix_pixels()
+
         assert isinstance(xmatched, npd.NestedFrame)
         assert len(xmatched) == len(xmatch_correct)
         for _, correct_row in xmatch_correct.iterrows():

--- a/tests/lsdb/catalog/test_join.py
+++ b/tests/lsdb/catalog/test_join.py
@@ -1,4 +1,3 @@
-import hipscat as hc
 import nested_dask as nd
 import nested_pandas as npd
 import numpy as np


### PR DESCRIPTION
Uses the `PixelAlignment` object's moc as the moc in the output catalogs of join and crossmatch operations.

Fixes #428 