### PR TITLE
added kwargs on hats.read_hats to pass http headers

### DIFF
--- a/src/lsdb/loaders/hats/read_hats.py
+++ b/src/lsdb/loaders/hats/read_hats.py
@@ -68,7 +68,7 @@ def read_hats(
         kwargs=kwargs,
     )
 
-    hc_catalog = hc.read_hats(path)
+    hc_catalog = hc.read_hats(path, **kwargs)
     if hc_catalog.schema is None:
         raise ValueError(
             "The catalog schema could not be loaded from metadata."


### PR DESCRIPTION
Added kwargs to hats.read_hats for HTTP headers support

This is related to 
https://github.com/astronomy-commons/hats/pull/411

And issue
https://github.com/astronomy-commons/hats/issues/410

Even without the pull request in the hats repo, the code in this pull request works. 

This code functions as expected, even without the corresponding pull request in the hats repository.
Tested with and without headers.