### PR TITLE
Remove the `lonlat` argument from `ang2vec`

### DIFF
--- a/src/lsdb/core/search/polygon_search.py
+++ b/src/lsdb/core/search/polygon_search.py
@@ -63,6 +63,6 @@ def get_cartesian_polygon(vertices: list[tuple[float, float]]) -> ConvexPolygon:
     Returns:
         The convex polygon object.
     """
-    vertices_xyz = hp.ang2vec(*np.array(vertices).T, lonlat=True)
+    vertices_xyz = hp.ang2vec(*np.array(vertices).T)
     edge_vectors = [UnitVector3d(x, y, z) for x, y, z in vertices_xyz]
     return ConvexPolygon(edge_vectors)


### PR DESCRIPTION
Remove the `lonlat` argument from the `hp.ang2vec` call. Depends on https://github.com/astronomy-commons/hats/pull/426.