### PR TITLE
Display the total number of available columns

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,7 +94,7 @@ repos:
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.11
+        language_version: python3.12
     # Analyze type hints and report errors.
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,7 +94,7 @@ repos:
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.12
+        language_version: python3.11
     # Analyze type hints and report errors.
   - repo: local
     hooks:

--- a/src/lsdb/catalog/dataset/dataset.py
+++ b/src/lsdb/catalog/dataset/dataset.py
@@ -31,11 +31,13 @@ class Dataset:
 
     def _repr_html_(self):
         data = self._repr_data().to_html(max_rows=5, show_dimensions=False, notebook=True)
+        loaded_cols = len(self.columns)
+        available_cols = len(self.all_columns)
         return (
             f"<div><strong>lsdb Catalog {self.name}:</strong></div>"
             f"{data}"
-            f"<div>The catalog has been loaded <strong>lazily</strong>, meaning no data has been read, only "
-            f"the catalog schema</div>"
+            f"<div>{loaded_cols} out of {available_cols} columns in the catalog have been loaded "
+            f"<strong>lazily</strong>, meaning no data has been read, only the catalog schema</div>"
         )
 
     def _repr_data(self):

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -45,7 +45,7 @@ def test_catalog_html_repr(small_sky_order1_catalog):
     assert small_sky_order1_catalog.name in full_html
     assert str(small_sky_order1_catalog.get_ordered_healpix_pixels()[0]) in full_html
     assert str(small_sky_order1_catalog.get_ordered_healpix_pixels()[-1]) in full_html
-    assert "The catalog has been loaded <strong>lazily</strong>" in full_html
+    assert "columns in the catalog have been loaded <strong>lazily</strong>" in full_html
 
 
 def test_catalog_compute_equals_ddf_compute(small_sky_order1_catalog):


### PR DESCRIPTION
Building on the `all_columns` property and the default-columns behavior, display to the user in Jupyter notebooks when a catalog is lazily loaded, how many columns have been loaded versus how many are available.

Closes #662 .