### PR TITLE
Operations update metadata correctly

### DIFF
--- a/src/lsdb/catalog/association_catalog.py
+++ b/src/lsdb/catalog/association_catalog.py
@@ -23,3 +23,22 @@ class AssociationCatalog(HealpixDataset):
         hc_structure: hc.catalog.AssociationCatalog,
     ):
         super().__init__(ddf, ddf_pixel_map, hc_structure)
+
+    def _create_modified_hc_structure(
+        self, hc_structure=None, updated_schema=None, **kwargs
+    ) -> hc.catalog.AssociationCatalog:
+        """Copy the catalog structure and override the specified catalog info parameters.
+
+        Returns:
+            A copy of the catalog's structure with updated info parameters.
+        """
+        if hc_structure is None:
+            hc_structure = self.hc_structure
+        return hc_structure.__class__(
+            catalog_info=hc_structure.catalog_info.copy_and_update(**kwargs),
+            pixels=hc_structure.pixel_tree,
+            join_pixels=hc_structure.join_info,
+            catalog_path=hc_structure.catalog_path,
+            schema=hc_structure.schema if updated_schema is None else updated_schema,
+            moc=hc_structure.moc,
+        )

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -29,8 +29,8 @@ from lsdb.dask.join_catalog_data import (
     join_catalog_data_through,
     merge_asof_catalog_data,
 )
+from lsdb.dask.merge_catalog_functions import create_merged_catalog_info
 from lsdb.dask.merge_map_catalog_data import merge_map_catalog_data
-from lsdb.dask.partition_indexer import PartitionIndexer
 from lsdb.io.schema import get_arrow_schema
 from lsdb.types import DaskDFPixelMap
 
@@ -66,33 +66,6 @@ class Catalog(HealpixDataset):
         """
         super().__init__(ddf, ddf_pixel_map, hc_structure)
         self.margin = margin
-
-    @property
-    def partitions(self):
-        """Returns the partitions of the catalog"""
-        return PartitionIndexer(self)
-
-    def head(self, n: int = 5) -> npd.NestedFrame:
-        """Returns a few rows of data for previewing purposes.
-
-        Args:
-            n (int): The number of desired rows.
-
-        Returns:
-            A pandas DataFrame with up to `n` of data.
-        """
-        dfs = []
-        remaining_rows = n
-        for partition in self._ddf.partitions:
-            if remaining_rows == 0:
-                break
-            partition_head = partition.head(remaining_rows)
-            if len(partition_head) > 0:
-                dfs.append(partition_head)
-                remaining_rows -= len(partition_head)
-        if len(dfs) > 0:
-            return npd.NestedFrame(pd.concat(dfs))
-        return self._ddf._meta
 
     def query(self, expr: str) -> Catalog:
         """Filters catalog and respective margin, if it exists, using a complex query expression
@@ -137,7 +110,7 @@ class Catalog(HealpixDataset):
                 catalog = catalog.assign(new_col=new_data)
         """
         ddf = self._ddf.assign(**kwargs)
-        return Catalog(ddf, self._ddf_pixel_map, self.hc_structure)
+        return self._create_updated_dataset(ddf=ddf)
 
     def crossmatch(
         self,
@@ -231,16 +204,13 @@ class Catalog(HealpixDataset):
         ddf, ddf_map, alignment = crossmatch_catalog_data(
             self, other, suffixes, algorithm=algorithm, **kwargs
         )
-        new_catalog_info = self.hc_structure.catalog_info.copy_and_update(
-            catalog_name=output_catalog_name,
-            ra_column=self.hc_structure.catalog_info.ra_column + suffixes[0],
-            dec_column=self.hc_structure.catalog_info.dec_column + suffixes[0],
-            total_rows=0,
+        new_catalog_info = create_merged_catalog_info(
+            self.hc_structure.catalog_info, other.hc_structure.catalog_info, output_catalog_name, suffixes
         )
-        hc_catalog = hc.catalog.Catalog(
+        hc_catalog = self.hc_structure.__class__(
             new_catalog_info, alignment.pixel_tree, schema=get_arrow_schema(ddf), moc=alignment.moc
         )
-        return Catalog(ddf, ddf_map, hc_catalog)
+        return self.__class__(ddf, ddf_map, hc_catalog)
 
     def merge_map(
         self,
@@ -286,11 +256,13 @@ class Catalog(HealpixDataset):
             crossmatch algorithm.
         """
         ddf, ddf_map, alignment = merge_map_catalog_data(self, map_catalog, func, *args, meta=meta, **kwargs)
-        new_catalog_info = self.hc_structure.catalog_info.copy_and_update(total_rows=0)
-        hc_catalog = hc.catalog.Catalog(
-            new_catalog_info, alignment.pixel_tree, schema=get_arrow_schema(ddf), moc=alignment.moc
+        hc_catalog = self.hc_structure.__class__(
+            self.hc_structure.catalog_info,
+            alignment.pixel_tree,
+            schema=get_arrow_schema(ddf),
+            moc=alignment.moc,
         )
-        return Catalog(ddf, ddf_map, hc_catalog)
+        return self._create_updated_dataset(ddf=ddf, ddf_pixel_map=ddf_map, hc_structure=hc_catalog)
 
     def cone_search(self, ra: float, dec: float, radius_arcsec: float, fine: bool = True) -> Catalog:
         """Perform a cone search to filter the catalog
@@ -507,11 +479,8 @@ class Catalog(HealpixDataset):
                 f"{other.hc_structure.catalog_info.catalog_name}"
             )
 
-        new_catalog_info = self.hc_structure.catalog_info.copy_and_update(
-            catalog_name=output_catalog_name,
-            ra_column=self.hc_structure.catalog_info.ra_column + suffixes[0],
-            dec_column=self.hc_structure.catalog_info.dec_column + suffixes[0],
-            total_rows=0,
+        new_catalog_info = create_merged_catalog_info(
+            self.hc_structure.catalog_info, other.hc_structure.catalog_info, output_catalog_name, suffixes
         )
         hc_catalog = hc.catalog.Catalog(
             new_catalog_info, alignment.pixel_tree, schema=get_arrow_schema(ddf), moc=alignment.moc
@@ -558,11 +527,8 @@ class Catalog(HealpixDataset):
             if output_catalog_name is None:
                 output_catalog_name = self.hc_structure.catalog_info.catalog_name
 
-            new_catalog_info = self.hc_structure.catalog_info.copy_and_update(
-                catalog_name=output_catalog_name,
-                ra_column=self.hc_structure.catalog_info.ra_column + suffixes[0],
-                dec_column=self.hc_structure.catalog_info.dec_column + suffixes[0],
-                total_rows=0,
+            new_catalog_info = create_merged_catalog_info(
+                self.hc_structure.catalog_info, other.hc_structure.catalog_info, output_catalog_name, suffixes
             )
             hc_catalog = hc.catalog.Catalog(
                 new_catalog_info, alignment.pixel_tree, schema=get_arrow_schema(ddf), moc=alignment.moc
@@ -581,11 +547,8 @@ class Catalog(HealpixDataset):
         if output_catalog_name is None:
             output_catalog_name = self.hc_structure.catalog_info.catalog_name
 
-        new_catalog_info = self.hc_structure.catalog_info.copy_and_update(
-            catalog_name=output_catalog_name,
-            ra_column=self.hc_structure.catalog_info.ra_column + suffixes[0],
-            dec_column=self.hc_structure.catalog_info.dec_column + suffixes[0],
-            total_rows=0,
+        new_catalog_info = create_merged_catalog_info(
+            self.hc_structure.catalog_info, other.hc_structure.catalog_info, output_catalog_name, suffixes
         )
         hc_catalog = hc.catalog.Catalog(
             new_catalog_info, alignment.pixel_tree, schema=get_arrow_schema(ddf), moc=alignment.moc

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, Self, Type
+from typing import Callable, Type
 
 import hats as hc
 import nested_dask as nd
@@ -11,6 +11,7 @@ from mocpy import MOC
 from pandas._libs import lib
 from pandas._typing import AnyAll, Axis, IndexLabel
 from pandas.api.extensions import no_default
+from typing_extensions import Self
 
 from lsdb.catalog.association_catalog import AssociationCatalog
 from lsdb.catalog.dataset.healpix_dataset import HealpixDataset

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, Type
+from typing import Callable, Type, Self
 
 import hats as hc
 import nested_dask as nd
@@ -66,6 +66,18 @@ class Catalog(HealpixDataset):
         """
         super().__init__(ddf, ddf_pixel_map, hc_structure)
         self.margin = margin
+
+    def _create_updated_dataset(
+        self,
+        ddf: nd.NestedFrame = None,
+        ddf_pixel_map: DaskDFPixelMap = None,
+        hc_structure: hc.catalog.Catalog = None,
+        updated_catalog_info_params: dict = None,
+        margin: MarginCatalog | None = None,
+    ) -> Self:
+        cat = super()._create_updated_dataset(ddf, ddf_pixel_map, hc_structure, updated_catalog_info_params)
+        cat.margin = margin
+        return cat
 
     def query(self, expr: str) -> Catalog:
         """Filters catalog and respective margin, if it exists, using a complex query expression

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import Callable, Type, Self
+from typing import Callable, Self, Type
 
 import hats as hc
 import nested_dask as nd
 import nested_pandas as npd
-import pandas as pd
+from hats.catalog.healpix_dataset.healpix_dataset import HealpixDataset as HCHealpixDataset
 from hats.catalog.index.index_catalog import IndexCatalog as HCIndexCatalog
 from mocpy import MOC
 from pandas._libs import lib
@@ -69,10 +69,10 @@ class Catalog(HealpixDataset):
 
     def _create_updated_dataset(
         self,
-        ddf: nd.NestedFrame = None,
-        ddf_pixel_map: DaskDFPixelMap = None,
-        hc_structure: hc.catalog.Catalog = None,
-        updated_catalog_info_params: dict = None,
+        ddf: nd.NestedFrame | None = None,
+        ddf_pixel_map: DaskDFPixelMap | None = None,
+        hc_structure: HCHealpixDataset | None = None,
+        updated_catalog_info_params: dict | None = None,
         margin: MarginCatalog | None = None,
     ) -> Self:
         cat = super()._create_updated_dataset(ddf, ddf_pixel_map, hc_structure, updated_catalog_info_params)

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -1,3 +1,4 @@
+import hats as hc
 from __future__ import annotations
 
 import warnings
@@ -129,14 +130,26 @@ class HealpixDataset(Dataset):
         hc_structure: HCHealpixDataset | None = None,
         updated_catalog_info_params: dict | None = None,
     ) -> Self:
-        """Creates an"""
+        """Creates a new copy of the catalog, updating any provided arguments
+
+        Shallow copies the ddf and ddf_pixel_map if not provided. Creates a new hc_structure if not provided.
+        Updates the hc_structure with any provided catalog info parameters, resets the total rows, removes
+        any default columns that don't exist, and updates the pyarrow schema to reflect the new ddf.
+
+        Args:
+            ddf (nd.NestedFrame): The catalog ddf to update in the new catalog
+            ddf_pixel_map (DaskDFPixelMap): The partition to healpix pixel map to update in the new catalog
+            hc_structure (hats.HealpixDataset): The hats HealpixDataset object to update in the new catalog
+            updated_catalog_info_params (dict): The dictionary of updates to the parameters of the hats
+                dataset object's catalog_info
+        Returns:
+            A new dataset object with the arguments updated to those provided to the function, and the
+            hc_structure metadata updated to match the new ddf
+        """
         ddf = ddf or self._ddf
-        if ddf_pixel_map is None:
-            ddf_pixel_map = self._ddf_pixel_map
-        if hc_structure is None:
-            hc_structure = self.hc_structure
-        if updated_catalog_info_params is None:
-            updated_catalog_info_params = {}
+        ddf_pixel_map = ddf_pixel_map or self._ddf_pixel_map
+        hc_structure = hc_structure or self.hc_structure
+        updated_catalog_info_params = updated_catalog_info_params or {}
         if (
             "default_columns" not in updated_catalog_info_params
             and hc_structure.catalog_info.default_columns is not None

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -130,8 +130,7 @@ class HealpixDataset(Dataset):
         updated_catalog_info_params: dict | None = None,
     ) -> Self:
         """Creates an"""
-        if ddf is None:
-            ddf = self._ddf
+        ddf = ddf or self._ddf
         if ddf_pixel_map is None:
             ddf_pixel_map = self._ddf_pixel_map
         if hc_structure is None:

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -1,4 +1,3 @@
-import hats as hc
 from __future__ import annotations
 
 import warnings

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -37,6 +37,7 @@ from lsdb.core.plotting.skymap import compute_skymap, perform_inner_skymap
 from lsdb.core.search.abstract_search import AbstractSearch
 from lsdb.core.search.moc_search import MOCSearch
 from lsdb.dask.merge_catalog_functions import concat_metas
+from lsdb.dask.partition_indexer import PartitionIndexer
 from lsdb.io.schema import get_arrow_schema
 from lsdb.types import DaskDFPixelMap
 
@@ -75,7 +76,7 @@ class HealpixDataset(Dataset):
     def __getitem__(self, item):
         result = self._ddf.__getitem__(item)
         if isinstance(result, nd.NestedFrame):
-            return self.__class__(result, self._ddf_pixel_map, self.hc_structure)
+            return self._create_updated_dataset(ddf=result)
         return result
 
     def __len__(self):
@@ -104,19 +105,53 @@ class HealpixDataset(Dataset):
         divisions = pd.Index(self.get_ordered_healpix_pixels(), name=name)
         return divisions
 
-    def _create_modified_hc_structure(self, **kwargs) -> HCHealpixDataset:
+    def _create_modified_hc_structure(
+        self, hc_structure=None, updated_schema=None, **kwargs
+    ) -> HCHealpixDataset:
         """Copy the catalog structure and override the specified catalog info parameters.
 
         Returns:
             A copy of the catalog's structure with updated info parameters.
         """
-        return self.hc_structure.__class__(
-            catalog_info=self.hc_structure.catalog_info.copy_and_update(**kwargs),
-            pixels=self.hc_structure.pixel_tree,
-            catalog_path=self.hc_structure.catalog_path,
-            schema=self.hc_structure.schema,
-            moc=self.hc_structure.moc,
+        if hc_structure is None:
+            hc_structure = self.hc_structure
+        return hc_structure.__class__(
+            catalog_info=hc_structure.catalog_info.copy_and_update(**kwargs),
+            pixels=hc_structure.pixel_tree,
+            catalog_path=hc_structure.catalog_path,
+            schema=hc_structure.schema if updated_schema is None else updated_schema,
+            moc=hc_structure.moc,
         )
+
+    def _create_updated_dataset(
+        self,
+        ddf: nd.NestedFrame = None,
+        ddf_pixel_map: DaskDFPixelMap = None,
+        hc_structure: HCHealpixDataset = None,
+        updated_catalog_info_params: dict = None,
+    ) -> Self:
+        if ddf is None:
+            ddf = self._ddf
+        if ddf_pixel_map is None:
+            ddf_pixel_map = self._ddf_pixel_map
+        if hc_structure is None:
+            hc_structure = self.hc_structure
+        if updated_catalog_info_params is None:
+            updated_catalog_info_params = {}
+        if (
+            "default_columns" not in updated_catalog_info_params
+            and hc_structure.catalog_info.default_columns is not None
+        ):
+            updated_catalog_info_params["default_columns"] = [
+                col for col in hc_structure.catalog_info.default_columns if col in ddf.columns
+            ]
+        if "total_rows" not in updated_catalog_info_params:
+            updated_catalog_info_params["total_rows"] = 0
+        updated_schema = get_arrow_schema(ddf)
+        hc_structure = self._create_modified_hc_structure(
+            hc_structure=hc_structure, updated_schema=updated_schema, **updated_catalog_info_params
+        )
+        return self.__class__(ddf, ddf_pixel_map, hc_structure)
 
     def get_healpix_pixels(self) -> list[HealpixPixel]:
         """Get all HEALPix pixels that are contained in the catalog
@@ -167,6 +202,33 @@ class HealpixDataset(Dataset):
         partition_index = self._ddf_pixel_map[hp_pixel]
         return partition_index
 
+    @property
+    def partitions(self):
+        """Returns the partitions of the catalog"""
+        return PartitionIndexer(self)
+
+    def head(self, n: int = 5) -> npd.NestedFrame:
+        """Returns a few rows of data for previewing purposes.
+
+        Args:
+            n (int): The number of desired rows.
+
+        Returns:
+            A pandas DataFrame with up to `n` of data.
+        """
+        dfs = []
+        remaining_rows = n
+        for partition in self._ddf.partitions:
+            if remaining_rows == 0:
+                break
+            partition_head = partition.head(remaining_rows)
+            if len(partition_head) > 0:
+                dfs.append(partition_head)
+                remaining_rows -= len(partition_head)
+        if len(dfs) > 0:
+            return npd.NestedFrame(pd.concat(dfs))
+        return self._ddf._meta
+
     def query(self, expr: str) -> Self:
         """Filters catalog using a complex query expression
 
@@ -182,8 +244,7 @@ class HealpixDataset(Dataset):
             with the query expression
         """
         ndf = self._ddf.query(expr)
-        hc_structure = self._create_modified_hc_structure(total_rows=0)
-        return self.__class__(ndf, self._ddf_pixel_map, hc_structure)
+        return self._create_updated_dataset(ddf=ndf)
 
     def _perform_search(
         self,
@@ -231,7 +292,9 @@ class HealpixDataset(Dataset):
         """
         filtered_hc_structure = search.filter_hc_catalog(self.hc_structure)
         ddf_partition_map, search_ndf = self._perform_search(filtered_hc_structure, search)
-        return self.__class__(search_ndf, ddf_partition_map, filtered_hc_structure)
+        return self._create_updated_dataset(
+            ddf=search_ndf, ddf_pixel_map=ddf_partition_map, hc_structure=filtered_hc_structure
+        )
 
     def map_partitions(
         self,
@@ -297,9 +360,7 @@ class HealpixDataset(Dataset):
             output_ddf = self._ddf.map_partitions(func, *args, meta=meta, **kwargs)
 
         if isinstance(output_ddf, nd.NestedFrame) | isinstance(output_ddf, dd.DataFrame):
-            return self.__class__(
-                nd.NestedFrame.from_dask_dataframe(output_ddf), self._ddf_pixel_map, self.hc_structure
-            )
+            return self._create_updated_dataset(ddf=nd.NestedFrame.from_dask_dataframe(output_ddf))
         warnings.warn(
             "output of the function must be a DataFrame to generate an LSDB `Catalog`. `map_partitions` "
             "will return a dask object instead of a Catalog.",
@@ -327,7 +388,9 @@ class HealpixDataset(Dataset):
         )
         ddf_partition_map = {pixel: i for i, pixel in enumerate(non_empty_pixels)}
         filtered_hc_structure = self.hc_structure.filter_from_pixel_list(non_empty_pixels)
-        return self.__class__(search_ddf, ddf_partition_map, filtered_hc_structure)
+        return self._create_updated_dataset(
+            ddf=search_ddf, ddf_pixel_map=ddf_partition_map, hc_structure=filtered_hc_structure
+        )
 
     def _get_non_empty_partitions(self) -> tuple[list[HealpixPixel], np.ndarray]:
         """Determines which pixels and partitions of a catalog are not empty
@@ -488,6 +551,7 @@ class HealpixDataset(Dataset):
         base_catalog_path: str | Path | UPath,
         *,
         catalog_name: str | None = None,
+        default_columns: list[str] | None = None,
         overwrite: bool = False,
         **kwargs,
     ):
@@ -496,6 +560,9 @@ class HealpixDataset(Dataset):
         Args:
             base_catalog_path (str): Location where catalog is saved to
             catalog_name (str): The name of the catalog to be saved
+            default_columns (list[str]): A metadata property with the list of the columns in the catalog to
+                be loaded by default. By default, uses the default columns from the original hats catalogs if
+                they exist.
             overwrite (bool): If True existing catalog is overwritten
             **kwargs: Arguments to pass to the parquet write operations
         """
@@ -506,6 +573,7 @@ class HealpixDataset(Dataset):
             self,
             base_catalog_path=base_catalog_path,
             catalog_name=catalog_name,
+            default_columns=default_columns,
             histogram_order=histogram_order,
             overwrite=overwrite,
             **kwargs,
@@ -594,8 +662,7 @@ class HealpixDataset(Dataset):
             return df
 
         ndf = self._ddf.map_partitions(drop_na_part, meta=self._ddf._meta)
-        hc_structure = self._create_modified_hc_structure(total_rows=0)
-        return self.__class__(ndf, self._ddf_pixel_map, hc_structure)
+        return self._create_updated_dataset(ddf=ndf)
 
     def nest_lists(
         self,
@@ -639,8 +706,7 @@ class HealpixDataset(Dataset):
             list_columns=list_columns,
             name=name,
         )
-        hc_structure = self._create_modified_hc_structure(total_rows=0)
-        return self.__class__(new_ddf, self._ddf_pixel_map, hc_structure)
+        return self._create_updated_dataset(ddf=new_ddf)
 
     def reduce(self, func, *args, meta=None, append_columns=False, **kwargs) -> Self:
         """
@@ -706,13 +772,10 @@ class HealpixDataset(Dataset):
 
         ndf = nd.NestedFrame.from_dask_dataframe(self._ddf.map_partitions(reduce_part, meta=meta))
 
-        hc_updates: dict = {"total_rows": 0}
+        hc_updates = {}
         if not append_columns:
-            hc_updates = {**hc_updates, "ra_column": "", "dec_column": ""}
-
-        hc_catalog = self._create_modified_hc_structure(**hc_updates)
-        hc_catalog.schema = get_arrow_schema(ndf)
-        return self.__class__(ndf, self._ddf_pixel_map, hc_catalog)
+            hc_updates = {"ra_column": "", "dec_column": ""}
+        return self._create_updated_dataset(ddf=ndf, updated_catalog_info_params=hc_updates)
 
     def plot_points(
         self,

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, Iterable, Type, cast
 import astropy
 import dask
 import dask.dataframe as dd
-import hats as hc
 import nested_dask as nd
 import nested_pandas as npd
 import numpy as np
@@ -125,11 +124,12 @@ class HealpixDataset(Dataset):
 
     def _create_updated_dataset(
         self,
-        ddf: nd.NestedFrame = None,
-        ddf_pixel_map: DaskDFPixelMap = None,
-        hc_structure: HCHealpixDataset = None,
-        updated_catalog_info_params: dict = None,
+        ddf: nd.NestedFrame | None = None,
+        ddf_pixel_map: DaskDFPixelMap | None = None,
+        hc_structure: HCHealpixDataset | None = None,
+        updated_catalog_info_params: dict | None = None,
     ) -> Self:
+        """Creates an"""
         if ddf is None:
             ddf = self._ddf
         if ddf_pixel_map is None:
@@ -248,7 +248,7 @@ class HealpixDataset(Dataset):
 
     def _perform_search(
         self,
-        metadata: hc.catalog.Catalog | hc.catalog.MarginCatalog,
+        metadata: HCHealpixDataset,
         search: AbstractSearch,
     ) -> tuple[DaskDFPixelMap, nd.NestedFrame]:
         """Performs a search on the catalog from a list of pixels to search in

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -145,9 +145,9 @@ class HealpixDataset(Dataset):
             A new dataset object with the arguments updated to those provided to the function, and the
             hc_structure metadata updated to match the new ddf
         """
-        ddf = ddf or self._ddf
-        ddf_pixel_map = ddf_pixel_map or self._ddf_pixel_map
-        hc_structure = hc_structure or self.hc_structure
+        ddf = ddf if ddf is not None else self._ddf
+        ddf_pixel_map = ddf_pixel_map if ddf_pixel_map is not None else self._ddf_pixel_map
+        hc_structure = hc_structure if hc_structure is not None else self.hc_structure
         updated_catalog_info_params = updated_catalog_info_params or {}
         if (
             "default_columns" not in updated_catalog_info_params

--- a/src/lsdb/core/search/abstract_search.py
+++ b/src/lsdb/core/search/abstract_search.py
@@ -33,7 +33,7 @@ class AbstractSearch(ABC):
     def __init__(self, fine: bool = True):
         self.fine = fine
 
-    def filter_hc_catalog(self, hc_structure: HCCatalogTypeVar) -> MOC:
+    def filter_hc_catalog(self, hc_structure: HCCatalogTypeVar) -> HCCatalogTypeVar:
         """Determine the target partitions for further filtering."""
         raise NotImplementedError("Search Class must implement `filter_hc_catalog` method")
 

--- a/src/lsdb/core/search/abstract_search.py
+++ b/src/lsdb/core/search/abstract_search.py
@@ -13,7 +13,6 @@ from hats.catalog import TableProperties
 from hats.inspection.visualize_catalog import initialize_wcs_axes
 from matplotlib import pyplot as plt
 from matplotlib.figure import Figure
-from mocpy import MOC
 
 if TYPE_CHECKING:
     from lsdb.types import HCCatalogTypeVar

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -10,6 +10,7 @@ import numpy.typing as npt
 import pandas as pd
 from dask.dataframe.dispatch import make_meta
 from dask.delayed import Delayed, delayed
+from hats.catalog import TableProperties
 from hats.io import paths
 from hats.pixel_math import HealpixPixel
 from hats.pixel_math.spatial_index import SPATIAL_INDEX_COLUMN, healpix_to_spatial_index
@@ -372,3 +373,24 @@ def align_catalog_to_partitions(
     )
     partitions = get_partition(pixels)
     return list(partitions)
+
+
+def create_merged_catalog_info(
+    left_info: TableProperties, right_info: TableProperties, updated_name: str, suffixes: tuple[str, str]
+) -> TableProperties:
+    default_cols = (
+        [c + suffixes[0] for c in left_info.default_columns] if left_info.default_columns is not None else []
+    )
+    default_cols = (
+        default_cols + [c + suffixes[1] for c in right_info.default_columns]
+        if right_info.default_columns is not None
+        else default_cols
+    )
+    default_cols = default_cols if len(default_cols) > 0 else None
+    return left_info.copy_and_update(
+        catalog_name=updated_name,
+        ra_column=left_info.ra_column + suffixes[0],
+        dec_column=left_info.dec_column + suffixes[0],
+        total_rows=0,
+        default_columns=default_cols,
+    )

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -232,7 +232,7 @@ def generate_meta_df_for_joined_tables(
     suffixes: Sequence[str],
     extra_columns: pd.DataFrame | None = None,
     index_name: str = SPATIAL_INDEX_COLUMN,
-    index_type: npt.DTypeLike = np.int64,
+    index_type: npt.DTypeLike | None = None,
 ) -> npd.NestedFrame:
     """Generates a Dask meta DataFrame that would result from joining two catalogs
 
@@ -244,7 +244,8 @@ def generate_meta_df_for_joined_tables(
         suffixes (Sequence[Str]): The column suffixes to apply each catalog
         extra_columns (pd.Dataframe): Any additional columns to the merged catalogs
         index_name (str): The name of the index in the resulting DataFrame
-        index_type (npt.DTypeLike): The type of the index in the resulting DataFrame
+        index_type (npt.DTypeLike): The type of the index in the resulting DataFrame.
+            Default: type of index in the first catalog
 
     Returns:
         An empty dataframe with the columns of each catalog with their respective suffix, and any extra
@@ -258,6 +259,8 @@ def generate_meta_df_for_joined_tables(
     # Construct meta for crossmatch result columns
     if extra_columns is not None:
         meta.update(extra_columns)
+    if index_type is None:
+        index_type = catalogs[0]._ddf._meta.index.dtype
     index = pd.Index(pd.Series(dtype=index_type), name=index_name)
     meta_df = pd.DataFrame(meta, index)
     return npd.NestedFrame(meta_df)

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -260,6 +260,7 @@ def generate_meta_df_for_joined_tables(
     if extra_columns is not None:
         meta.update(extra_columns)
     if index_type is None:
+        # pylint: disable=protected-access
         index_type = catalogs[0]._ddf._meta.index.dtype
     index = pd.Index(pd.Series(dtype=index_type), name=index_name)
     meta_df = pd.DataFrame(meta, index)
@@ -381,6 +382,17 @@ def align_catalog_to_partitions(
 def create_merged_catalog_info(
     left_info: TableProperties, right_info: TableProperties, updated_name: str, suffixes: tuple[str, str]
 ) -> TableProperties:
+    """Creates the catalog info of the resulting catalog from merging two catalogs
+
+    Updates the ra and dec columns names, and any default columns by adding the correct suffixes, updates the
+    catalog name, and sets the total rows to 0
+
+    Args:
+        left_info (TableProperties): The catalog_info of the left catalog
+        right_info (TableProperties): The catalog_info of the right catalog
+        updated_name (str): The updated name of the catalog
+        suffixes (tuple[str, str]): The suffixes of the catalogs in the merged result
+    """
     default_cols = (
         [c + suffixes[0] for c in left_info.default_columns] if left_info.default_columns is not None else []
     )
@@ -389,11 +401,11 @@ def create_merged_catalog_info(
         if right_info.default_columns is not None
         else default_cols
     )
-    default_cols = default_cols if len(default_cols) > 0 else None
+    default_cols_to_use = default_cols if len(default_cols) > 0 else None
     return left_info.copy_and_update(
         catalog_name=updated_name,
         ra_column=left_info.ra_column + suffixes[0],
         dec_column=left_info.dec_column + suffixes[0],
         total_rows=0,
-        default_columns=default_cols,
+        default_columns=default_cols_to_use,
     )

--- a/src/lsdb/io/schema.py
+++ b/src/lsdb/io/schema.py
@@ -14,4 +14,4 @@ def get_arrow_schema(ddf: dd.DataFrame) -> pa.Schema:
         The arrow schema for the provided Dask DataFrame.
     """
     # pylint: disable=protected-access
-    return pa.Schema.from_pandas(ddf._meta)
+    return pa.Schema.from_pandas(ddf._meta).remove_metadata()

--- a/src/lsdb/io/to_hats.py
+++ b/src/lsdb/io/to_hats.py
@@ -89,7 +89,7 @@ def to_hats(
         base_catalog_path (str): Location where catalog is saved to
         catalog_name (str): The name of the output catalog
         default_columns (list[str]): A metadata property with the list of the columns in the catalog to be
-            loaded by default. By default, uses the default columns from the original hats catalogs if they
+            loaded by default. Uses the default columns from the original hats catalogs if they
             exist.
         histogram_order (int): The default order for the count histogram. Defaults to 8.
         overwrite (bool): If True existing catalog is overwritten

--- a/src/lsdb/io/to_hats.py
+++ b/src/lsdb/io/to_hats.py
@@ -75,6 +75,7 @@ def to_hats(
     *,
     base_catalog_path: str | Path | UPath,
     catalog_name: str | None = None,
+    default_columns: list[str] | None = None,
     histogram_order: int = 8,
     overwrite: bool = False,
     **kwargs,
@@ -87,6 +88,9 @@ def to_hats(
         catalog (HealpixDataset): A catalog to export
         base_catalog_path (str): Location where catalog is saved to
         catalog_name (str): The name of the output catalog
+        default_columns (list[str]): A metadata property with the list of the columns in the catalog to be
+            loaded by default. By default, uses the default columns from the original hats catalogs if they
+            exist.
         histogram_order (int): The default order for the count histogram. Defaults to 8.
         overwrite (bool): If True existing catalog is overwritten
         **kwargs: Arguments to pass to the parquet write operations
@@ -110,11 +114,16 @@ def to_hats(
     # Save partition info
     PartitionInfo(pixels.tolist()).write_to_file(base_catalog_path / "partition_info.csv")
     # Save catalog info
+    if default_columns is None:
+        default_columns = catalog.hc_structure.catalog_info.default_columns
+    if default_columns is not None and len(default_columns) == 0:
+        default_columns = None
     new_hc_structure = create_modified_catalog_structure(
         catalog.hc_structure,
         base_catalog_path,
         catalog_name if catalog_name else catalog.hc_structure.catalog_name,
         total_rows=int(np.sum(counts)),
+        default_columns=default_columns,
     )
     new_hc_structure.catalog_info.to_properties_file(base_catalog_path)
     # Save the point distribution map

--- a/src/lsdb/loaders/dataframe/margin_catalog_generator.py
+++ b/src/lsdb/loaders/dataframe/margin_catalog_generator.py
@@ -11,6 +11,7 @@ import pandas as pd
 from hats.catalog import CatalogType, TableProperties
 from hats.pixel_math import HealpixPixel, get_margin
 from hats.pixel_math.healpix_pixel_function import get_pixel_argsort
+from hats.pixel_math.spatial_index import SPATIAL_INDEX_COLUMN
 
 from lsdb import Catalog
 from lsdb.catalog.margin_catalog import MarginCatalog, _create_margin_schema
@@ -107,7 +108,7 @@ class MarginCatalogGenerator:
 
     def _create_empty_catalog(self) -> MarginCatalog:
         """Create an empty margin catalog"""
-        dask_meta_schema = self.margin_schema.empty_table().to_pandas()
+        dask_meta_schema = self.margin_schema.empty_table().to_pandas().set_index(SPATIAL_INDEX_COLUMN)
         ddf = nd.NestedFrame.from_pandas(dask_meta_schema, npartitions=1)
         catalog_info = self._create_catalog_info(**self.catalog_info_kwargs, total_rows=0)
         margin_structure = hc.catalog.MarginCatalog(catalog_info, [], schema=self.margin_schema)

--- a/src/lsdb/loaders/dataframe/margin_catalog_generator.py
+++ b/src/lsdb/loaders/dataframe/margin_catalog_generator.py
@@ -108,7 +108,9 @@ class MarginCatalogGenerator:
 
     def _create_empty_catalog(self) -> MarginCatalog:
         """Create an empty margin catalog"""
-        dask_meta_schema = self.margin_schema.empty_table().to_pandas().set_index(SPATIAL_INDEX_COLUMN)
+        dask_meta_schema = self.margin_schema.empty_table().to_pandas()
+        if SPATIAL_INDEX_COLUMN in dask_meta_schema.columns:
+            dask_meta_schema = dask_meta_schema.set_index(SPATIAL_INDEX_COLUMN)
         ddf = nd.NestedFrame.from_pandas(dask_meta_schema, npartitions=1)
         catalog_info = self._create_catalog_info(**self.catalog_info_kwargs, total_rows=0)
         margin_structure = hc.catalog.MarginCatalog(catalog_info, [], schema=self.margin_schema)

--- a/src/lsdb/loaders/hats/read_hats.py
+++ b/src/lsdb/loaders/hats/read_hats.py
@@ -107,6 +107,7 @@ def read_hats(
     else:
         raise NotImplementedError(f"Cannot load catalog of type {catalog_type}")
 
+    # pylint: disable=protected-access
     catalog.hc_structure = catalog._create_modified_hc_structure(
         updated_schema=get_arrow_schema(catalog._ddf),
         default_columns=(

--- a/src/lsdb/loaders/hats/read_hats.py
+++ b/src/lsdb/loaders/hats/read_hats.py
@@ -95,16 +95,20 @@ def read_hats(
 
     catalog_type = hc_catalog.catalog_info.catalog_type
 
-    if catalog_type in (CatalogType.OBJECT, CatalogType.SOURCE):
-        return _load_object_catalog(hc_catalog, config)
-    if catalog_type == CatalogType.MARGIN:
-        return _load_margin_catalog(hc_catalog, config)
-    if catalog_type == CatalogType.ASSOCIATION:
-        return _load_association_catalog(hc_catalog, config)
-    if catalog_type == CatalogType.MAP:
-        return _load_map_catalog(hc_catalog, config)
+    catalog = None
 
-    raise NotImplementedError(f"Cannot load catalog of type {catalog_type}")
+    if catalog_type in (CatalogType.OBJECT, CatalogType.SOURCE):
+        catalog = _load_object_catalog(hc_catalog, config)
+    elif catalog_type == CatalogType.MARGIN:
+        catalog = _load_margin_catalog(hc_catalog, config)
+    elif catalog_type == CatalogType.ASSOCIATION:
+        catalog = _load_association_catalog(hc_catalog, config)
+    elif catalog_type == CatalogType.MAP:
+        catalog = _load_map_catalog(hc_catalog, config)
+    else:
+        raise NotImplementedError(f"Cannot load catalog of type {catalog_type}")
+
+    return catalog._create_updated_dataset()
 
 
 def _load_association_catalog(hc_catalog, config):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,15 @@
 from pathlib import Path
 
 import hats as hc
+import numpy.testing as npt
 import pandas as pd
 import pytest
 from hats.pixel_math import spatial_index_to_healpix
 from hats.pixel_math.spatial_index import (
     SPATIAL_INDEX_COLUMN,
-    healpix_to_spatial_index,
     compute_spatial_index,
+    healpix_to_spatial_index,
 )
-import numpy.testing as npt
-
 
 import lsdb
 
@@ -317,7 +316,6 @@ def pytest_collection_modifyitems(items):
 
 
 class Helpers:
-
     @staticmethod
     def assert_divisions_are_correct(catalog):
         # Check that number of divisions == number of pixels + 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -350,9 +350,10 @@ class Helpers:
 
     @staticmethod
     def assert_schema_correct(cat, types_mapper=pd.ArrowDtype):
-        pd.testing.assert_frame_equal(
-            cat._ddf._meta, cat.hc_structure.schema.empty_table().to_pandas(types_mapper=types_mapper)
-        )
+        schema_to_pandas = cat.hc_structure.schema.empty_table().to_pandas(types_mapper=types_mapper)
+        if SPATIAL_INDEX_COLUMN in schema_to_pandas.columns:
+            schema_to_pandas = schema_to_pandas.set_index(SPATIAL_INDEX_COLUMN)
+        pd.testing.assert_frame_equal(cat._ddf._meta, schema_to_pandas)
 
     @staticmethod
     def assert_default_columns_in_columns(cat):

--- a/tests/lsdb/catalog/test_box_search.py
+++ b/tests/lsdb/catalog/test_box_search.py
@@ -3,7 +3,7 @@ import pytest
 from hats.pixel_math.validators import ValidatorsErrors
 
 
-def test_box_search_filters_correct_points(small_sky_order1_catalog, assert_divisions_are_correct):
+def test_box_search_filters_correct_points(small_sky_order1_catalog, helpers):
     search_catalog = small_sky_order1_catalog.box_search(ra=(280, 300), dec=(-40, -30))
     search_df = search_catalog.compute()
     ra_values = search_df[small_sky_order1_catalog.hc_structure.catalog_info.ra_column]
@@ -11,12 +11,10 @@ def test_box_search_filters_correct_points(small_sky_order1_catalog, assert_divi
     assert len(search_df) < len(small_sky_order1_catalog.compute())
     assert all(280 <= ra <= 300 for ra in ra_values)
     assert all(-40 <= dec <= -30 for dec in dec_values)
-    assert_divisions_are_correct(search_catalog)
+    helpers.assert_divisions_are_correct(search_catalog)
 
 
-def test_box_search_filters_correct_points_margin(
-    small_sky_order1_source_with_margin, assert_divisions_are_correct
-):
+def test_box_search_filters_correct_points_margin(small_sky_order1_source_with_margin, helpers):
     ra_search_catalog = small_sky_order1_source_with_margin.box_search(ra=(280, 300), dec=(-90, 30))
     ra_search_df = ra_search_catalog.compute()
     ra_values = ra_search_df[small_sky_order1_source_with_margin.hc_structure.catalog_info.ra_column]
@@ -24,7 +22,7 @@ def test_box_search_filters_correct_points_margin(
     assert len(ra_search_df) < len(small_sky_order1_source_with_margin.compute())
     assert all(280 <= ra <= 300 for ra in ra_values)
     assert all(-90 <= dec <= 30 for dec in dec_values)
-    assert_divisions_are_correct(ra_search_catalog)
+    helpers.assert_divisions_are_correct(ra_search_catalog)
 
     assert ra_search_catalog.margin is not None
     ra_margin_search_df = ra_search_catalog.margin.compute()
@@ -33,7 +31,7 @@ def test_box_search_filters_correct_points_margin(
     assert len(ra_margin_search_df) < len(small_sky_order1_source_with_margin.margin.compute())
     assert all(280 <= ra <= 300 for ra in ra_values)
     assert all(-90 <= dec <= 30 for dec in dec_values)
-    assert_divisions_are_correct(ra_search_catalog.margin)
+    helpers.assert_divisions_are_correct(ra_search_catalog.margin)
 
 
 def test_box_search_ra_complement(small_sky_order1_catalog):

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -115,7 +115,7 @@ def test_head_empty_catalog(small_sky_order1_catalog):
     assert len(empty_catalog.head()) == 0
 
 
-def test_query(small_sky_order1_catalog):
+def test_query(small_sky_order1_catalog, helpers):
     expected_ddf = small_sky_order1_catalog._ddf.copy()[
         (small_sky_order1_catalog._ddf["ra"] > 300) & (small_sky_order1_catalog._ddf["dec"] < -50)
     ]
@@ -135,6 +135,7 @@ def test_query(small_sky_order1_catalog):
     result_catalog = small_sky_order1_catalog.query("`right ascension` > 300 and dec < -50")
     assert isinstance(result_catalog._ddf, nd.NestedFrame)
     pd.testing.assert_frame_equal(result_catalog._ddf.compute(), expected_ddf.compute())
+    helpers.assert_schema_correct(result_catalog)
 
 
 def test_query_margin(small_sky_xmatch_with_margin):
@@ -215,6 +216,34 @@ def test_save_catalog(small_sky_catalog, tmp_path):
     assert expected_catalog.hc_structure.catalog_info == small_sky_catalog.hc_structure.catalog_info
     assert expected_catalog.get_healpix_pixels() == small_sky_catalog.get_healpix_pixels()
     pd.testing.assert_frame_equal(expected_catalog.compute(), small_sky_catalog._ddf.compute())
+
+
+def test_save_catalog_default_columns(small_sky_order1_default_cols_catalog, tmp_path, helpers):
+    cat = small_sky_order1_default_cols_catalog[["ra", "dec"]]
+    new_catalog_name = "small_sky_order1"
+    base_catalog_path = Path(tmp_path) / new_catalog_name
+    cat.to_hats(base_catalog_path, catalog_name=new_catalog_name)
+    expected_catalog = lsdb.read_hats(base_catalog_path)
+    assert expected_catalog.hc_structure.catalog_name == new_catalog_name
+    assert expected_catalog.get_healpix_pixels() == cat.get_healpix_pixels()
+    pd.testing.assert_frame_equal(expected_catalog.compute(), cat._ddf.compute())
+    helpers.assert_schema_correct(expected_catalog)
+    helpers.assert_default_columns_in_columns(expected_catalog)
+
+
+def test_save_catalog_empty_default_columns(small_sky_order1_default_cols_catalog, tmp_path, helpers):
+    cat = small_sky_order1_default_cols_catalog[["ra", "dec"]]
+    cat.hc_structure.catalog_info.default_columns = []
+    new_catalog_name = "small_sky_order1"
+    base_catalog_path = Path(tmp_path) / new_catalog_name
+    cat.to_hats(base_catalog_path, catalog_name=new_catalog_name)
+    expected_catalog = lsdb.read_hats(base_catalog_path)
+    assert expected_catalog.hc_structure.catalog_info.default_columns is None
+    assert expected_catalog.hc_structure.catalog_name == new_catalog_name
+    assert expected_catalog.get_healpix_pixels() == cat.get_healpix_pixels()
+    pd.testing.assert_frame_equal(expected_catalog.compute(), cat._ddf.compute())
+    helpers.assert_schema_correct(expected_catalog)
+    helpers.assert_default_columns_in_columns(expected_catalog)
 
 
 def test_save_catalog_point_map(small_sky_order1_catalog, tmp_path):
@@ -579,7 +608,7 @@ def test_plot_coverage(small_sky_order1_catalog, mocker):
     )
 
 
-def test_square_bracket_columns(small_sky_order1_catalog):
+def test_square_bracket_columns(small_sky_order1_catalog, helpers):
     columns = ["ra", "dec", "id"]
     column_subset = small_sky_order1_catalog[columns]
     assert all(column_subset.columns == columns)
@@ -590,6 +619,25 @@ def test_square_bracket_columns(small_sky_order1_catalog):
     assert np.all(
         column_subset.compute().index.to_numpy() == small_sky_order1_catalog.compute().index.to_numpy()
     )
+    helpers.assert_schema_correct(column_subset)
+
+
+def test_square_bracket_columns_default_columns(small_sky_order1_default_cols_catalog, helpers):
+    columns = ["ra", "dec"]
+    column_subset = small_sky_order1_default_cols_catalog[columns]
+    assert all(column_subset.columns == columns)
+    assert isinstance(column_subset, Catalog)
+    assert isinstance(column_subset._ddf, nd.NestedFrame)
+    assert isinstance(column_subset.compute(), npd.NestedFrame)
+    pd.testing.assert_frame_equal(
+        column_subset.compute(), small_sky_order1_default_cols_catalog.compute()[columns]
+    )
+    assert np.all(
+        column_subset.compute().index.to_numpy()
+        == small_sky_order1_default_cols_catalog.compute().index.to_numpy()
+    )
+    helpers.assert_schema_correct(column_subset)
+    helpers.assert_default_columns_in_columns(column_subset)
 
 
 def test_square_bracket_column(small_sky_order1_catalog):
@@ -600,7 +648,7 @@ def test_square_bracket_column(small_sky_order1_catalog):
     assert isinstance(column, dd.Series)
 
 
-def test_square_bracket_filter(small_sky_order1_catalog):
+def test_square_bracket_filter(small_sky_order1_catalog, helpers):
     filtered_id = small_sky_order1_catalog[small_sky_order1_catalog["id"] > 750]
     assert isinstance(filtered_id, Catalog)
     assert isinstance(filtered_id._ddf, nd.NestedFrame)
@@ -610,6 +658,7 @@ def test_square_bracket_filter(small_sky_order1_catalog):
     assert np.all(
         filtered_id.compute().index.to_numpy() == ss_computed[ss_computed["id"] > 750].index.to_numpy()
     )
+    helpers.assert_schema_correct(filtered_id)
 
 
 def test_map_partitions(small_sky_order1_catalog):

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -246,6 +246,31 @@ def test_save_catalog_empty_default_columns(small_sky_order1_default_cols_catalo
     helpers.assert_default_columns_in_columns(expected_catalog)
 
 
+def test_save_catalog_default_columns_cross_matched(
+    small_sky_order1_default_cols_catalog, small_sky_xmatch_catalog, tmp_path, helpers
+):
+    cat = small_sky_order1_default_cols_catalog.crossmatch(
+        small_sky_xmatch_catalog, radius_arcsec=0.01 * 3600
+    )
+    new_catalog_name = "small_sky_order1"
+    base_catalog_path = Path(tmp_path) / new_catalog_name
+    cat.to_hats(base_catalog_path, catalog_name=new_catalog_name)
+    expected_catalog = lsdb.read_hats(base_catalog_path)
+    assert expected_catalog.hc_structure.catalog_name == new_catalog_name
+    assert expected_catalog.get_healpix_pixels() == cat.get_healpix_pixels()
+    pd.testing.assert_frame_equal(
+        expected_catalog.compute(), cat._ddf.compute()[cat.hc_structure.catalog_info.default_columns]
+    )
+    helpers.assert_schema_correct(expected_catalog)
+    helpers.assert_default_columns_in_columns(expected_catalog)
+    expected_catalog_all_cols = lsdb.read_hats(base_catalog_path, columns="all")
+    assert expected_catalog_all_cols.hc_structure.catalog_name == new_catalog_name
+    assert expected_catalog_all_cols.get_healpix_pixels() == cat.get_healpix_pixels()
+    pd.testing.assert_frame_equal(expected_catalog_all_cols.compute(), cat._ddf.compute())
+    helpers.assert_schema_correct(expected_catalog_all_cols)
+    helpers.assert_default_columns_in_columns(expected_catalog_all_cols)
+
+
 def test_save_catalog_point_map(small_sky_order1_catalog, tmp_path):
     new_catalog_name = "small_sky_order1"
     base_catalog_path = Path(tmp_path) / new_catalog_name

--- a/tests/lsdb/catalog/test_cone_search.py
+++ b/tests/lsdb/catalog/test_cone_search.py
@@ -9,7 +9,7 @@ from hats.pixel_math.validators import ValidatorsErrors
 from lsdb import ConeSearch
 
 
-def test_cone_search_filters_correct_points(small_sky_order1_catalog, assert_divisions_are_correct):
+def test_cone_search_filters_correct_points(small_sky_order1_catalog, helpers):
     ra = 0
     dec = -80
     radius_degrees = 20
@@ -27,12 +27,12 @@ def test_cone_search_filters_correct_points(small_sky_order1_catalog, assert_div
             assert len(cone_search_df.loc[cone_search_df["id"] == row["id"]]) == 1
         else:
             assert len(cone_search_df.loc[cone_search_df["id"] == row["id"]]) == 0
-    assert_divisions_are_correct(cone_search_catalog)
+    helpers.assert_divisions_are_correct(cone_search_catalog)
 
 
 def test_cone_search_filters_correct_points_margin(
     small_sky_order1_source_with_margin,
-    assert_divisions_are_correct,
+    helpers,
     cone_search_expected,
     cone_search_margin_expected,
 ):
@@ -50,8 +50,8 @@ def test_cone_search_filters_correct_points_margin(
     pd.testing.assert_frame_equal(
         cone_search_margin_df, cone_search_margin_expected, check_index_type=False, check_dtype=False
     )
-    assert_divisions_are_correct(cone_search_catalog)
-    assert_divisions_are_correct(cone_search_catalog.margin)
+    helpers.assert_divisions_are_correct(cone_search_catalog)
+    helpers.assert_divisions_are_correct(cone_search_catalog.margin)
 
 
 def test_cone_search_big_margin(small_sky_order1_source_with_margin):
@@ -72,24 +72,24 @@ def test_cone_search_filters_partitions(small_sky_order1_catalog):
         assert pixel in consearch_catalog._ddf_pixel_map
 
 
-def test_cone_search_filters_no_matching_points(small_sky_order1_catalog, assert_divisions_are_correct):
+def test_cone_search_filters_no_matching_points(small_sky_order1_catalog, helpers):
     ra = 0
     dec = -80
     radius = 0.2 * 3600
     cone_search_catalog = small_sky_order1_catalog.cone_search(ra, dec, radius)
     cone_search_df = cone_search_catalog.compute()
     assert len(cone_search_df) == 0
-    assert_divisions_are_correct(cone_search_catalog)
+    helpers.assert_divisions_are_correct(cone_search_catalog)
 
 
-def test_cone_search_filters_no_matching_partitions(small_sky_order1_catalog, assert_divisions_are_correct):
+def test_cone_search_filters_no_matching_partitions(small_sky_order1_catalog, helpers):
     ra = 20
     dec = 80
     radius = 20 * 3600
     cone_search_catalog = small_sky_order1_catalog.cone_search(ra, dec, radius)
     cone_search_df = cone_search_catalog.compute()
     assert len(cone_search_df) == 0
-    assert_divisions_are_correct(cone_search_catalog)
+    helpers.assert_divisions_are_correct(cone_search_catalog)
 
 
 def test_cone_search_wrapped_ra(small_sky_order1_catalog):

--- a/tests/lsdb/catalog/test_index_search.py
+++ b/tests/lsdb/catalog/test_index_search.py
@@ -3,7 +3,7 @@ import nested_pandas as npd
 from hats import read_hats
 
 
-def test_index_search(small_sky_order1_catalog, small_sky_order1_id_index_dir, assert_divisions_are_correct):
+def test_index_search(small_sky_order1_catalog, small_sky_order1_id_index_dir, helpers):
     catalog_index = read_hats(small_sky_order1_id_index_dir)
     # Searching for an object that does not exist
     index_search_catalog = small_sky_order1_catalog.index_search([900], catalog_index)
@@ -11,12 +11,12 @@ def test_index_search(small_sky_order1_catalog, small_sky_order1_id_index_dir, a
     index_search_df = index_search_catalog.compute()
     assert isinstance(index_search_df, npd.NestedFrame)
     assert len(index_search_df) == 0
-    assert_divisions_are_correct(index_search_catalog)
+    helpers.assert_divisions_are_correct(index_search_catalog)
     # Searching for an object that exists
     index_search_catalog = small_sky_order1_catalog.index_search([700], catalog_index)
     index_search_df = index_search_catalog.compute()
     assert len(index_search_df) == 1
-    assert_divisions_are_correct(index_search_catalog)
+    helpers.assert_divisions_are_correct(index_search_catalog)
 
 
 def test_index_search_coarse_versus_fine(small_sky_order1_catalog, small_sky_order1_id_index_dir):

--- a/tests/lsdb/catalog/test_join.py
+++ b/tests/lsdb/catalog/test_join.py
@@ -2,8 +2,8 @@ import nested_dask as nd
 import nested_pandas as npd
 import numpy as np
 import pandas as pd
-import pytest
 import pyarrow as pa
+import pytest
 from hats.pixel_math import HealpixPixel
 from hats.pixel_math.spatial_index import SPATIAL_INDEX_COLUMN, spatial_index_to_healpix
 

--- a/tests/lsdb/catalog/test_join.py
+++ b/tests/lsdb/catalog/test_join.py
@@ -3,6 +3,7 @@ import nested_pandas as npd
 import numpy as np
 import pandas as pd
 import pytest
+import pyarrow as pa
 from hats.pixel_math import HealpixPixel
 from hats.pixel_math.spatial_index import SPATIAL_INDEX_COLUMN, spatial_index_to_healpix
 
@@ -22,7 +23,7 @@ def test_small_sky_join_small_sky_order1(small_sky_catalog, small_sky_order1_cat
     for col_name, dtype in small_sky_order1_catalog.dtypes.items():
         assert (col_name + suffixes[1], dtype) in joined.dtypes.items()
     assert joined._ddf.index.name == SPATIAL_INDEX_COLUMN
-    assert joined._ddf.index.dtype == np.int64
+    assert joined._ddf.index.dtype == pd.ArrowDtype(pa.int64())
     alignment = align_catalogs(small_sky_catalog, small_sky_order1_catalog)
     assert joined.hc_structure.moc == alignment.moc
     assert joined.get_healpix_pixels() == alignment.pixel_tree.get_healpix_pixels()
@@ -126,7 +127,7 @@ def test_join_association(small_sky_catalog, small_sky_xmatch_catalog, small_sky
     for col in small_sky_xmatch_catalog._ddf.columns:
         assert col + suffixes[1] in joined._ddf.columns
     assert joined._ddf.index.name == SPATIAL_INDEX_COLUMN
-    assert joined._ddf.index.dtype == np.int64
+    assert joined._ddf.index.dtype == pd.ArrowDtype(pa.int64())
 
     small_sky_compute = small_sky_catalog.compute()
     small_sky_xmatch_compute = small_sky_xmatch_catalog.compute()

--- a/tests/lsdb/catalog/test_order_search.py
+++ b/tests/lsdb/catalog/test_order_search.py
@@ -5,27 +5,27 @@ import pytest
 from lsdb.core.search import OrderSearch
 
 
-def test_order_search_filters_correct_pixels(small_sky_source_catalog, assert_divisions_are_correct):
+def test_order_search_filters_correct_pixels(small_sky_source_catalog, helpers):
     order_search_catalog = small_sky_source_catalog.order_search(min_order=1, max_order=1)
     assert isinstance(order_search_catalog._ddf, nd.NestedFrame)
     pixel_orders = [pixel.order for pixel in order_search_catalog.get_healpix_pixels()]
     assert all(order == 1 for order in pixel_orders)
-    assert_divisions_are_correct(order_search_catalog)
+    helpers.assert_divisions_are_correct(order_search_catalog)
 
     order_search_catalog = small_sky_source_catalog.order_search(min_order=1, max_order=2)
     pixel_orders = [pixel.order for pixel in order_search_catalog.get_healpix_pixels()]
     assert all(1 <= order <= 2 for order in pixel_orders)
-    assert_divisions_are_correct(order_search_catalog)
+    helpers.assert_divisions_are_correct(order_search_catalog)
 
     order_search_catalog = small_sky_source_catalog.order_search(min_order=1)
     pixel_orders = [pixel.order for pixel in order_search_catalog.get_healpix_pixels()]
     assert all(1 <= order <= 2 for order in pixel_orders)
-    assert_divisions_are_correct(order_search_catalog)
+    helpers.assert_divisions_are_correct(order_search_catalog)
 
     order_search_catalog = small_sky_source_catalog.order_search(max_order=1)
     pixel_orders = [pixel.order for pixel in order_search_catalog.get_healpix_pixels()]
     assert all(0 <= order <= 1 for order in pixel_orders)
-    assert_divisions_are_correct(order_search_catalog)
+    helpers.assert_divisions_are_correct(order_search_catalog)
 
 
 def test_order_search_keeps_all_points(small_sky_source_catalog):

--- a/tests/lsdb/catalog/test_polygon_search.py
+++ b/tests/lsdb/catalog/test_polygon_search.py
@@ -9,7 +9,7 @@ from lsdb.core.search.polygon_search import get_cartesian_polygon
 
 
 @pytest.mark.sphgeom
-def test_polygon_search_filters_correct_points(small_sky_order1_catalog, assert_divisions_are_correct):
+def test_polygon_search_filters_correct_points(small_sky_order1_catalog, helpers):
     vertices = [(300, -50), (300, -55), (272, -55), (272, -50)]
     polygon = get_cartesian_polygon(vertices)
     polygon_search_catalog = small_sky_order1_catalog.polygon_search(vertices)
@@ -23,13 +23,11 @@ def test_polygon_search_filters_correct_points(small_sky_order1_catalog, assert_
         polygon_search_df[small_sky_order1_catalog.hc_structure.catalog_info.dec_column]
     )
     assert all(polygon.contains(ra_values_radians, dec_values_radians))
-    assert_divisions_are_correct(polygon_search_catalog)
+    helpers.assert_divisions_are_correct(polygon_search_catalog)
 
 
 @pytest.mark.sphgeom
-def test_polygon_search_filters_correct_points_margin(
-    small_sky_order1_source_with_margin, assert_divisions_are_correct
-):
+def test_polygon_search_filters_correct_points_margin(small_sky_order1_source_with_margin, helpers):
     vertices = [(300, -50), (300, -55), (272, -55), (272, -50)]
     polygon = get_cartesian_polygon(vertices)
     polygon_search_catalog = small_sky_order1_source_with_margin.polygon_search(vertices)
@@ -41,7 +39,7 @@ def test_polygon_search_filters_correct_points_margin(
         polygon_search_df[small_sky_order1_source_with_margin.hc_structure.catalog_info.dec_column]
     )
     assert all(polygon.contains(ra_values_radians, dec_values_radians))
-    assert_divisions_are_correct(polygon_search_catalog)
+    helpers.assert_divisions_are_correct(polygon_search_catalog)
 
     assert polygon_search_catalog.margin is not None
     polygon_search_margin_df = polygon_search_catalog.margin.compute()
@@ -52,7 +50,7 @@ def test_polygon_search_filters_correct_points_margin(
         polygon_search_margin_df[small_sky_order1_source_with_margin.hc_structure.catalog_info.dec_column]
     )
     assert all(polygon.contains(ra_values_radians, dec_values_radians))
-    assert_divisions_are_correct(polygon_search_catalog.margin)
+    helpers.assert_divisions_are_correct(polygon_search_catalog.margin)
 
 
 @pytest.mark.sphgeom

--- a/tests/lsdb/loaders/dataframe/test_from_dataframe.py
+++ b/tests/lsdb/loaders/dataframe/test_from_dataframe.py
@@ -33,9 +33,7 @@ def get_catalog_kwargs(catalog, **kwargs):
     return kwargs
 
 
-def test_from_dataframe(
-    small_sky_order1_dir, small_sky_order1_df, small_sky_order1_catalog, assert_divisions_are_correct
-):
+def test_from_dataframe(small_sky_order1_dir, small_sky_order1_df, small_sky_order1_catalog, helpers):
     """Tests that we can initialize a catalog from a Pandas Dataframe and
     that the loaded content is correct"""
     kwargs = get_catalog_kwargs(small_sky_order1_catalog)
@@ -56,7 +54,7 @@ def test_from_dataframe(
         small_sky_order1_catalog.compute().sort_values([SPATIAL_INDEX_COLUMN, "id"]),
     )
     # Divisions belong to the respective HEALPix pixels
-    assert_divisions_are_correct(catalog)
+    helpers.assert_divisions_are_correct(catalog)
     # The arrow schema was automatically inferred
     expected_schema = hc.read_hats(small_sky_order1_dir).schema
     assert catalog.hc_structure.schema.equals(expected_schema)
@@ -152,7 +150,7 @@ def test_partitions_obey_threshold(small_sky_order1_df, small_sky_order1_catalog
     assert all(num_pixels <= threshold for num_pixels in num_partition_pixels)
 
 
-def test_from_dataframe_large_input(small_sky_order1_catalog, assert_divisions_are_correct):
+def test_from_dataframe_large_input(small_sky_order1_catalog, helpers):
     """Tests that we can initialize a catalog from a LARGE Pandas Dataframe and
     that we're warned about the catalog's size"""
     original_catalog_info = small_sky_order1_catalog.hc_structure.catalog_info
@@ -177,7 +175,7 @@ def test_from_dataframe_large_input(small_sky_order1_catalog, assert_divisions_a
     # Index is set to spatial index
     assert catalog._ddf.index.name == SPATIAL_INDEX_COLUMN
     # Divisions belong to the respective HEALPix pixels
-    assert_divisions_are_correct(catalog)
+    helpers.assert_divisions_are_correct(catalog)
 
 
 def test_partitions_obey_default_threshold_when_no_arguments_specified(


### PR DESCRIPTION
Refactors catalogs to create returned objects using a new `_create_updated_dataset` that sets `total_rows` to 0 and updates the `schema` and `default_columns` properties in the `hc_structure`. 

Fixes #566 fixes #178 fixes #143