### PR TITLE
Add testing after updating catalog structure.

### DIFF
--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -136,6 +136,7 @@ def test_query(small_sky_order1_catalog, helpers):
     assert isinstance(result_catalog._ddf, nd.NestedFrame)
     pd.testing.assert_frame_equal(result_catalog._ddf.compute(), expected_ddf.compute())
     helpers.assert_schema_correct(result_catalog)
+    assert result_catalog.hc_structure.catalog_path is not None
 
 
 def test_query_margin(small_sky_xmatch_with_margin):
@@ -710,6 +711,7 @@ def test_map_partitions(small_sky_order1_catalog):
     mapcomp = mapped.compute()
     assert isinstance(mapcomp, npd.NestedFrame)
     assert np.all(mapcomp["a"] == mapcomp["ra"] + 1)
+    assert mapped.hc_structure.catalog_path is not None
 
 
 def test_map_partitions_include_pixel(small_sky_order1_catalog):

--- a/tests/lsdb/catalog/test_cone_search.py
+++ b/tests/lsdb/catalog/test_cone_search.py
@@ -28,6 +28,7 @@ def test_cone_search_filters_correct_points(small_sky_order1_catalog, helpers):
         else:
             assert len(cone_search_df.loc[cone_search_df["id"] == row["id"]]) == 0
     helpers.assert_divisions_are_correct(cone_search_catalog)
+    assert cone_search_catalog.hc_structure.catalog_path is not None
 
 
 def test_cone_search_filters_correct_points_margin(

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -53,6 +53,7 @@ class TestCrossmatch:
         alignment = align_catalogs(small_sky_order1_default_cols_catalog, small_sky_xmatch_catalog)
         assert xmatched_cat.hc_structure.moc == alignment.moc
         assert xmatched_cat.get_healpix_pixels() == alignment.pixel_tree.get_healpix_pixels()
+        assert not xmatched_cat.hc_structure.on_disk
 
         assert isinstance(xmatched, npd.NestedFrame)
         assert len(xmatched) == len(xmatch_correct)

--- a/tests/lsdb/catalog/test_join.py
+++ b/tests/lsdb/catalog/test_join.py
@@ -38,6 +38,7 @@ def test_small_sky_join_small_sky_order1(small_sky_catalog, small_sky_order1_cat
     helpers.assert_divisions_are_correct(joined)
     helpers.assert_schema_correct(joined)
     helpers.assert_hive_columns_correct(joined)
+    assert not joined.hc_structure.on_disk
 
 
 def test_small_sky_join_small_sky_order1_source(


### PR DESCRIPTION
Serves to test upstream changes in https://github.com/astronomy-commons/hats/pull/470