### PR TITLE
Separate tutorials into multiple sections

### DIFF
--- a/docs/advanced-topics.rst
+++ b/docs/advanced-topics.rst
@@ -1,0 +1,15 @@
+Advanced Topics
+========================================================================================
+
+A more in-depth look into how LSDB works
+
+.. toctree::
+    :maxdepth: 1
+    :name: Advanced Topics
+
+    Import catalogs <tutorials/import_catalogs>
+    Manual catalog verification <tutorials/pre_executed/manual_verification>
+    Accessing remote data <tutorials/remote_data>
+    Margins <tutorials/margins>
+    Index tables <tutorials/pre_executed/index_table>
+    Performance testing <tutorials/performance>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,11 +47,11 @@ Using this Guide
 
        The detailed API documentation
 
-   .. grid-item-card:: Contribution Guide
-       :link: developer/contributing
+   .. grid-item-card:: Example Science Notebooks
+       :link: science-notebooks
        :link-type: doc
 
-       For developers, learn more about contributing to this repository
+       Jupyter notebooks going over some example scientific use cases
 
 .. toctree::
    :hidden:
@@ -59,6 +59,8 @@ Using this Guide
    Home page <self>
    Getting Started <getting-started>
    Tutorials <tutorials>
+   Advanced Topics<advanced-topics>
+   Example Science Notebooks<science-notebooks>
    API Reference <autoapi/index>
 
 .. toctree::

--- a/docs/science-notebooks.rst
+++ b/docs/science-notebooks.rst
@@ -1,7 +1,7 @@
 Example Science Use Cases
 ========================================================================================
 
-Here we have a selection Jupyter notebooks going over some example scientific use cases
+Here we have some Jupyter notebooks demonstrating how LSDB can be used to perform example scientific use cases
 
 .. toctree::
     :maxdepth: 1

--- a/docs/science-notebooks.rst
+++ b/docs/science-notebooks.rst
@@ -1,0 +1,12 @@
+Example Science Use Cases
+========================================================================================
+
+Here we have a selection Jupyter notebooks going over some example scientific use cases
+
+.. toctree::
+    :maxdepth: 1
+    :name: Example Use Cases
+
+    Cross-match ZTF BTS and NGC <tutorials/pre_executed/ztf_bts-ngc>
+    Import and cross-match DES and Gaia <tutorials/pre_executed/des-gaia>
+    Search for Supernovae in ZTF alerts <tutorials/pre_executed/ztf-alerts-sne>

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -17,31 +17,12 @@ An introduction to LSDB's core features and functionality
     Joining catalogs <tutorials/join_catalogs>
     Exporting results <tutorials/exporting_results>
 
-Advanced Topics
+:doc:`Advanced Topics<advanced-topics>`
 ---------------------------
 
-A more in-depth look into how LSDB works
+A more in-depth look into how LSDB works.
 
-.. toctree::
-    :maxdepth: 1
-    :name: Advanced Topics
-
-    Topic: Import catalogs <tutorials/import_catalogs>
-    Topic: Manual catalog verification <tutorials/pre_executed/manual_verification>
-    Topic: Accessing remote data <tutorials/remote_data>
-    Topic: Margins <tutorials/margins>
-    Topic: Index tables <tutorials/pre_executed/index_table>
-    Topic: Performance testing <tutorials/performance>
-
-Example Science Use Cases
+:doc:`Example Science Use Cases<science-notebooks>`
 ---------------------------
 
 Notebooks going over some more scientific example use cases
-
-.. toctree::
-    :maxdepth: 1
-    :name: Example Use Cases
-
-    Science Notebook: Cross-match ZTF BTS and NGC <tutorials/pre_executed/ztf_bts-ngc>
-    Science Notebook: Import and cross-match DES and Gaia <tutorials/pre_executed/des-gaia>
-    Science Notebook: Search for Supernovae in ZTF alerts <tutorials/pre_executed/ztf-alerts-sne>


### PR DESCRIPTION
Tutorials currently has a large number of pages within it, which makes it hard to navigate. This splits the sections into Tutorials, Advanced topics, and Example Science Notebooks.