### PR TITLE
Reimport `*Search` from root `__init__.py`

### DIFF
--- a/docs/tutorials/join_catalogs.ipynb
+++ b/docs/tutorials/join_catalogs.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "import lsdb\n",
-    "from lsdb.core.search import ConeSearch"
+    "from lsdb import ConeSearch"
    ]
   },
   {

--- a/docs/tutorials/margins.ipynb
+++ b/docs/tutorials/margins.ipynb
@@ -59,7 +59,7 @@
    },
    "outputs": [],
    "source": [
-    "from lsdb.core.search import BoxSearch\n",
+    "from lsdb import BoxSearch\n",
     "\n",
     "box = BoxSearch(ra=(179.5, 180.1), dec=(9.4, 10))\n",
     "\n",

--- a/src/lsdb/__init__.py
+++ b/src/lsdb/__init__.py
@@ -1,4 +1,5 @@
 from ._version import __version__
 from .catalog import Catalog, MarginCatalog
+from .core.search import BoxSearch, ConeSearch, PolygonSearch
 from .loaders.dataframe.from_dataframe import from_dataframe
 from .loaders.hats.read_hats import read_hats


### PR DESCRIPTION
It allows to do `from lsdb import ConeSearch`