### PR TITLE
Fix shallow copy of catalog structure

### DIFF
--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -614,21 +614,17 @@ class Catalog(HealpixDataset):
             recommend setting the following dask config setting to prevent this:
             `dask.config.set({"dataframe.convert-string":False})`
         """
-        new_ddf = super().nest_lists(
+        catalog = super().nest_lists(
             base_columns=base_columns,
             list_columns=list_columns,
             name=name,
         )
-
-        catalog = Catalog(new_ddf._ddf, self._ddf_pixel_map, self.hc_structure)
-
         if self.margin is not None:
             catalog.margin = self.margin.nest_lists(
                 base_columns=base_columns,
                 list_columns=list_columns,
                 name=name,
             )
-
         return catalog
 
     def dropna(
@@ -708,6 +704,53 @@ class Catalog(HealpixDataset):
         return catalog
 
     def reduce(self, func, *args, meta=None, **kwargs) -> Catalog:
+        """
+        Takes a function and applies it to each top-level row of the Catalog.
+
+        docstring copied from nested-pandas
+
+        The user may specify which columns the function is applied to, with
+        columns from the 'base' layer being passsed to the function as
+        scalars and columns from the nested layers being passed as numpy arrays.
+
+        Parameters
+        ----------
+        func : callable
+            Function to apply to each nested dataframe. The first arguments to `func` should be which
+            columns to apply the function to. See the Notes for recommendations
+            on writing func outputs.
+        args : positional arguments
+            Positional arguments to pass to the function, the first *args should be the names of the
+            columns to apply the function to.
+        meta : dataframe or series-like, optional
+            The dask meta of the output. If append_columns is True, the meta should specify just the
+            additional columns output by func.
+        append_columns : bool
+            If the output columns should be appended to the orignal dataframe.
+        kwargs : keyword arguments, optional
+            Keyword arguments to pass to the function.
+
+        Returns
+        -------
+        `HealpixDataset`
+            `HealpixDataset` with the results of the function applied to the columns of the frame.
+
+        Notes
+        -----
+        By default, `reduce` will produce a `NestedFrame` with enumerated
+        column names for each returned value of the function. For more useful
+        naming, it's recommended to have `func` return a dictionary where each
+        key is an output column of the dataframe returned by `reduce`.
+
+        Example User Function:
+
+        >>> def my_sum(col1, col2):
+        >>>    '''reduce will return a NestedFrame with two columns'''
+        >>>    return {"sum_col1": sum(col1), "sum_col2": sum(col2)}
+        >>>
+        >>> catalog.reduce(my_sum, 'sources.col1', 'sources.col2')
+
+        """
         catalog = super().reduce(func, *args, meta=meta, **kwargs)
         if self.margin is not None:
             catalog.margin = self.margin.reduce(func, *args, meta=meta, **kwargs)

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -658,3 +658,27 @@ def test_joined_catalog_has_undetermined_len(
         )
     with pytest.raises(ValueError, match="undetermined"):
         len(small_sky_order1_catalog.merge_asof(small_sky_xmatch_catalog))
+
+
+def test_modified_hc_structure_is_a_deep_copy(small_sky_order1_catalog):
+    assert small_sky_order1_catalog.hc_structure.pixel_tree is not None
+    assert small_sky_order1_catalog.hc_structure.catalog_path is not None
+    assert small_sky_order1_catalog.hc_structure.schema is not None
+    assert small_sky_order1_catalog.hc_structure.moc is not None
+    assert small_sky_order1_catalog.hc_structure.catalog_info.total_rows == 131
+
+    modified_hc_structure = small_sky_order1_catalog._create_modified_hc_structure()
+    modified_hc_structure.pixel_tree = None
+    modified_hc_structure.catalog_path = None
+    modified_hc_structure.schema = None
+    modified_hc_structure.moc = None
+
+    # The original catalog structure is not modified
+    assert small_sky_order1_catalog.hc_structure.pixel_tree is not None
+    assert small_sky_order1_catalog.hc_structure.catalog_path is not None
+    assert small_sky_order1_catalog.hc_structure.schema is not None
+    assert small_sky_order1_catalog.hc_structure.moc is not None
+    assert small_sky_order1_catalog.hc_structure.catalog_info.total_rows == 131
+
+    # The rows of the new structure are invalidated
+    assert modified_hc_structure.catalog_info.total_rows == 0

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -667,7 +667,7 @@ def test_modified_hc_structure_is_a_deep_copy(small_sky_order1_catalog):
     assert small_sky_order1_catalog.hc_structure.moc is not None
     assert small_sky_order1_catalog.hc_structure.catalog_info.total_rows == 131
 
-    modified_hc_structure = small_sky_order1_catalog._create_modified_hc_structure()
+    modified_hc_structure = small_sky_order1_catalog._create_modified_hc_structure(total_rows=0)
     modified_hc_structure.pixel_tree = None
     modified_hc_structure.catalog_path = None
     modified_hc_structure.schema = None

--- a/tests/lsdb/catalog/test_nested.py
+++ b/tests/lsdb/catalog/test_nested.py
@@ -72,6 +72,9 @@ def test_reduce(small_sky_with_nested_sources):
     assert isinstance(reduced_cat, Catalog)
     assert isinstance(reduced_cat._ddf, nd.NestedFrame)
 
+    assert reduced_cat.hc_structure.catalog_info.ra_column == ""
+    assert reduced_cat.hc_structure.catalog_info.dec_column == ""
+
     reduced_cat_compute = reduced_cat.compute()
     assert isinstance(reduced_cat_compute, npd.NestedFrame)
 


### PR DESCRIPTION
Fix the catalog structure, which was being shallow copied, for operations such as `query`, `dropna` and `nest_lists`. It adds a method that performs the deep copy of the underlying structure and that allows to override catalog info parameters (e.g. we invalidate rows setting `total_rows` to 0). It further adds a missing docstring to `reduce`.