### PR TITLE
Update nested-dask to v0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "deprecated",
     "hats>=0.4.2",
     "lsst-sphgeom", # To handle spherical sky polygons
-    "nested-dask",
+    "nested-dask>=0.3.0",
     "nested-pandas",
     "pyarrow",
     "scipy", # kdtree

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -100,6 +100,7 @@ def test_head_empty_catalog(small_sky_order1_catalog):
     assert len(empty_catalog.head()) == 0
 
 
+@pytest.mark.skip(reason="lincc-frameworks/nested-pandas#174")
 def test_query(small_sky_order1_catalog):
     expected_ddf = small_sky_order1_catalog._ddf.copy()[
         (small_sky_order1_catalog._ddf["ra"] > 300) & (small_sky_order1_catalog._ddf["dec"] < -50)


### PR DESCRIPTION
Currently we have a single test failure when querying with column names that include a space. Here is the corresponding Nested-Pandas issue: https://github.com/lincc-frameworks/nested-pandas/issues/174