### PR TITLE
Support only providing list_columns in catalog.nest_lists

### DIFF
--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -870,7 +870,8 @@ class Catalog(HealpixDataset):
 
         Args:
             base_columns (list-like or None): Any columns that have non-list values in the input catalog.
-                These will simply be kept as identical columns in the result
+                These will simply be kept as identical columns in the result. If None, is inferred to be
+                all columns in the input catalog that are not considered list-value columns.
             list_columns (list-like or None): The list-value columns that should be packed into a nested
                 column. All columns in the list will attempt to be packed into a single nested column with
                 the name provided in ``nested_name``. All columns in list_columns must have pyarrow list

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -862,7 +862,7 @@ class Catalog(HealpixDataset):
 
     def nest_lists(
         self,
-        base_columns: list[str] | None,
+        base_columns: list[str] | None = None,
         list_columns: list[str] | None = None,
         name: str = "nested",
     ) -> Catalog:

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -828,7 +828,8 @@ class HealpixDataset(Dataset):
 
         Args:
             base_columns (list-like or None): Any columns that have non-list values in the input catalog.
-                These will simply be kept as identical columns in the result
+                These will simply be kept as identical columns in the result. If None, is inferred to be
+                all columns in the input catalog that are not considered list-value columns.
             list_columns (list-like or None): The list-value columns that should be packed into a nested
                 column. All columns in the list will attempt to be packed into a single nested column
                 with the name provided in `nested_name`. All columns in list_columns must have pyarrow

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -819,7 +819,7 @@ class HealpixDataset(Dataset):
 
     def nest_lists(
         self,
-        base_columns: list[str] | None,
+        base_columns: list[str] | None = None,
         list_columns: list[str] | None = None,
         name: str = "nested",
     ) -> Self:  # type: ignore[name-defined] # noqa: F821:

--- a/tests/lsdb/catalog/test_nested.py
+++ b/tests/lsdb/catalog/test_nested.py
@@ -68,8 +68,8 @@ def test_nest_lists(small_sky_with_nested_sources):
     pd.testing.assert_frame_equal(renested_flat, original_flat)
 
 
-def test_nest_lists_no_base_columns(small_sky_with_nested_sources):
-    """Test the behavior of catalog.nest_lists"""
+def test_nest_lists_only_list_columns(small_sky_with_nested_sources):
+    """Test the behavior of catalog.nest_lists when only list columns are provided"""
     cat_ndf = small_sky_with_nested_sources._ddf.map_partitions(
         lambda df: df.set_index(df.index.to_numpy() + np.arange(len(df)))
     )
@@ -77,6 +77,8 @@ def test_nest_lists_no_base_columns(small_sky_with_nested_sources):
     smallsky_lists = cat_ndf[["id", "ra", "dec"]].join(catlists_ndf)
     small_sky_with_nested_sources._ddf = smallsky_lists
 
+    # Use the columns from the original catalog as the list columns. All other
+    # columns are inferred to be "base" columns.
     cat_ndf_renested = small_sky_with_nested_sources.nest_lists(list_columns=cat_ndf["sources"].nest.fields)
 
     # check column structure

--- a/tests/lsdb/catalog/test_nested.py
+++ b/tests/lsdb/catalog/test_nested.py
@@ -67,6 +67,7 @@ def test_nest_lists(small_sky_with_nested_sources):
 
     pd.testing.assert_frame_equal(renested_flat, original_flat)
 
+
 def test_nest_lists_no_base_columns(small_sky_with_nested_sources):
     """Test the behavior of catalog.nest_lists"""
     cat_ndf = small_sky_with_nested_sources._ddf.map_partitions(
@@ -90,6 +91,7 @@ def test_nest_lists_no_base_columns(small_sky_with_nested_sources):
     original_flat = cat_ndf.compute()["sources"].nest.to_flat()
 
     pd.testing.assert_frame_equal(renested_flat, original_flat)
+
 
 def test_reduce(small_sky_with_nested_sources):
     def mean_mag(ra, dec, mag):

--- a/tests/lsdb/catalog/test_nested.py
+++ b/tests/lsdb/catalog/test_nested.py
@@ -67,6 +67,29 @@ def test_nest_lists(small_sky_with_nested_sources):
 
     pd.testing.assert_frame_equal(renested_flat, original_flat)
 
+def test_nest_lists_no_base_columns(small_sky_with_nested_sources):
+    """Test the behavior of catalog.nest_lists"""
+    cat_ndf = small_sky_with_nested_sources._ddf.map_partitions(
+        lambda df: df.set_index(df.index.to_numpy() + np.arange(len(df)))
+    )
+    catlists_ndf = cat_ndf.sources.nest.to_lists()
+    smallsky_lists = cat_ndf[["id", "ra", "dec"]].join(catlists_ndf)
+    small_sky_with_nested_sources._ddf = smallsky_lists
+
+    cat_ndf_renested = small_sky_with_nested_sources.nest_lists(list_columns=cat_ndf["sources"].nest.fields)
+
+    # check column structure
+    assert "nested" in cat_ndf_renested.columns
+    assert "id" in cat_ndf_renested.columns
+    assert "ra" in cat_ndf_renested.columns
+    assert "dec" in cat_ndf_renested.columns
+    assert cat_ndf_renested._ddf["nested"].nest.fields == cat_ndf["sources"].nest.fields
+
+    # try a compute call
+    renested_flat = cat_ndf_renested.compute()["nested"].nest.to_flat()
+    original_flat = cat_ndf.compute()["sources"].nest.to_flat()
+
+    pd.testing.assert_frame_equal(renested_flat, original_flat)
 
 def test_reduce(small_sky_with_nested_sources):
     def mean_mag(ra, dec, mag):


### PR DESCRIPTION
Fixes #583 

Modifies the lsdb wrappers around `NestedFrame.from_lists` so they match the nested-pandas behavior of allowing the `base_columns` to be optional. When`base_columns` are not provided, all non-list columns are inferred to be based columns. This required no changes from LSDB outside of the function signatures of the wrappers. 