### PR TITLE
New catalog preview methods tail, sample, and random_sample

### DIFF
--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -287,6 +287,10 @@ class HealpixDataset(Dataset):
         partition = self._ddf.partitions[partition_id]
         # Get the count of rows in the partition.
         pixel_rows = len(partition)
+        if pixel_rows == 0:
+            fraction = 0.0
+            logging.debug("Zero rows in partition %d, returning empty", partition_id)
+            return partition._meta
         fraction = n / pixel_rows
         logging.debug("Getting %d / %d = %f", n, pixel_rows, fraction)
         return partition.sample(frac=fraction).compute()

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -227,7 +227,7 @@ class HealpixDataset(Dataset):
             n (int): The number of desired rows.
 
         Returns:
-            A pandas DataFrame with up to `n` rows of data.
+            A NestedFrame with up to `n` rows of data.
         """
         dfs = []
         remaining_rows = n
@@ -249,7 +249,7 @@ class HealpixDataset(Dataset):
             n (int): The number of desired rows.
 
         Returns:
-            A pandas DataFrame with up to `n` rows of data.
+            A NestedFrame with up to `n` rows of data.
         """
         dfs = []
         remaining_rows = n
@@ -277,7 +277,7 @@ class HealpixDataset(Dataset):
         as in unit tests.
 
         Returns:
-            A pandas DataFrame with up to `n` rows of data.
+            A NestedFrame with up to `n` rows of data.
         """
         random.seed(seed)
         # Get the number of partitions so that we can range-check the input argument
@@ -309,7 +309,7 @@ class HealpixDataset(Dataset):
         as in unit tests.
 
         Returns:
-            A pandas DataFrame with up to `n` rows of data.
+            A NestedFrame with up to `n` rows of data.
         """
         random.seed(seed)
         dfs = []

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -272,6 +272,11 @@ class HealpixDataset(Dataset):
             n (int): the number of desired rows.
             seed (int): random seed
 
+        As with `NestedFrame.sample`, `n` is an approximate number of
+        items to return.  The exact number of elements selected will
+        depend on how your data is partitioned.  (In practice, it
+        should be pretty close.)
+
         The `seed` argument is passed directly to `random.seed` in order
         to assist with creating predictable outputs when wanted, such
         as in unit tests.
@@ -303,6 +308,11 @@ class HealpixDataset(Dataset):
         Args:
             n (int): the number of desired rows.
             seed (int): random seed
+
+        As with `.sample`, `n` is an approximate number of items to
+        return.  The exact number of elements selected will depend on
+        how your data is partitioned.  (In practice, it should be
+        pretty close.)
 
         The `seed` argument is passed directly to `random.seed` in order
         to assist with creating predictable outputs when wanted, such

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -41,7 +41,7 @@ from lsdb.io.schema import get_arrow_schema
 from lsdb.types import DaskDFPixelMap
 
 
-# pylint: disable=protected-access,too-many-public-methods
+# pylint: disable=protected-access,too-many-public-methods,too-many-lines
 class HealpixDataset(Dataset):
     """LSDB Catalog DataFrame to perform analysis of sky catalogs and efficient
     spatial operations.
@@ -273,7 +273,6 @@ class HealpixDataset(Dataset):
             A pandas DataFrame with up to `n` rows of data.
         """
         dfs = []
-        remaining_rows = n
         partition = self._ddf.partitions[partition_id]
         # Get the count of rows in the partition.
         pixel_rows = len(partition)
@@ -306,7 +305,6 @@ class HealpixDataset(Dataset):
             row_counts = stats[f"{rep_col}: row_count"].map(int)
         else:
             row_counts = np.array(dask.compute(*[dp.shape[0].to_delayed() for dp in self._ddf.partitions]))
-        npartitions = len(row_counts)
         rows_per_partition = np.random.multinomial(n, row_counts / row_counts.sum())
         # With this breakdown, we randomly sample rows from each partition
         # to collect the entire sampling.

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -173,32 +173,6 @@ def test_random_sample(small_sky_order1_catalog):
     assert len(rsample_df) == 10
 
 
-# def test_random_sample_rows_less_than_requested(small_sky_order1_catalog):
-#     schema = small_sky_order1_catalog.dtypes
-#     two_rows = small_sky_order1_catalog._ddf.partitions[0].compute()[:2]
-#     tiny_df = pd.DataFrame(data=two_rows, columns=schema.index, dtype=schema.to_numpy())
-#     altered_ndf = nd.NestedFrame.from_pandas(tiny_df, npartitions=1)
-#     catalog = lsdb.Catalog(altered_ndf, {}, small_sky_order1_catalog.hc_structure)
-#     # The random sample must only contain two values
-#     assert len(catalog.random_sample(seed=0)) == 2
-
-
-def test_random_sample_first_partition_is_empty(small_sky_order1_catalog):
-    # The same catalog but now the first partition is empty
-    schema = small_sky_order1_catalog.dtypes
-    empty_df = pd.DataFrame(columns=schema.index, dtype=schema.to_numpy())
-    empty_ddf = dd.from_pandas(empty_df, npartitions=1)
-    altered_ndf = nd.NestedFrame.from_dask_dataframe(dd.concat([empty_ddf, small_sky_order1_catalog._ddf]))
-    catalog = lsdb.Catalog(altered_ndf, {}, small_sky_order1_catalog.hc_structure)
-    # The first partition is empty
-    first_partition_df = catalog._ddf.partitions[0].compute()
-    assert len(first_partition_df) == 0
-    # We still get values from the second (non-empty) partition
-    # TODO: fix this
-    assert True
-    # assert len(catalog.random_sample(seed=0)) == 5
-
-
 def test_random_sample_empty_catalog(small_sky_order1_catalog):
     # Create an empty Pandas DataFrame with the same schema
     schema = small_sky_order1_catalog.dtypes
@@ -206,6 +180,31 @@ def test_random_sample_empty_catalog(small_sky_order1_catalog):
     empty_ddf = dd.from_pandas(empty_df, npartitions=1)
     empty_catalog = lsdb.Catalog(empty_ddf, {}, small_sky_order1_catalog.hc_structure)
     assert len(empty_catalog.random_sample(seed=0)) == 0
+
+
+def test_sample(small_sky_order1_catalog):
+    # By default, sample returns 5 rows
+    sample_df = small_sky_order1_catalog.sample(partition_id=0, seed=0)
+    assert isinstance(sample_df, npd.NestedFrame)
+    assert len(sample_df) == 5
+    # But we can also specify the number of rows we desire
+    sample_df = small_sky_order1_catalog.sample(partition_id=0, n=10, seed=0)
+    assert len(sample_df) == 10
+    # Verify that partition_id is verified to be in range
+    with pytest.raises(IndexError):
+        small_sky_order1_catalog.sample(partition_id=-1, n=10, seed=0)
+    with pytest.raises(IndexError):
+        npartitions = len(small_sky_order1_catalog.get_healpix_pixels())
+        small_sky_order1_catalog.sample(partition_id=npartitions, n=10)
+
+
+def test_sample_empty_catalog(small_sky_order1_catalog):
+    # Create an empty Pandas DataFrame with the same schema
+    schema = small_sky_order1_catalog.dtypes
+    empty_df = pd.DataFrame(columns=schema.index, dtype=schema.to_numpy())
+    empty_ddf = dd.from_pandas(empty_df, npartitions=1)
+    empty_catalog = lsdb.Catalog(empty_ddf, {}, small_sky_order1_catalog.hc_structure)
+    assert len(empty_catalog.sample(partition_id=0, seed=0)) == 0
 
 
 def test_query(small_sky_order1_catalog, helpers):

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -115,6 +115,53 @@ def test_head_empty_catalog(small_sky_order1_catalog):
     assert len(empty_catalog.head()) == 0
 
 
+def test_tail(small_sky_order1_catalog):
+    # By default, tail returns 5 rows
+    expected_df = small_sky_order1_catalog._ddf.partitions[0].compute()[-5:]
+    tail_df = small_sky_order1_catalog.tail()
+    assert isinstance(tail_df, npd.NestedFrame)
+    assert len(tail_df) == 5
+    pd.testing.assert_frame_equal(expected_df, tail_df)
+    # But we can also specify the number of rows we desire
+    expected_df = small_sky_order1_catalog._ddf.partitions[0].compute()[-10:]
+    tail_df = small_sky_order1_catalog.tail(n=10)
+    assert len(tail_df) == 10
+    pd.testing.assert_frame_equal(expected_df, tail_df)
+
+
+def test_tail_rows_less_than_requested(small_sky_order1_catalog):
+    schema = small_sky_order1_catalog.dtypes
+    two_rows = small_sky_order1_catalog._ddf.partitions[0].compute()[-2:]
+    tiny_df = pd.DataFrame(data=two_rows, columns=schema.index, dtype=schema.to_numpy())
+    altered_ndf = nd.NestedFrame.from_pandas(tiny_df, npartitions=1)
+    catalog = lsdb.Catalog(altered_ndf, {}, small_sky_order1_catalog.hc_structure)
+    # The tail only contains two values
+    assert len(catalog.tail()) == 2
+
+
+def test_tail_first_partition_is_empty(small_sky_order1_catalog):
+    # The same catalog but now the first partition is empty
+    schema = small_sky_order1_catalog.dtypes
+    empty_df = pd.DataFrame(columns=schema.index, dtype=schema.to_numpy())
+    empty_ddf = dd.from_pandas(empty_df, npartitions=1)
+    altered_ndf = nd.NestedFrame.from_dask_dataframe(dd.concat([empty_ddf, small_sky_order1_catalog._ddf]))
+    catalog = lsdb.Catalog(altered_ndf, {}, small_sky_order1_catalog.hc_structure)
+    # The first partition is empty
+    first_partition_df = catalog._ddf.partitions[0].compute()
+    assert len(first_partition_df) == 0
+    # We still get values from the second (non-empty) partition
+    assert len(catalog.tail()) == 5
+
+
+def test_tail_empty_catalog(small_sky_order1_catalog):
+    # Create an empty Pandas DataFrame with the same schema
+    schema = small_sky_order1_catalog.dtypes
+    empty_df = pd.DataFrame(columns=schema.index, dtype=schema.to_numpy())
+    empty_ddf = dd.from_pandas(empty_df, npartitions=1)
+    empty_catalog = lsdb.Catalog(empty_ddf, {}, small_sky_order1_catalog.hc_structure)
+    assert len(empty_catalog.tail()) == 0
+
+
 def test_query(small_sky_order1_catalog, helpers):
     expected_ddf = small_sky_order1_catalog._ddf.copy()[
         (small_sky_order1_catalog._ddf["ra"] > 300) & (small_sky_order1_catalog._ddf["dec"] < -50)

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 from pathlib import Path
 
 import astropy.units as u
@@ -160,6 +161,51 @@ def test_tail_empty_catalog(small_sky_order1_catalog):
     empty_ddf = dd.from_pandas(empty_df, npartitions=1)
     empty_catalog = lsdb.Catalog(empty_ddf, {}, small_sky_order1_catalog.hc_structure)
     assert len(empty_catalog.tail()) == 0
+
+
+def test_random_sample(small_sky_order1_catalog):
+    # By default, random_sample returns 5 rows
+    rsample_df = small_sky_order1_catalog.random_sample(seed=0)
+    assert isinstance(rsample_df, npd.NestedFrame)
+    assert len(rsample_df) == 5
+    # But we can also specify the number of rows we desire
+    rsample_df = small_sky_order1_catalog.random_sample(n=10, seed=0)
+    assert len(rsample_df) == 10
+
+
+# def test_random_sample_rows_less_than_requested(small_sky_order1_catalog):
+#     schema = small_sky_order1_catalog.dtypes
+#     two_rows = small_sky_order1_catalog._ddf.partitions[0].compute()[:2]
+#     tiny_df = pd.DataFrame(data=two_rows, columns=schema.index, dtype=schema.to_numpy())
+#     altered_ndf = nd.NestedFrame.from_pandas(tiny_df, npartitions=1)
+#     catalog = lsdb.Catalog(altered_ndf, {}, small_sky_order1_catalog.hc_structure)
+#     # The random sample must only contain two values
+#     assert len(catalog.random_sample(seed=0)) == 2
+
+
+def test_random_sample_first_partition_is_empty(small_sky_order1_catalog):
+    # The same catalog but now the first partition is empty
+    schema = small_sky_order1_catalog.dtypes
+    empty_df = pd.DataFrame(columns=schema.index, dtype=schema.to_numpy())
+    empty_ddf = dd.from_pandas(empty_df, npartitions=1)
+    altered_ndf = nd.NestedFrame.from_dask_dataframe(dd.concat([empty_ddf, small_sky_order1_catalog._ddf]))
+    catalog = lsdb.Catalog(altered_ndf, {}, small_sky_order1_catalog.hc_structure)
+    # The first partition is empty
+    first_partition_df = catalog._ddf.partitions[0].compute()
+    assert len(first_partition_df) == 0
+    # We still get values from the second (non-empty) partition
+    # TODO: fix this
+    assert True
+    # assert len(catalog.random_sample(seed=0)) == 5
+
+
+def test_random_sample_empty_catalog(small_sky_order1_catalog):
+    # Create an empty Pandas DataFrame with the same schema
+    schema = small_sky_order1_catalog.dtypes
+    empty_df = pd.DataFrame(columns=schema.index, dtype=schema.to_numpy())
+    empty_ddf = dd.from_pandas(empty_df, npartitions=1)
+    empty_catalog = lsdb.Catalog(empty_ddf, {}, small_sky_order1_catalog.hc_structure)
+    assert len(empty_catalog.random_sample(seed=0)) == 0
 
 
 def test_query(small_sky_order1_catalog, helpers):


### PR DESCRIPTION
Add a few more preview methods to `lsdb.Catalog`, allowing a user to get a quick sense of what data is in the catalog.  New methods are:

```python
def tail(self, n: int = 5) -> npd.NestedFrame:
    """Returns a few rows of data from the end of the catalog for previewing purposes.
    """

def sample(self, partition_id: int, n: int = 5) -> npd.NestedFrame:
    """Returns a few randomly sampled rows from a given partition.
    """

def random_sample(self, n: int = 5) -> npd.NestedFrame:
    """Returns a few randomly sampled rows, like self.sample(),
       except that it randomly samples all partitions in order to
       fulfill the rows.
    """
```

Closes #549.