### PR TITLE
Add "all" options to read_hats columns

### DIFF
--- a/src/lsdb/loaders/hats/read_hats.py
+++ b/src/lsdb/loaders/hats/read_hats.py
@@ -28,7 +28,7 @@ from lsdb.types import CatalogTypeVar
 def read_hats(
     path: str | Path | UPath,
     search_filter: AbstractSearch | None = None,
-    columns: list[str] | None = None,
+    columns: list[str] | str | None = None,
     margin_cache: str | Path | UPath | None = None,
     dtype_backend: str | None = "pyarrow",
     **kwargs,
@@ -50,7 +50,8 @@ def read_hats(
     Args:
         path (UPath | Path): The path that locates the root of the HATS catalog
         search_filter (Type[AbstractSearch]): Default `None`. The filter method to be applied.
-        columns (List[str]): Default `None`. The set of columns to filter the catalog on.
+        columns (List[str]): Default `None`. The set of columns to filter the catalog on. If None, the
+            catalog's default columns will be loaded. To load all catalog columns, use `columns="all"`
         margin_cache (path-like): Default `None`. The margin for the main catalog, provided as a path.
         dtype_backend (str): Backend data type to apply to the catalog.
             Defaults to "pyarrow". If None, no type conversion is performed.
@@ -65,6 +66,9 @@ def read_hats(
 
     if columns is None and hc_catalog.catalog_info.default_columns is not None:
         columns = hc_catalog.catalog_info.default_columns
+
+    if columns == "all":
+        columns = None
 
     config = HatsLoadingConfig(
         search_filter=search_filter,

--- a/src/lsdb/loaders/hats/read_hats.py
+++ b/src/lsdb/loaders/hats/read_hats.py
@@ -70,6 +70,9 @@ def read_hats(
     if columns == "all":
         columns = None
 
+    if isinstance(columns, str):
+        raise TypeError("`columns` argument must be a list of strings, None, or 'all'")
+
     config = HatsLoadingConfig(
         search_filter=search_filter,
         columns=columns,

--- a/tests/lsdb/loaders/hats/test_read_hats.py
+++ b/tests/lsdb/loaders/hats/test_read_hats.py
@@ -63,6 +63,19 @@ def test_read_hats_default_cols_specify_cols(small_sky_order1_default_cols_dir, 
     assert_index_correct(catalog)
 
 
+def test_read_hats_default_cols_all_cols(small_sky_order1_default_cols_dir, assert_divisions_are_correct):
+    expected_all_cols = ["id", "ra", "dec", "ra_error", "dec_error", "Norder", "Dir", "Npix"]
+    catalog = lsdb.read_hats(small_sky_order1_default_cols_dir, columns="all")
+    assert isinstance(catalog, lsdb.Catalog)
+    assert isinstance(catalog._ddf, nd.NestedFrame)
+    assert catalog.hc_structure.catalog_info.default_columns is not None
+    assert np.all(catalog.columns == expected_all_cols)
+    assert np.all(catalog.compute().columns == expected_all_cols)
+    assert isinstance(catalog.compute(), npd.NestedFrame)
+    assert_divisions_are_correct(catalog)
+    assert_index_correct(catalog)
+
+
 def test_read_hats_no_pandas(small_sky_order1_no_pandas_dir, assert_divisions_are_correct):
     catalog = lsdb.read_hats(small_sky_order1_no_pandas_dir)
     assert isinstance(catalog, lsdb.Catalog)


### PR DESCRIPTION
Passing "all" as the argument to the "read_hats" keyword now loads all columns, ignoring the default columns property.

Fixes #563 