### PR TITLE
Crossmatch pandas dataframe with an lsdb catalog

### DIFF
--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -261,33 +261,24 @@ class Catalog(HealpixDataset):
 
         See `crossmatch` for details on the cross-matching process.
 
-        Parameters
-        ----------
-        other : pd.DataFrame
-            The DataFrame to cross-match against the catalog.
-        suffixes : tuple[str, str], optional
-            A pair of suffixes to be appended to each column name when they are joined.
-            Defaults to using the catalog name as the suffix.
-        algorithm : BuiltInCrossmatchAlgorithm | Type[AbstractCrossmatchAlgorithm], optional
-            The algorithm used for cross-matching. Can be either a string to specify one of
-                the built-in cross-matching methods, or a custom method defined by subclassing
+        Args:
+            other (pd.DataFrame): The DataFrame to cross-match against the catalog.
+            suffixes (Tuple[str, str], optional): A pair of suffixes to be appended to each column
+                name when they are joined. Defaults to using the catalog name as the suffix.
+            algorithm (BuiltInCrossmatchAlgorithm | Type[AbstractCrossmatchAlgorithm], optional): The
+                algorithm used for cross-matching. Can be either a string to specify one of the
+                built-in cross-matching methods, or a custom method defined by subclassing
                 AbstractCrossmatchAlgorithm. Defaults to `BuiltInCrossmatchAlgorithm.KD_TREE`.
-        output_catalog_name : str, optional
-            The name of the resulting catalog. Defaults to `{left_name}_x_{right_name}`.
-        **kwargs
-            Additional keyword arguments for both `from_dataframe` and `crossmatch`.
-            Any arguments recognized by `from_dataframe` will be passed accordingly.
+            output_catalog_name (str, optional): The name of the resulting catalog.
+                Default: `{left_name}_x_{right_name}`
+            require_right_margin (bool, optional): If `True`, raises an error if the right margin is missing,
+                which could lead to incomplete crossmatches. Default: `False`.
+            **kwargs: Additional keyword arguments for both `from_dataframe` and `crossmatch`.
+                Any arguments recognized by `from_dataframe` will be passed accordingly.
 
-        Returns
-        -------
-        Catalog
-            A `Catalog` with data from the input catalog and DataFrame, cross-matched
+        Returns:
+            Catalog: A `Catalog` with data from the input catalog and DataFrame, cross-matched
             according to the specified algorithm.
-
-        See Also
-        --------
-        crossmatch : Performs cross-matching between two `Catalog` objects.
-        from_dataframe : Converts a DataFrame into a `Catalog` with spatial partitioning.
         """
         # Lazy import to avoid circular dependencies.
         # pylint: disable=C0415

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -32,6 +32,7 @@ from lsdb.dask.join_catalog_data import (
 from lsdb.dask.merge_map_catalog_data import merge_map_catalog_data
 from lsdb.dask.partition_indexer import PartitionIndexer
 from lsdb.io.schema import get_arrow_schema
+from lsdb.loaders.dataframe.from_dataframe import from_dataframe
 from lsdb.types import DaskDFPixelMap
 
 
@@ -241,6 +242,26 @@ class Catalog(HealpixDataset):
             new_catalog_info, alignment.pixel_tree, schema=get_arrow_schema(ddf), moc=alignment.moc
         )
         return Catalog(ddf, ddf_map, hc_catalog)
+
+    def crossmatch_df(
+        self,
+        other: pd.DataFrame,
+        suffixes: tuple[str, str] | None = None,
+        algorithm: (
+            Type[AbstractCrossmatchAlgorithm] | BuiltInCrossmatchAlgorithm
+        ) = BuiltInCrossmatchAlgorithm.KD_TREE,
+        output_catalog_name: str | None = None,
+        require_right_margin: bool = False,
+        **kwargs,
+    ) -> Catalog:
+        """Perform a cross-match between a catalog and a DataFrame."""
+        # Convert the given DataFrame to a Catalog. Pass along any additional keyword arguments.
+        other_catalog = from_dataframe(other, **kwargs)
+
+        # Call the crossmatch method with the newly generated Catalog.
+        return self.crossmatch(
+            other_catalog, suffixes, algorithm, output_catalog_name, require_right_margin, **kwargs
+        )
 
     def merge_map(
         self,

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -244,7 +244,7 @@ class Catalog(HealpixDataset):
 
     def crossmatch_dataframe(
         self,
-        other: pd.DataFrame,
+        other: npd.NestedFrame,
         suffixes: tuple[str, str] | None = None,
         algorithm: (
             Type[AbstractCrossmatchAlgorithm] | BuiltInCrossmatchAlgorithm

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from typing import Callable, Type
 
 import hats as hc
@@ -285,25 +286,9 @@ class Catalog(HealpixDataset):
         from lsdb.loaders.dataframe.from_dataframe import from_dataframe
 
         # Separate kwargs for from_dataframe and crossmatch
-        from_dataframe_kwargs = {
-            k: kwargs.pop(k)
-            for k in (
-                "ra_column",
-                "dec_column",
-                "lowest_order",
-                "highest_order",
-                "drop_empty_siblings",
-                "partition_size",
-                "threshold",
-                "margin_order",
-                "margin_threshold",
-                "should_generate_moc",
-                "moc_max_order",
-                "use_pyarrow_types",
-                "schema",
-            )
-            if k in kwargs
-        }
+        sig = inspect.signature(from_dataframe)
+        from_dataframe_arg_names = list(sig.parameters.keys())
+        from_dataframe_kwargs = {k: kwargs.pop(k) for k in kwargs if k in from_dataframe_arg_names}
 
         # Convert the given DataFrame to a Catalog.
         other_catalog = from_dataframe(other, **from_dataframe_kwargs)

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -288,7 +288,7 @@ class Catalog(HealpixDataset):
         # Separate kwargs for from_dataframe and crossmatch
         sig = inspect.signature(from_dataframe)
         from_dataframe_arg_names = list(sig.parameters.keys())
-        from_dataframe_kwargs = {k: kwargs.pop(k) for k in kwargs if k in from_dataframe_arg_names}
+        from_dataframe_kwargs = {k: kwargs.pop(k) for k in from_dataframe_arg_names if k in kwargs}
 
         # Convert the given DataFrame to a Catalog.
         other_catalog = from_dataframe(other, **from_dataframe_kwargs)

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -246,7 +246,7 @@ class Catalog(HealpixDataset):
         See `crossmatch` for details on the cross-matching process.
 
         Args:
-            other (pd.DataFrame): The DataFrame to cross-match against the catalog.
+            other (npd.NestedFrame): The frame to cross-match against the catalog.
             suffixes (Tuple[str, str], optional): A pair of suffixes to be appended to each column
                 name when they are joined. Defaults to using the catalog name as the suffix.
             algorithm (BuiltInCrossmatchAlgorithm | Type[AbstractCrossmatchAlgorithm], optional): The

--- a/src/lsdb/loaders/dataframe/from_dataframe.py
+++ b/src/lsdb/loaders/dataframe/from_dataframe.py
@@ -1,15 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pandas as pd
 import pyarrow as pa
 
+from lsdb.catalog import Catalog
 from lsdb.loaders.dataframe.dataframe_catalog_loader import DataframeCatalogLoader
 from lsdb.loaders.dataframe.margin_catalog_generator import MarginCatalogGenerator
-
-if TYPE_CHECKING:
-    from lsdb.catalog import Catalog
 
 
 # pylint: disable=too-many-arguments

--- a/src/lsdb/loaders/dataframe/from_dataframe.py
+++ b/src/lsdb/loaders/dataframe/from_dataframe.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pandas as pd
 import pyarrow as pa
 
-from lsdb.catalog import Catalog
 from lsdb.loaders.dataframe.dataframe_catalog_loader import DataframeCatalogLoader
 from lsdb.loaders.dataframe.margin_catalog_generator import MarginCatalogGenerator
+
+if TYPE_CHECKING:
+    from lsdb.catalog import Catalog
 
 
 # pylint: disable=too-many-arguments

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -126,9 +126,7 @@ class TestCrossmatch:
     def test_right_margin_missing(algo, small_sky_catalog, small_sky_xmatch_catalog):
         small_sky_xmatch_catalog.margin = None
         with pytest.raises(ValueError, match="Right catalog margin"):
-            small_sky_catalog.crossmatch(
-                small_sky_xmatch_catalog, algorithm=algo, require_right_margin=True, testing_line_length=True
-            )
+            small_sky_catalog.crossmatch(small_sky_xmatch_catalog, algorithm=algo, require_right_margin=True)
 
     @staticmethod
     def test_dataframe_crossmatch(algo, small_sky_catalog, small_sky_xmatch_catalog, xmatch_correct):


### PR DESCRIPTION
Closes #578 

Note:
- The function signatures between `crossmatch` and `crossmatch_dataframe` were almost completely preserved, except the omission of `require_right_margin`, which doesn't make sense for a dataframe where we can (and unless otherwise specified in kwargs, will) generate the margin on the spot.
- I took my best shot at allowing the user to pass kwargs to `from_dataframe`, but I'm not thrilled at the need to keep this list up to date with the possible args `from_dataframe` will accept. However, without filtering the overall kwargs at this point, `self.crossmatch` on L312 will crash when encountering unexpected kwargs. Open to alternate strategies here.