### PR TITLE
Add npartitions property to top of catalog.

### DIFF
--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -220,6 +220,11 @@ class HealpixDataset(Dataset):
         """Returns the partitions of the catalog"""
         return PartitionIndexer(self)
 
+    @property
+    def npartitions(self):
+        """Returns the number of partitions of the catalog"""
+        return len(self.get_healpix_pixels())
+
     def head(self, n: int = 5) -> npd.NestedFrame:
         """Returns a few rows of initial data for previewing purposes.
 

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -69,6 +69,11 @@ def test_get_catalog_partition_gets_correct_partition(small_sky_order1_catalog):
         pd.testing.assert_frame_equal(partition.compute(), ddf_partition.compute())
 
 
+def test_npartitions_property(small_sky_order1_catalog):
+    underlying_count = len(small_sky_order1_catalog.get_healpix_pixels())
+    assert underlying_count == small_sky_order1_catalog.npartitions
+
+
 def test_head(small_sky_order1_catalog):
     # By default, head returns 5 rows
     expected_df = small_sky_order1_catalog._ddf.partitions[0].compute()[:5]


### PR DESCRIPTION
When an LSDB catalog is displayed in a Jupyter notebook, the number of partitions in a catalog `c` is available as `n = len(c.get_healpix_pixels())`. But the information is displayed as `npartitions=<n>` in the notebook, leading the user to expect a property with the name `npartitions`.

Closes #627 .