### PR TITLE
Raise a helpful error message when the user is accessing a catalog's column that hasn't been loaded.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,7 +94,7 @@ repos:
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.11
+        language_version: python3.12
     # Analyze type hints and report errors.
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,7 +94,7 @@ repos:
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.12
+        language_version: python3.11
     # Analyze type hints and report errors.
   - repo: local
     hooks:

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -680,19 +680,18 @@ class Catalog(HealpixDataset):
         if len(suffixes) != 2:
             raise ValueError("`suffixes` must be a tuple with two strings")
 
-        # This is kind of a mess
-        def harmonize(col: str | list[str] | None) -> list[str]:
+        def make_strlist(col: str | list[str] | None) -> list[str]:
             if not col:
                 return []
             if isinstance(col, str):
                 return [col]
             return col
 
-        names_to_check = harmonize(on)
+        names_to_check = make_strlist(on)
         if not left_index:
-            names_to_check += harmonize(left_on)
+            names_to_check += make_strlist(left_on)
         if not right_index:
-            names_to_check += harmonize(right_on)
+            names_to_check += make_strlist(right_on)
         self.check_unloaded_columns(names_to_check)
         return self._ddf.merge(
             other._ddf,

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -150,7 +150,7 @@ class Catalog(HealpixDataset):
                 new_data = da.arange(...)
                 catalog = catalog.assign(new_col=new_data)
         """
-        self.check_unloaded_columns(list(kwargs.keys()))
+        self._check_unloaded_columns(list(kwargs.keys()))
         ddf = self._ddf.assign(**kwargs)
         return self._create_updated_dataset(ddf=ddf)
 
@@ -504,7 +504,7 @@ class Catalog(HealpixDataset):
         Returns:
             A new Catalog containing the results of the column match.
         """
-        self.check_unloaded_columns(list(values.keys()))
+        self._check_unloaded_columns(list(values.keys()))
 
         def _get_index_catalog_for_field(field: str):
             """Find the index catalog for `field`. Index catalogs declared
@@ -681,7 +681,7 @@ class Catalog(HealpixDataset):
             raise ValueError("`suffixes` must be a tuple with two strings")
 
         def make_strlist(col: str | list[str] | None) -> list[str]:
-            if not col:
+            if col is None:
                 return []
             if isinstance(col, str):
                 return [col]
@@ -692,7 +692,7 @@ class Catalog(HealpixDataset):
             names_to_check += make_strlist(left_on)
         if not right_index:
             names_to_check += make_strlist(right_on)
-        self.check_unloaded_columns(names_to_check)
+        self._check_unloaded_columns(names_to_check)
         return self._ddf.merge(
             other._ddf,
             how=how,
@@ -784,7 +784,7 @@ class Catalog(HealpixDataset):
         if len(suffixes) != 2:
             raise ValueError("`suffixes` must be a tuple with two strings")
 
-        self.check_unloaded_columns([left_on, right_on])
+        self._check_unloaded_columns([left_on, right_on])
 
         if through is not None:
             ddf, ddf_map, alignment = join_catalog_data_through(self, other, through, suffixes)
@@ -857,11 +857,11 @@ class Catalog(HealpixDataset):
         if left_on is None or right_on is None:
             raise ValueError("Both of left_on and right_on must be set")
 
-        self.check_unloaded_columns([left_on])
+        self._check_unloaded_columns([left_on])
         if left_on not in self._ddf.columns:
             raise ValueError("left_on must be a column in the left catalog")
 
-        other.check_unloaded_columns([right_on])
+        other._check_unloaded_columns([right_on])
         if right_on not in other._ddf.columns:
             raise ValueError("right_on must be a column in the right catalog")
 
@@ -988,7 +988,7 @@ class Catalog(HealpixDataset):
         to a single layer, multi-layer operations are not supported at this
         time.
         """
-        self.check_unloaded_columns(subset)
+        self._check_unloaded_columns(subset)
         catalog = super().dropna(
             axis=axis, how=how, thresh=thresh, on_nested=on_nested, subset=subset, ignore_index=ignore_index
         )

--- a/src/lsdb/catalog/dataset/dataset.py
+++ b/src/lsdb/catalog/dataset/dataset.py
@@ -98,7 +98,7 @@ class Dataset:
             raise ValueError("Original catalog schema is not available")
         return self.hc_structure.original_schema
 
-    def check_unloaded_columns(self, column_names: Sequence[str | None] | None):
+    def _check_unloaded_columns(self, column_names: Sequence[str | None] | None):
         """Check the list of given column names for any that are valid
         but unavailable because they were not loaded.
         """

--- a/src/lsdb/catalog/dataset/dataset.py
+++ b/src/lsdb/catalog/dataset/dataset.py
@@ -95,7 +95,7 @@ class Dataset:
     def original_schema(self):
         """Returns the schema of the original Dataset"""
         if self.hc_structure.original_schema is None:
-            raise ValueError("Original Catalog Columns are not available")
+            raise ValueError("Original catalog schema is not available")
         return self.hc_structure.original_schema
 
     def check_unloaded_columns(self, column_names: Sequence[str | None] | None):

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -435,7 +435,6 @@ class HealpixDataset(Dataset):
             A catalog that contains the data from the original catalog that complies
             with the query expression
         """
-        # TODO: validate the columns in the expr?
         ndf = self._ddf.query(expr)
         return self._create_updated_dataset(ddf=ndf)
 

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -81,9 +81,9 @@ class HealpixDataset(Dataset):
         # is extensive, so it's safer to check only those type configurations
         # which are known to be either a column name or sequence thereof.
         if isinstance(item, str):
-            self.check_unloaded_columns([item])
+            self._check_unloaded_columns([item])
         elif isinstance(item, Sequence):
-            self.check_unloaded_columns([col for col in item if isinstance(col, str)])
+            self._check_unloaded_columns([col for col in item if isinstance(col, str)])
         result = self._ddf.__getitem__(item)
         if isinstance(result, nd.NestedFrame):
             return self._create_updated_dataset(ddf=result)
@@ -212,8 +212,8 @@ class HealpixDataset(Dataset):
         include_pixels: list[HealpixPixel] | None = None,
     ) -> list[HealpixPixel]:
         """Read footer statistics in parquet metadata, and report on global min/max values."""
-        self.check_unloaded_columns(exclude_columns)
-        self.check_unloaded_columns(include_columns)
+        self._check_unloaded_columns(exclude_columns)
+        self._check_unloaded_columns(include_columns)
         if use_default_columns and include_columns is None:
             include_columns = self.hc_structure.catalog_info.default_columns
 
@@ -235,8 +235,8 @@ class HealpixDataset(Dataset):
         include_pixels: list[HealpixPixel] | None = None,
     ) -> list[HealpixPixel]:
         """Read footer statistics in parquet metadata, and report on global min/max values."""
-        self.check_unloaded_columns(exclude_columns)
-        self.check_unloaded_columns(include_columns)
+        self._check_unloaded_columns(exclude_columns)
+        self._check_unloaded_columns(include_columns)
         if use_default_columns and include_columns is None:
             include_columns = self.hc_structure.catalog_info.default_columns
 
@@ -732,7 +732,7 @@ class HealpixDataset(Dataset):
             overwrite (bool): If True existing catalog is overwritten
             **kwargs: Arguments to pass to the parquet write operations
         """
-        self.check_unloaded_columns(default_columns)
+        self._check_unloaded_columns(default_columns)
         default_histogram_order = 8
         max_catalog_depth = self.hc_structure.pixel_tree.get_max_depth()
         histogram_order = max(max_catalog_depth, default_histogram_order)
@@ -867,8 +867,8 @@ class HealpixDataset(Dataset):
             recommend setting the following dask config setting to prevent this:
             `dask.config.set({"dataframe.convert-string":False})`
         """
-        self.check_unloaded_columns(base_columns)
-        self.check_unloaded_columns(list_columns)
+        self._check_unloaded_columns(base_columns)
+        self._check_unloaded_columns(list_columns)
         new_ddf = nd.NestedFrame.from_lists(
             self._ddf,
             base_columns=base_columns,
@@ -935,7 +935,7 @@ class HealpixDataset(Dataset):
         0  1372475556631677955      21.1       20.9
         1  1389879706834706546      22.2       21.8
         """
-        self.check_unloaded_columns(args)
+        self._check_unloaded_columns(args)
 
         if append_columns:
             meta = concat_metas([self._ddf._meta.copy(), meta])
@@ -1044,7 +1044,7 @@ class HealpixDataset(Dataset):
         if title is None:
             title = f"Points in the {self.name} catalog"
 
-        self.check_unloaded_columns([ra_column, dec_column, color_col])
+        self._check_unloaded_columns([ra_column, dec_column, color_col])
         return plot_points(
             computed_catalog,
             ra_column,
@@ -1092,7 +1092,7 @@ class HealpixDataset(Dataset):
         """
         if isinstance(by, str):
             by = [by]
-        self.check_unloaded_columns(by)
+        self._check_unloaded_columns(by)
         # Check "by" columns for hierarchical references
         for col in by:
             if not self._ddf._is_known_hierarchical_column(col):

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import random
 import warnings
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, Callable, Iterable, Literal, Type, cast
 
@@ -75,6 +76,14 @@ class HealpixDataset(Dataset):
         self._ddf_pixel_map = ddf_pixel_map
 
     def __getitem__(self, item):
+        """Select a column or columns from the catalog."""
+        # The number of types with which multiple columns can be specified
+        # is extensive, so it's safer to check only those type configurations
+        # which are known to be either a column name or sequence thereof.
+        if isinstance(item, str):
+            self.check_unloaded_columns([item])
+        elif isinstance(item, Sequence):
+            self.check_unloaded_columns([col for col in item if isinstance(col, str)])
         result = self._ddf.__getitem__(item)
         if isinstance(result, nd.NestedFrame):
             return self._create_updated_dataset(ddf=result)
@@ -203,6 +212,8 @@ class HealpixDataset(Dataset):
         include_pixels: list[HealpixPixel] | None = None,
     ) -> list[HealpixPixel]:
         """Read footer statistics in parquet metadata, and report on global min/max values."""
+        self.check_unloaded_columns(exclude_columns)
+        self.check_unloaded_columns(include_columns)
         if use_default_columns and include_columns is None:
             include_columns = self.hc_structure.catalog_info.default_columns
 
@@ -224,6 +235,8 @@ class HealpixDataset(Dataset):
         include_pixels: list[HealpixPixel] | None = None,
     ) -> list[HealpixPixel]:
         """Read footer statistics in parquet metadata, and report on global min/max values."""
+        self.check_unloaded_columns(exclude_columns)
+        self.check_unloaded_columns(include_columns)
         if use_default_columns and include_columns is None:
             include_columns = self.hc_structure.catalog_info.default_columns
 
@@ -422,6 +435,7 @@ class HealpixDataset(Dataset):
             A catalog that contains the data from the original catalog that complies
             with the query expression
         """
+        # TODO: validate the columns in the expr?
         ndf = self._ddf.query(expr)
         return self._create_updated_dataset(ddf=ndf)
 
@@ -719,6 +733,7 @@ class HealpixDataset(Dataset):
             overwrite (bool): If True existing catalog is overwritten
             **kwargs: Arguments to pass to the parquet write operations
         """
+        self.check_unloaded_columns(default_columns)
         default_histogram_order = 8
         max_catalog_depth = self.hc_structure.pixel_tree.get_max_depth()
         histogram_order = max(max_catalog_depth, default_histogram_order)
@@ -853,6 +868,8 @@ class HealpixDataset(Dataset):
             recommend setting the following dask config setting to prevent this:
             `dask.config.set({"dataframe.convert-string":False})`
         """
+        self.check_unloaded_columns(base_columns)
+        self.check_unloaded_columns(list_columns)
         new_ddf = nd.NestedFrame.from_lists(
             self._ddf,
             base_columns=base_columns,
@@ -919,6 +936,7 @@ class HealpixDataset(Dataset):
         0  1372475556631677955      21.1       20.9
         1  1389879706834706546      22.2       21.8
         """
+        self.check_unloaded_columns(args)
 
         if append_columns:
             meta = concat_metas([self._ddf._meta.copy(), meta])
@@ -1027,6 +1045,7 @@ class HealpixDataset(Dataset):
         if title is None:
             title = f"Points in the {self.name} catalog"
 
+        self.check_unloaded_columns([ra_column, dec_column, color_col])
         return plot_points(
             computed_catalog,
             ra_column,
@@ -1074,6 +1093,7 @@ class HealpixDataset(Dataset):
         """
         if isinstance(by, str):
             by = [by]
+        self.check_unloaded_columns(by)
         # Check "by" columns for hierarchical references
         for col in by:
             if not self._ddf._is_known_hierarchical_column(col):


### PR DESCRIPTION
Now that we have default columns for catalogs, there are usually columns available on disk that aren't pulled into memory, and this is even more true when the `columns=` argument is used.  When the user tries to reference columns that are part of the catalog but which weren't loaded, the error messages imply that the columns were never available.  Instead, building on the `all_columns` property, give a more specific error when the user tries to access an unloaded column.

Closes #685 and #765 .