### PR TITLE
Add example for anonymous S3 catalog reads

### DIFF
--- a/src/lsdb/loaders/hats/read_hats.py
+++ b/src/lsdb/loaders/hats/read_hats.py
@@ -59,6 +59,12 @@ def read_hats(
 
     Returns:
         Catalog object loaded from the given parameters
+
+    Examples:
+        To read a catalog from a public S3 bucket, call it as follows::
+
+            from upath import UPath
+            catalog = lsdb.read_hats(UPath(..., anon=True))
     """
     # Creates a config object to store loading parameters from all keyword arguments.
 


### PR DESCRIPTION
Following https://github.com/astronomy-commons/hats/pull/459, add an example to `lsdb.read_hats` for reading catalogs from public S3 buckets.