### PR TITLE
Save named indices in `from_dataframe`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,3 +13,5 @@ sphinx-book-theme
 sphinx-design
 git+https://github.com/astronomy-commons/hats.git@main
 git+https://github.com/astronomy-commons/hats-import.git@main
+git+https://github.com/lincc-frameworks/nested-pandas.git@main
+git+https://github.com/lincc-frameworks/nested-dask.git@main

--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -27,6 +27,7 @@ from lsdb.loaders.dataframe.from_dataframe_utils import (
     _append_partition_information_to_dataframe,
     _extra_property_dict,
     _generate_dask_dataframe,
+    _has_named_index,
 )
 from lsdb.types import DaskDFPixelMap
 
@@ -170,11 +171,12 @@ class DataframeCatalogLoader:
     def _set_spatial_index(self):
         """Generates the spatial indices for each data point and assigns
         the spatial index column as the Dataframe index."""
+        if _has_named_index(self.dataframe):
+            self.dataframe.reset_index(inplace=True)
         self.dataframe[SPATIAL_INDEX_COLUMN] = compute_spatial_index(
             ra_values=self.dataframe[self.catalog_info.ra_column].to_numpy(),
             dec_values=self.dataframe[self.catalog_info.dec_column].to_numpy(),
         )
-        self.dataframe.insert(0, self.dataframe.index.name, self.dataframe.index)
         self.dataframe.set_index(SPATIAL_INDEX_COLUMN, inplace=True)
 
     def _compute_pixel_list(self) -> List[HealpixPixel]:

--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -174,6 +174,7 @@ class DataframeCatalogLoader:
             ra_values=self.dataframe[self.catalog_info.ra_column].to_numpy(),
             dec_values=self.dataframe[self.catalog_info.dec_column].to_numpy(),
         )
+        dataframe.insert(0, dataframe.index.name, dataframe.index)
         self.dataframe.set_index(SPATIAL_INDEX_COLUMN, inplace=True)
 
     def _compute_pixel_list(self) -> List[HealpixPixel]:

--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -174,7 +174,7 @@ class DataframeCatalogLoader:
             ra_values=self.dataframe[self.catalog_info.ra_column].to_numpy(),
             dec_values=self.dataframe[self.catalog_info.dec_column].to_numpy(),
         )
-        dataframe.insert(0, dataframe.index.name, dataframe.index)
+        self.dataframe.insert(0, dataframe.index.name, dataframe.index)
         self.dataframe.set_index(SPATIAL_INDEX_COLUMN, inplace=True)
 
     def _compute_pixel_list(self) -> List[HealpixPixel]:

--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -174,7 +174,7 @@ class DataframeCatalogLoader:
             ra_values=self.dataframe[self.catalog_info.ra_column].to_numpy(),
             dec_values=self.dataframe[self.catalog_info.dec_column].to_numpy(),
         )
-        self.dataframe.insert(0, dataframe.index.name, dataframe.index)
+        self.dataframe.insert(0, self.dataframe.index.name, self.dataframe.index)
         self.dataframe.set_index(SPATIAL_INDEX_COLUMN, inplace=True)
 
     def _compute_pixel_list(self) -> List[HealpixPixel]:

--- a/src/lsdb/loaders/dataframe/from_dataframe_utils.py
+++ b/src/lsdb/loaders/dataframe/from_dataframe_utils.py
@@ -148,3 +148,17 @@ def _extra_property_dict(est_size_bytes: int):
     properties["hats_version"] = "v0.1"
 
     return properties
+
+
+def _has_named_index(dataframe: npd.NestedFrame) -> bool:
+    """Heuristic to determine if a dataframe has some meaningful index.
+
+    This will reject dataframes with no index name for a single index,
+    or empty names for multi-index (e.g. [] or [None]).
+    """
+    if dataframe.index.name is not None:
+        ## Single index with a given name.
+        return True
+    if len(dataframe.index.names) == 0 or all(name is None for name in dataframe.index.names):
+        return False
+    return True


### PR DESCRIPTION
Save named indices when importing data with `from_dataframe`. When named indices appear in data they are usually relevant and should not be dropped, at the risk of rendering the catalog useless (e.g. if they are object/source IDs).