### PR TITLE
Remove margin object from `read_hats`

### DIFF
--- a/src/lsdb/loaders/hats/hats_loading_config.py
+++ b/src/lsdb/loaders/hats/hats_loading_config.py
@@ -8,7 +8,6 @@ import pandas as pd
 from pandas.io._util import _arrow_dtype_mapping
 from upath import UPath
 
-from lsdb.catalog.margin_catalog import MarginCatalog
 from lsdb.core.search.abstract_search import AbstractSearch
 
 
@@ -25,9 +24,8 @@ class HatsLoadingConfig:
     columns: List[str] | None = None
     """Columns to load from the catalog. If not specified, all columns are loaded"""
 
-    margin_cache: MarginCatalog | str | Path | UPath | None = None
-    """Margin cache for the catalog. It can be provided as a path for the margin on disk,
-    or as a margin object instance. By default, it is None."""
+    margin_cache: str | Path | UPath | None = None
+    """Path to the margin cache catalog. Defaults to None."""
 
     dtype_backend: str | None = "pyarrow"
     """The backend data type to apply to the catalog. It defaults to "pyarrow" and 

--- a/src/lsdb/loaders/hats/read_hats.pyi
+++ b/src/lsdb/loaders/hats/read_hats.pyi
@@ -28,7 +28,7 @@ def read_hats(
     path: str | Path | UPath,
     search_filter: AbstractSearch | None = None,
     columns: List[str] | None = None,
-    margin_cache: MarginCatalog | str | Path | UPath | None = None,
+    margin_cache: str | Path | UPath | None = None,
     dtype_backend: str | None = "pyarrow",
     **kwargs,
 ) -> Dataset | None: ...
@@ -38,7 +38,7 @@ def read_hats(
     catalog_type: Type[CatalogTypeVar],
     search_filter: AbstractSearch | None = None,
     columns: List[str] | None = None,
-    margin_cache: MarginCatalog | str | Path | UPath | None = None,
+    margin_cache: str | Path | UPath | None = None,
     dtype_backend: str | None = "pyarrow",
     **kwargs,
 ) -> CatalogTypeVar | None: ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,8 +142,8 @@ def small_sky_xmatch_margin_catalog(small_sky_xmatch_margin_dir):
 
 
 @pytest.fixture
-def small_sky_xmatch_with_margin(small_sky_xmatch_dir, small_sky_xmatch_margin_catalog):
-    return lsdb.read_hats(small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_catalog)
+def small_sky_xmatch_with_margin(small_sky_xmatch_dir, small_sky_xmatch_margin_dir):
+    return lsdb.read_hats(small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_dir)
 
 
 @pytest.fixture
@@ -167,8 +167,8 @@ def small_sky_order1_catalog(small_sky_order1_dir):
 
 
 @pytest.fixture
-def small_sky_order1_source_with_margin(small_sky_order1_source_dir, small_sky_order1_source_margin_catalog):
-    return lsdb.read_hats(small_sky_order1_source_dir, margin_cache=small_sky_order1_source_margin_catalog)
+def small_sky_order1_source_with_margin(small_sky_order1_source_dir, small_sky_order1_source_margin_dir):
+    return lsdb.read_hats(small_sky_order1_source_dir, margin_cache=small_sky_order1_source_margin_dir)
 
 
 @pytest.fixture

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -75,10 +75,10 @@ class TestCrossmatch:
 
     @staticmethod
     def test_kdtree_crossmatch_multiple_neighbors_margin(
-        algo, small_sky_catalog, small_sky_xmatch_dir, small_sky_xmatch_margin_catalog, xmatch_correct_3n_2t
+        algo, small_sky_catalog, small_sky_xmatch_dir, small_sky_xmatch_margin_dir, xmatch_correct_3n_2t
     ):
         small_sky_xmatch_catalog = lsdb.read_hats(
-            small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_catalog
+            small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_dir
         )
         xmatched = small_sky_catalog.crossmatch(
             small_sky_xmatch_catalog, n_neighbors=3, radius_arcsec=2 * 3600, algorithm=algo
@@ -98,11 +98,11 @@ class TestCrossmatch:
         algo,
         small_sky_left_xmatch_catalog,
         small_sky_xmatch_dir,
-        small_sky_xmatch_margin_catalog,
+        small_sky_xmatch_margin_dir,
         xmatch_correct_3n_2t_negative,
     ):
         small_sky_xmatch_catalog = lsdb.read_hats(
-            small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_catalog
+            small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_dir
         )
         xmatched = small_sky_left_xmatch_catalog.crossmatch(
             small_sky_xmatch_catalog, n_neighbors=3, radius_arcsec=2 * 3600, algorithm=algo
@@ -154,11 +154,11 @@ class TestBoundedCrossmatch:
         algo,
         small_sky_catalog,
         small_sky_xmatch_dir,
-        small_sky_xmatch_margin_catalog,
+        small_sky_xmatch_margin_dir,
         xmatch_correct_05_2_3n_margin,
     ):
         small_sky_xmatch_catalog = lsdb.read_hats(
-            small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_catalog
+            small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_dir
         )
         xmatched = small_sky_catalog.crossmatch(
             small_sky_xmatch_catalog,

--- a/tests/lsdb/loaders/hats/test_read_hats.py
+++ b/tests/lsdb/loaders/hats/test_read_hats.py
@@ -134,15 +134,6 @@ def test_read_hats_specify_catalog_type(small_sky_catalog, small_sky_dir):
     assert isinstance(catalog.compute(), npd.NestedFrame)
 
 
-def test_catalog_with_margin_object(small_sky_xmatch_dir, small_sky_xmatch_margin_catalog):
-    catalog = lsdb.read_hats(small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_catalog)
-    assert isinstance(catalog, lsdb.Catalog)
-    assert isinstance(catalog.margin, lsdb.MarginCatalog)
-    assert isinstance(catalog._ddf, nd.NestedFrame)
-    assert catalog.margin is small_sky_xmatch_margin_catalog
-    assert isinstance(catalog.margin._ddf, nd.NestedFrame)
-
-
 def test_catalog_with_margin_path(
     small_sky_xmatch_dir, small_sky_xmatch_margin_dir, small_sky_xmatch_margin_catalog
 ):
@@ -237,7 +228,7 @@ def test_read_hats_subset_no_partitions(small_sky_order1_dir, small_sky_order1_i
 
 
 def test_read_hats_with_margin_subset(
-    small_sky_order1_source_dir, small_sky_order1_source_with_margin, small_sky_order1_source_margin_catalog
+    small_sky_order1_source_dir, small_sky_order1_source_with_margin, small_sky_order1_source_margin_dir
 ):
     cone_search = ConeSearch(ra=315, dec=-66, radius_arcsec=20)
     # Filtering using catalog's cone_search
@@ -246,7 +237,7 @@ def test_read_hats_with_margin_subset(
     cone_search_catalog_2 = lsdb.read_hats(
         small_sky_order1_source_dir,
         search_filter=cone_search,
-        margin_cache=small_sky_order1_source_margin_catalog,
+        margin_cache=small_sky_order1_source_margin_dir,
     )
     assert isinstance(cone_search_catalog_2, lsdb.Catalog)
     # The partitions of the catalogs are equivalent

--- a/tests/lsdb/loaders/hats/test_read_hats.py
+++ b/tests/lsdb/loaders/hats/test_read_hats.py
@@ -134,7 +134,7 @@ def test_read_hats_specify_catalog_type(small_sky_catalog, small_sky_dir):
     assert isinstance(catalog.compute(), npd.NestedFrame)
 
 
-def test_catalog_with_margin_path(
+def test_catalog_with_margin(
     small_sky_xmatch_dir, small_sky_xmatch_margin_dir, small_sky_xmatch_margin_catalog
 ):
     assert isinstance(small_sky_xmatch_margin_dir, Path)
@@ -154,6 +154,11 @@ def test_catalog_without_margin_is_none(small_sky_xmatch_dir):
     catalog = lsdb.read_hats(small_sky_xmatch_dir)
     assert isinstance(catalog, lsdb.Catalog)
     assert catalog.margin is None
+
+
+def test_catalog_with_wrong_margin(small_sky_order1_dir, small_sky_order1_source_margin_dir):
+    with pytest.raises(ValueError, match="must have the same schema"):
+        lsdb.read_hats(small_sky_order1_dir, margin_cache=small_sky_order1_source_margin_dir)
 
 
 def test_read_hats_subset_with_cone_search(small_sky_order1_dir, small_sky_order1_catalog):


### PR DESCRIPTION
Remove code path that allows to provide a margin object to `read_hats`. Adds a simple validation to make sure that the loaded margin has a compatible schema. Closes #473. 