### PR TITLE
Add .loc/.iloc accessors

### DIFF
--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -88,6 +88,26 @@ class Catalog(HealpixDataset):
         cat.margin = margin
         return cat
 
+    @property
+    def iloc(self):
+        """Returns the position-indexer for the catalog"""
+        raise NotImplementedError(
+            "Access via .iloc is not supported since it would require computing the entire catalog."
+        )
+
+    @property
+    def loc(self):
+        """Returns the label-indexer for the catalog"""
+        raise NotImplementedError(
+            "Access via .loc is not allowed. Please use `Catalog.id_search` instead."
+            " For example, to retrieve a row for an object of ID 'GAIA_123' use"
+            " catalog.id_search(values={'objid':'GAIA_123'}), where 'objid' is the"
+            " column for which there is an index catalog. If `id_search` is targeted"
+            " at a column other than the collection's default index column, or if"
+            " working with a stand-alone catalog, use the `index_catalogs` argument"
+            " to specify a HATS index catalog for the desired column."
+        )
+
     def query(self, expr: str) -> Catalog:
         """Filters catalog and respective margin, if it exists, using a complex query expression
 

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -56,6 +56,16 @@ def test_catalog_uses_dask_expressions(small_sky_order1_catalog):
     assert hasattr(small_sky_order1_catalog._ddf, "expr")
 
 
+def test_catalog_iloc_raises_error(small_sky_order1_catalog):
+    with pytest.raises(NotImplementedError, match="computing the entire catalog"):
+        _ = small_sky_order1_catalog.iloc[0]
+
+
+def test_catalog_loc_raises_error(small_sky_order1_catalog):
+    with pytest.raises(NotImplementedError, match="id_search"):
+        _ = small_sky_order1_catalog.loc[707]
+
+
 def test_get_catalog_partition_gets_correct_partition(small_sky_order1_catalog):
     for healpix_pixel in small_sky_order1_catalog.get_healpix_pixels():
         hp_order = healpix_pixel.order


### PR DESCRIPTION
Add descriptive messages to Catalog's `.iloc` and `.loc` accessors. The message for `.loc` directs users to the newly created `id_search` and shortly describes how to call it. Closes #667 and closes #668. 