### PR TITLE
Crossmatch dataframes —expand ra/dec column name defaults, clarify docstring wording

### DIFF
--- a/src/lsdb/core/crossmatch/crossmatch.py
+++ b/src/lsdb/core/crossmatch/crossmatch.py
@@ -68,9 +68,13 @@ def crossmatch(
         left (Catalog | NestedFrame): The left catalog or frame to crossmatch.
         right (Catalog | NestedFrame): The right catalog or frame to crossmatch.
         ra_column (str, optional): The name of the right ascension column for both catalogs,
-            if passing dataframes. Defaults to None.
+            if passing dataframes. Can be specified in the left_args or right_args dictionaries if
+            left and right catalogs have different RA column names. Defaults to None, which will use
+            the default column names "ra" or "RA" if they exist in the DataFrame.
         dec_column (str, optional): The name of the declination column for both catalogs,
-            if passing dataframes. Defaults to None.
+            if passing dataframes. Can be specified in the left_args or right_args dictionaries if
+            left and right catalogs have different dec column names. Defaults to None, which will use
+            the default column names "dec" or "DEC" if they exist in the DataFrame.
         suffixes (tuple[str, str], optional): Suffixes to append to overlapping column names.
             Defaults to None.
         algorithm (Type[AbstractCrossmatchAlgorithm] | BuiltInCrossmatchAlgorithm, optional): The

--- a/src/lsdb/core/crossmatch/crossmatch.py
+++ b/src/lsdb/core/crossmatch/crossmatch.py
@@ -24,6 +24,8 @@ def _validate_and_convert_to_catalog(
             data_args["ra_column"] = "ra"
         elif "RA" in data.columns:
             data_args["ra_column"] = "RA"
+        elif "Ra" in data.columns:
+            data_args["ra_column"] = "Ra"
         else:
             raise ValueError("No 'ra' or 'RA' column found in DataFrame; specify 'ra_column' param.")
 
@@ -32,6 +34,8 @@ def _validate_and_convert_to_catalog(
             data_args["dec_column"] = "dec"
         elif "DEC" in data.columns:
             data_args["dec_column"] = "DEC"
+        elif "Dec" in data.columns:
+            data_args["dec_column"] = "Dec"
         else:
             raise ValueError("No 'dec' or 'DEC' column found in DataFrame; specify 'dec_column' param.")
 

--- a/tests/lsdb/core/test_crossmatch_method.py
+++ b/tests/lsdb/core/test_crossmatch_method.py
@@ -92,12 +92,10 @@ def test_ra_dec_columns_crossmatch(algo, small_sky_catalog, small_sky_xmatch_cat
     right_dataframe = small_sky_xmatch_catalog.compute()
 
     # Rename ra and dec columns to "RA" and "DEC"
-    right_dataframe_caps_ra_col = right_dataframe.rename(columns={"ra": "RA"})
-    right_dataframe_caps_dec_col = right_dataframe.rename(columns={"dec": "DEC"})
-
+    right_dataframe_caps_cols = right_dataframe.rename(columns={"ra": "RA"}).rename(columns={"dec": "DEC"})
     result = lsdb.crossmatch(
         left_dataframe,
-        right_dataframe_caps_ra_col,
+        right_dataframe_caps_cols,
         algorithm=algo,
         radius_arcsec=0.01 * 3600,
         right_args={"margin_threshold": 100},
@@ -105,9 +103,13 @@ def test_ra_dec_columns_crossmatch(algo, small_sky_catalog, small_sky_xmatch_cat
     assert isinstance(result, npd.NestedFrame)
     assert len(result) == len(xmatch_correct)
 
+    # Rename ra and dec columns to "Ra" and "Dec"
+    right_dataframe_title_case_cols = right_dataframe.rename(columns={"ra": "Ra"}).rename(
+        columns={"dec": "Dec"}
+    )
     result = lsdb.crossmatch(
         left_dataframe,
-        right_dataframe_caps_dec_col,
+        right_dataframe_title_case_cols,
         algorithm=algo,
         radius_arcsec=0.01 * 3600,
         right_args={"margin_threshold": 100},


### PR DESCRIPTION
- Adds "Ra" and "Dec" to recognized default ra/dec columns for dataframes
- Clarifies docstrings/unit test regarding the use of left/right_args for specifying column names on a per-dataframe basis