### PR TITLE
Test can be unskipped for column names with spaces

### DIFF
--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -100,7 +100,6 @@ def test_head_empty_catalog(small_sky_order1_catalog):
     assert len(empty_catalog.head()) == 0
 
 
-@pytest.mark.skip(reason="lincc-frameworks/nested-pandas#174")
 def test_query(small_sky_order1_catalog):
     expected_ddf = small_sky_order1_catalog._ddf.copy()[
         (small_sky_order1_catalog._ddf["ra"] > 300) & (small_sky_order1_catalog._ddf["dec"] < -50)


### PR DESCRIPTION
lincc-frameworks/nested-pandas#174 has been closed.

Columns names which contain spaces and other special characters are now supported (even if they'd be weird).