### PR TITLE
Update dependencies

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -59,7 +59,7 @@ advanced installation instructions in the :doc:`contribution guide </developer/c
 
     .. code-block:: console
 
-        python -m pip install lsdb[full]
+        python -m pip install 'lsdb[full]'
 
 Quickstart
 --------------------------

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -49,6 +49,18 @@ The latest release version of LSDB is available to install with `pip <https://py
 LSDB can also be installed from source on `GitHub <https://github.com/astronomy-commons/lsdb>`_. See our
 advanced installation instructions in the :doc:`contribution guide </developer/contributing>`.
 
+.. tip::
+    Installing optional dependencies
+
+    There are some extra dependencies that can make running LSDB in a jupyter
+    environment easier, or connecting to a variety of remote file systems.
+
+    These can be installed with the ``full`` extra.
+
+    .. code-block:: console
+
+        python -m pip install lsdb[full]
+
 Quickstart
 --------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     # dask diagnostics is required to spin up the dashboard for profiling.
     "dask[complete]",
     "deprecated",
-    "hats>=0.4",
+    "hats>=0.4.2",
     "lsst-sphgeom", # To handle spherical sky polygons
     "nested-dask",
     "nested-pandas",
@@ -44,6 +44,11 @@ dev = [
     "pytest",
     "pytest-cov", # Used to report total code coverage
     "pytest-mock", # Used to mock objects in tests
+]
+full = [
+    "fsspec[full]", # complete file system specs.
+    "ipykernel", # Support for Jupyter notebooks
+    "ipywidgets", # useful for tqdm in notebooks.
 ]
 
 [build-system]


### PR DESCRIPTION
- ipykernel is a nice-to-have dependency for folks running inside a jupyter notebook
- but ipywidgets is an even-nicer-to-have dependency
- extras handles the nice-to-haves, including the full suite of fsspec implementations.

See similar changes in https://github.com/astronomy-commons/hats-import/pull/421

Closes #436