### PR TITLE
Rename lsdb.read_hats to lsdb.hats_catalog

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,7 +94,7 @@ repos:
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.11
+        language_version: python3.12
     # Analyze type hints and report errors.
   - repo: local
     hooks:

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -22,15 +22,15 @@ BENCH_DATA_DIR = Path(__file__).parent / "data"
 
 
 def load_small_sky():
-    return lsdb.hats_catalog(TEST_DIR / DATA_DIR_NAME / SMALL_SKY_DIR_NAME)
+    return lsdb.open_catalog(TEST_DIR / DATA_DIR_NAME / SMALL_SKY_DIR_NAME)
 
 
 def load_small_sky_order1():
-    return lsdb.hats_catalog(TEST_DIR / DATA_DIR_NAME / SMALL_SKY_ORDER1)
+    return lsdb.open_catalog(TEST_DIR / DATA_DIR_NAME / SMALL_SKY_ORDER1)
 
 
 def load_small_sky_xmatch():
-    return lsdb.hats_catalog(TEST_DIR / DATA_DIR_NAME / SMALL_SKY_XMATCH_NAME)
+    return lsdb.open_catalog(TEST_DIR / DATA_DIR_NAME / SMALL_SKY_XMATCH_NAME)
 
 
 def time_kdtree_crossmatch():
@@ -66,8 +66,8 @@ def time_box_filter_on_partition():
 
 
 def time_create_midsize_catalog():
-    return lsdb.hats_catalog(BENCH_DATA_DIR / "midsize_catalog")
+    return lsdb.open_catalog(BENCH_DATA_DIR / "midsize_catalog")
 
 
 def time_create_large_catalog():
-    return lsdb.hats_catalog(BENCH_DATA_DIR / "large_catalog")
+    return lsdb.open_catalog(BENCH_DATA_DIR / "large_catalog")

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -22,15 +22,15 @@ BENCH_DATA_DIR = Path(__file__).parent / "data"
 
 
 def load_small_sky():
-    return lsdb.read_hats(TEST_DIR / DATA_DIR_NAME / SMALL_SKY_DIR_NAME)
+    return lsdb.hats_catalog(TEST_DIR / DATA_DIR_NAME / SMALL_SKY_DIR_NAME)
 
 
 def load_small_sky_order1():
-    return lsdb.read_hats(TEST_DIR / DATA_DIR_NAME / SMALL_SKY_ORDER1)
+    return lsdb.hats_catalog(TEST_DIR / DATA_DIR_NAME / SMALL_SKY_ORDER1)
 
 
 def load_small_sky_xmatch():
-    return lsdb.read_hats(TEST_DIR / DATA_DIR_NAME / SMALL_SKY_XMATCH_NAME)
+    return lsdb.hats_catalog(TEST_DIR / DATA_DIR_NAME / SMALL_SKY_XMATCH_NAME)
 
 
 def time_kdtree_crossmatch():
@@ -66,8 +66,8 @@ def time_box_filter_on_partition():
 
 
 def time_create_midsize_catalog():
-    return lsdb.read_hats(BENCH_DATA_DIR / "midsize_catalog")
+    return lsdb.hats_catalog(BENCH_DATA_DIR / "midsize_catalog")
 
 
 def time_create_large_catalog():
-    return lsdb.read_hats(BENCH_DATA_DIR / "large_catalog")
+    return lsdb.hats_catalog(BENCH_DATA_DIR / "large_catalog")

--- a/docs/tutorials/catalog_object.ipynb
+++ b/docs/tutorials/catalog_object.ipynb
@@ -99,7 +99,7 @@
    "outputs": [],
    "source": [
     "ztf_object_path = \"https://data.lsdb.io/hats/ztf_dr22/ztf_lc\"\n",
-    "ztf_object = lsdb.read_hats(ztf_object_path)\n",
+    "ztf_object = lsdb.open_catalog(ztf_object_path)\n",
     "ztf_object"
    ]
   },

--- a/docs/tutorials/filtering_large_catalogs.ipynb
+++ b/docs/tutorials/filtering_large_catalogs.ipynb
@@ -110,7 +110,7 @@
    "outputs": [],
    "source": [
     "ztf_object_path = f\"{surveys_path}/ztf_dr14/ztf_object\"\n",
-    "ztf_object = lsdb.read_hats(ztf_object_path, columns=[\"ps1_objid\", \"ra\", \"dec\", \"mean_mag_r\"])\n",
+    "ztf_object = lsdb.open_catalog(ztf_object_path, columns=[\"ps1_objid\", \"ra\", \"dec\", \"mean_mag_r\"])\n",
     "ztf_object"
    ]
   },

--- a/docs/tutorials/getting_data.ipynb
+++ b/docs/tutorials/getting_data.ipynb
@@ -46,7 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gaia_dr3 = lsdb.read_hats(\"https://data.lsdb.io/hats/gaia_dr3/gaia/\")\n",
+    "gaia_dr3 = lsdb.open_catalog(\"https://data.lsdb.io/hats/gaia_dr3/gaia/\")\n",
     "gaia_dr3"
    ]
   },
@@ -100,7 +100,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gaia_dr3 = lsdb.read_hats(\n",
+    "gaia_dr3 = lsdb.open_catalog(\n",
     "    \"https://data.lsdb.io/hats/gaia_dr3/gaia/\",\n",
     "    margin_cache=\"https://data.lsdb.io/hats/gaia_dr3/gaia_10arcs/\",\n",
     "    columns=[\n",

--- a/docs/tutorials/import_catalogs.ipynb
+++ b/docs/tutorials/import_catalogs.ipynb
@@ -233,7 +233,7 @@
    },
    "outputs": [],
    "source": [
-    "from_dataframe_catalog = lsdb.read_hats(tmp_path / \"from_dataframe\")\n",
+    "from_dataframe_catalog = lsdb.open_catalog(tmp_path / \"from_dataframe\")\n",
     "from_dataframe_catalog"
    ]
   },
@@ -249,7 +249,7 @@
    },
    "outputs": [],
    "source": [
-    "from_import_pipeline_catalog = lsdb.read_hats(tmp_path / \"from_import_pipeline\")\n",
+    "from_import_pipeline_catalog = lsdb.open_catalog(tmp_path / \"from_import_pipeline\")\n",
     "from_import_pipeline_catalog"
    ]
   },

--- a/docs/tutorials/margins.ipynb
+++ b/docs/tutorials/margins.ipynb
@@ -95,7 +95,7 @@
     "\n",
     "ztf_object_path = f\"{surveys_path}/ztf_dr14/ztf_object\"\n",
     "ztf_margin_path = f\"{surveys_path}/ztf_dr14/ztf_object_10arcs\"\n",
-    "ztf_object = lsdb.read_hats(\n",
+    "ztf_object = lsdb.open_catalog(\n",
     "    ztf_object_path, search_filter=box, margin_cache=ztf_margin_path, columns=[\"ra\", \"dec\"]\n",
     ")\n",
     "print(f\"Margin size: {ztf_object.margin.hc_structure.catalog_info.margin_threshold} arcsec\")\n",
@@ -167,7 +167,7 @@
    },
    "outputs": [],
    "source": [
-    "gaia = lsdb.read_hats(f\"{surveys_path}/gaia_dr3/gaia/\", columns=[\"ra\", \"dec\"], search_filter=box)\n",
+    "gaia = lsdb.open_catalog(f\"{surveys_path}/gaia_dr3/gaia/\", columns=[\"ra\", \"dec\"], search_filter=box)\n",
     "gaia"
    ]
   },

--- a/docs/tutorials/pre_executed/des-gaia.ipynb
+++ b/docs/tutorials/pre_executed/des-gaia.ipynb
@@ -3186,10 +3186,10 @@
     }
    ],
    "source": [
-    "des_catalog = lsdb.read_hats(DES_HATS_DIR)\n",
+    "des_catalog = lsdb.open_catalog(DES_HATS_DIR)\n",
     "\n",
-    "# gaia_margin_cache_catalog = lsdb.read_hats(GAIA_MARGIN_CACHE_DIR)\n",
-    "gaia_catalog = lsdb.read_hats(GAIA_HATS_DIR)\n",
+    "# gaia_margin_cache_catalog = lsdb.open_catalog(GAIA_MARGIN_CACHE_DIR)\n",
+    "gaia_catalog = lsdb.open_catalog(GAIA_HATS_DIR)\n",
     "\n",
     "xmatched = des_catalog.crossmatch(\n",
     "    gaia_catalog,\n",
@@ -3484,7 +3484,7 @@
    ],
    "source": [
     "# Look into the data\n",
-    "lsdb.read_hats(XMATCH_DIR).head()"
+    "lsdb.open_catalog(XMATCH_DIR).head()"
    ]
   },
   {
@@ -3602,7 +3602,7 @@
    "source": [
     "# Read the cross-matched catalog, just like we did before for Gaia and DES,\n",
     "# but keeping few columns only.\n",
-    "xmatched_from_disk = lsdb.read_hats(\n",
+    "xmatched_from_disk = lsdb.open_catalog(\n",
     "    XMATCH_DIR,\n",
     "    columns=[\n",
     "        \"parallax_gaia\",\n",

--- a/docs/tutorials/pre_executed/index_table.ipynb
+++ b/docs/tutorials/pre_executed/index_table.ipynb
@@ -59,7 +59,7 @@
    "source": [
     "import hats\n",
     "\n",
-    "catalog_index = hats.read_hats(\"/data3/epyc/data3/hats/catalogs/gaia_dr3/gaia_source_id_index/\")\n",
+    "catalog_index = hats.open_catalog(\"/data3/epyc/data3/hats/catalogs/gaia_dr3/gaia_source_id_index/\")\n",
     "catalog_index.schema"
    ]
   },
@@ -134,7 +134,7 @@
     "%%time\n",
     "import lsdb\n",
     "\n",
-    "gaia = lsdb.read_hats(\"/data3/epyc/data3/hats/catalogs/gaia_dr3/gaia\")"
+    "gaia = lsdb.open_catalog(\"/data3/epyc/data3/hats/catalogs/gaia_dr3/gaia\")"
    ]
   },
   {

--- a/docs/tutorials/pre_executed/join_catalogs.ipynb
+++ b/docs/tutorials/pre_executed/join_catalogs.ipynb
@@ -127,7 +127,7 @@
     }
    ],
    "source": [
-    "gaia = lsdb.read_hats(\n",
+    "gaia = lsdb.open_catalog(\n",
     "    \"https://data.lsdb.io/hats/gaia_dr3/gaia\",\n",
     "    margin_cache=\"https://data.lsdb.io/hats/gaia_dr3/gaia_10arcs\",\n",
     "    columns=[\"source_id\", \"ra\", \"dec\", \"parallax\"],\n",
@@ -234,7 +234,7 @@
     }
    ],
    "source": [
-    "gaia_edr3 = lsdb.read_hats(\n",
+    "gaia_edr3 = lsdb.open_catalog(\n",
     "    \"https://data.lsdb.io/hats/gaia_dr3/gaia_edr3_distances\",\n",
     "    margin_cache=\"https://data.lsdb.io/hats/gaia_dr3/gaia_edr3_distances_10arcs\",\n",
     "    columns=[\"source_id\", \"ra\", \"dec\", \"r_med_geo\"],\n",

--- a/docs/tutorials/pre_executed/manual_verification.ipynb
+++ b/docs/tutorials/pre_executed/manual_verification.ipynb
@@ -272,7 +272,7 @@
     }
    ],
    "source": [
-    "catalog_object = hats.read_hats(gaia_catalog_path)\n",
+    "catalog_object = hats.open_catalog(gaia_catalog_path)\n",
     "catalog_object.schema"
    ]
   },

--- a/docs/tutorials/pre_executed/map_partitions.ipynb
+++ b/docs/tutorials/pre_executed/map_partitions.ipynb
@@ -185,7 +185,7 @@
     "import lsdb\n",
     "\n",
     "gaia_root = \"https://data.lsdb.io/hats\"\n",
-    "gaia3 = lsdb.read_hats(\n",
+    "gaia3 = lsdb.open_catalog(\n",
     "    f\"{gaia_root}/gaia_dr3/gaia\",\n",
     "    margin_cache=f\"{gaia_root}/gaia_dr3/gaia_10arcs\",\n",
     "    search_filter=lsdb.ConeSearch(ra=280, dec=-60, radius_arcsec=2 * 3600),\n",
@@ -810,7 +810,7 @@
    },
    "outputs": [],
    "source": [
-    "gaia3_all = lsdb.read_hats(\n",
+    "gaia3_all = lsdb.open_catalog(\n",
     "    f\"{gaia_root}/gaia_dr3/gaia\",\n",
     "    margin_cache=f\"{gaia_root}/gaia_dr3/gaia_10arcs\",\n",
     "    columns=[\n",
@@ -1206,7 +1206,7 @@
    "source": [
     "import lsdb\n",
     "\n",
-    "gaia3 = lsdb.read_hats(\n",
+    "gaia3 = lsdb.open_catalog(\n",
     "    f\"{gaia_root}/gaia_dr3/gaia\",\n",
     "    margin_cache=f\"{gaia_root}/gaia_dr3/gaia_10arcs\",\n",
     "    search_filter=lsdb.ConeSearch(ra=280, dec=-60, radius_arcsec=2 * 3600),\n",
@@ -1818,7 +1818,7 @@
     }
    ],
    "source": [
-    "gaia3 = lsdb.read_hats(\n",
+    "gaia3 = lsdb.open_catalog(\n",
     "    f\"{gaia_root}/gaia_dr3/gaia\",\n",
     "    margin_cache=f\"{gaia_root}/gaia_dr3/gaia_10arcs\",\n",
     "    columns=[\n",

--- a/docs/tutorials/pre_executed/plotting.ipynb
+++ b/docs/tutorials/pre_executed/plotting.ipynb
@@ -79,7 +79,7 @@
     "from dask.distributed import Client\n",
     "\n",
     "client = Client(n_workers=4, memory_limit=\"auto\")\n",
-    "gaia = lsdb.read_hats(\"https://data.lsdb.io/hats/gaia_dr3/gaia\", columns=[\"ra\", \"dec\", \"phot_g_mean_mag\"])"
+    "gaia = lsdb.open_catalog(\"https://data.lsdb.io/hats/gaia_dr3/gaia\", columns=[\"ra\", \"dec\", \"phot_g_mean_mag\"])"
    ]
   },
   {
@@ -251,7 +251,7 @@
     }
    ],
    "source": [
-    "ztf = lsdb.read_hats(\n",
+    "ztf = lsdb.open_catalog(\n",
     "    \"https://data.lsdb.io/hats/ztf_dr14/ztf_object\",\n",
     "    margin_cache=\"https://data.lsdb.io/hats/ztf_dr14/ztf_object_10arcs\",\n",
     ")\n",

--- a/docs/tutorials/region_selection.ipynb
+++ b/docs/tutorials/region_selection.ipynb
@@ -97,7 +97,7 @@
    "outputs": [],
    "source": [
     "ztf_object_path = \"https://data.lsdb.io/hats/ztf_dr22/ztf_lc\"\n",
-    "ztf_object = lsdb.read_hats(ztf_object_path)\n",
+    "ztf_object = lsdb.open_catalog(ztf_object_path)\n",
     "ztf_object"
    ]
   },

--- a/docs/tutorials/remote_data.ipynb
+++ b/docs/tutorials/remote_data.ipynb
@@ -61,7 +61,7 @@
    "source": [
     "import lsdb\n",
     "\n",
-    "cat = lsdb.read_hats(\"https://data.lsdb.io/hats/gaia_dr3/gaia/\")\n",
+    "cat = lsdb.open_catalog(\"https://data.lsdb.io/hats/gaia_dr3/gaia/\")\n",
     "cat"
    ]
   },

--- a/docs/tutorials/row_filtering.ipynb
+++ b/docs/tutorials/row_filtering.ipynb
@@ -78,7 +78,7 @@
    "outputs": [],
    "source": [
     "ztf_object_path = \"https://data.lsdb.io/hats/ztf_dr22/ztf_lc\"\n",
-    "ztf_object = lsdb.read_hats(ztf_object_path)\n",
+    "ztf_object = lsdb.open_catalog(ztf_object_path)\n",
     "ztf_object"
    ]
   },

--- a/src/lsdb/__init__.py
+++ b/src/lsdb/__init__.py
@@ -3,4 +3,4 @@ from .catalog import Catalog, MarginCatalog
 from .core.crossmatch.crossmatch import crossmatch
 from .core.search import BoxSearch, ConeSearch, PixelSearch, PolygonSearch
 from .loaders.dataframe.from_dataframe import from_dataframe
-from .loaders.hats.read_hats import read_hats
+from .loaders.hats.read_hats import hats_catalog, read_hats

--- a/src/lsdb/__init__.py
+++ b/src/lsdb/__init__.py
@@ -3,4 +3,4 @@ from .catalog import Catalog, MarginCatalog
 from .core.crossmatch.crossmatch import crossmatch
 from .core.search import BoxSearch, ConeSearch, PixelSearch, PolygonSearch
 from .loaders.dataframe.from_dataframe import from_dataframe
-from .loaders.hats.read_hats import hats_catalog, read_hats
+from .loaders.hats.read_hats import hats_catalog

--- a/src/lsdb/__init__.py
+++ b/src/lsdb/__init__.py
@@ -3,4 +3,4 @@ from .catalog import Catalog, MarginCatalog
 from .core.crossmatch.crossmatch import crossmatch
 from .core.search import BoxSearch, ConeSearch, PixelSearch, PolygonSearch
 from .loaders.dataframe.from_dataframe import from_dataframe
-from .loaders.hats.read_hats import hats_catalog
+from .loaders.hats.read_hats import hats_catalog, read_hats

--- a/src/lsdb/__init__.py
+++ b/src/lsdb/__init__.py
@@ -3,4 +3,4 @@ from .catalog import Catalog, MarginCatalog
 from .core.crossmatch.crossmatch import crossmatch
 from .core.search import BoxSearch, ConeSearch, PixelSearch, PolygonSearch
 from .loaders.dataframe.from_dataframe import from_dataframe
-from .loaders.hats.read_hats import hats_catalog, read_hats
+from .loaders.hats.read_hats import open_catalog, read_hats

--- a/src/lsdb/loaders/__init__.py
+++ b/src/lsdb/loaders/__init__.py
@@ -1,2 +1,2 @@
 from .dataframe import from_dataframe
-from .hats import hats_catalog, read_hats
+from .hats import open_catalog, read_hats

--- a/src/lsdb/loaders/__init__.py
+++ b/src/lsdb/loaders/__init__.py
@@ -1,2 +1,2 @@
 from .dataframe import from_dataframe
-from .hats import hats_catalog, read_hats
+from .hats import hats_catalog

--- a/src/lsdb/loaders/__init__.py
+++ b/src/lsdb/loaders/__init__.py
@@ -1,2 +1,2 @@
 from .dataframe import from_dataframe
-from .hats import read_hats
+from .hats import hats_catalog, read_hats

--- a/src/lsdb/loaders/__init__.py
+++ b/src/lsdb/loaders/__init__.py
@@ -1,2 +1,2 @@
 from .dataframe import from_dataframe
-from .hats import hats_catalog
+from .hats import hats_catalog, read_hats

--- a/src/lsdb/loaders/hats/__init__.py
+++ b/src/lsdb/loaders/hats/__init__.py
@@ -1,1 +1,1 @@
-from .read_hats import read_hats
+from .read_hats import hats_catalog, read_hats

--- a/src/lsdb/loaders/hats/__init__.py
+++ b/src/lsdb/loaders/hats/__init__.py
@@ -1,1 +1,1 @@
-from .read_hats import hats_catalog, read_hats
+from .read_hats import hats_catalog

--- a/src/lsdb/loaders/hats/__init__.py
+++ b/src/lsdb/loaders/hats/__init__.py
@@ -1,1 +1,1 @@
-from .read_hats import hats_catalog, read_hats
+from .read_hats import open_catalog, read_hats

--- a/src/lsdb/loaders/hats/__init__.py
+++ b/src/lsdb/loaders/hats/__init__.py
@@ -1,1 +1,1 @@
-from .read_hats import hats_catalog
+from .read_hats import hats_catalog, read_hats

--- a/src/lsdb/loaders/hats/read_hats.py
+++ b/src/lsdb/loaders/hats/read_hats.py
@@ -35,10 +35,10 @@ def read_hats(
     **kwargs,
 ) -> Dataset:
     """Load catalog from a HATS path.  See hats_catalog()."""
-    return hats_catalog(path, search_filter, columns, margin_cache, **kwargs)
+    return open_catalog(path, search_filter, columns, margin_cache, **kwargs)
 
 
-def hats_catalog(
+def open_catalog(
     path: str | Path | UPath,
     search_filter: AbstractSearch | None = None,
     columns: list[str] | str | None = None,

--- a/src/lsdb/loaders/hats/read_hats.py
+++ b/src/lsdb/loaders/hats/read_hats.py
@@ -34,7 +34,18 @@ def read_hats(
     margin_cache: str | Path | UPath | None = None,
     **kwargs,
 ) -> Dataset:
-    """Load catalog from a HATS directory.
+    """Load catalog from a HATS path.  See hats_catalog()."""
+    return hats_catalog(path, search_filter, columns, margin_cache, **kwargs)
+
+
+def hats_catalog(
+    path: str | Path | UPath,
+    search_filter: AbstractSearch | None = None,
+    columns: list[str] | str | None = None,
+    margin_cache: str | Path | UPath | None = None,
+    **kwargs,
+) -> Dataset:
+    """Load catalog from a HATS path.
 
     Catalogs exist in collections or stand-alone.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,12 +159,12 @@ def small_sky_source_dir(test_data_dir):
 
 @pytest.fixture
 def small_sky_source_catalog(small_sky_source_dir):
-    return lsdb.read_hats(small_sky_source_dir)
+    return lsdb.hats_catalog(small_sky_source_dir)
 
 
 @pytest.fixture
 def small_sky_order1_source_collection_catalog(small_sky_order1_source_collection_dir):
-    return lsdb.read_hats(small_sky_order1_source_collection_dir)
+    return lsdb.hats_catalog(small_sky_order1_source_collection_dir)
 
 
 @pytest.fixture
@@ -214,37 +214,37 @@ def small_sky_order1_id_index_dir(test_data_dir):
 
 @pytest.fixture
 def small_sky_catalog(small_sky_dir):
-    return lsdb.read_hats(small_sky_dir)
+    return lsdb.hats_catalog(small_sky_dir)
 
 
 @pytest.fixture
 def small_sky_left_xmatch_catalog(small_sky_left_xmatch_dir):
-    return lsdb.read_hats(small_sky_left_xmatch_dir)
+    return lsdb.hats_catalog(small_sky_left_xmatch_dir)
 
 
 @pytest.fixture
 def small_sky_xmatch_catalog(small_sky_xmatch_dir):
-    return lsdb.read_hats(small_sky_xmatch_dir)
+    return lsdb.hats_catalog(small_sky_xmatch_dir)
 
 
 @pytest.fixture
 def small_sky_xmatch_margin_catalog(small_sky_xmatch_margin_dir):
-    return lsdb.read_hats(small_sky_xmatch_margin_dir)
+    return lsdb.hats_catalog(small_sky_xmatch_margin_dir)
 
 
 @pytest.fixture
 def small_sky_xmatch_with_margin(small_sky_xmatch_dir, small_sky_xmatch_margin_dir):
-    return lsdb.read_hats(small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_dir)
+    return lsdb.hats_catalog(small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_dir)
 
 
 @pytest.fixture
 def small_sky_to_xmatch_catalog(small_sky_to_xmatch_dir):
-    return lsdb.read_hats(small_sky_to_xmatch_dir)
+    return lsdb.hats_catalog(small_sky_to_xmatch_dir)
 
 
 @pytest.fixture
 def small_sky_to_xmatch_soft_catalog(small_sky_to_xmatch_soft_dir):
-    return lsdb.read_hats(small_sky_to_xmatch_soft_dir)
+    return lsdb.hats_catalog(small_sky_to_xmatch_soft_dir)
 
 
 @pytest.fixture
@@ -254,47 +254,47 @@ def small_sky_order1_hats_catalog(small_sky_order1_dir):
 
 @pytest.fixture
 def small_sky_order1_catalog(small_sky_order1_dir):
-    return lsdb.read_hats(small_sky_order1_dir)
+    return lsdb.hats_catalog(small_sky_order1_dir)
 
 
 @pytest.fixture
 def small_sky_order1_collection_catalog(small_sky_order1_collection_dir):
-    return lsdb.read_hats(small_sky_order1_collection_dir)
+    return lsdb.hats_catalog(small_sky_order1_collection_dir)
 
 
 @pytest.fixture
 def small_sky_order1_margin_1deg_catalog(small_sky_order1_margin_1deg_dir):
-    return lsdb.read_hats(small_sky_order1_margin_1deg_dir)
+    return lsdb.hats_catalog(small_sky_order1_margin_1deg_dir)
 
 
 @pytest.fixture
 def small_sky_order1_margin_2deg_catalog(small_sky_order1_margin_2deg_dir):
-    return lsdb.read_hats(small_sky_order1_margin_2deg_dir)
+    return lsdb.hats_catalog(small_sky_order1_margin_2deg_dir)
 
 
 @pytest.fixture
 def small_sky_order1_default_cols_catalog(small_sky_order1_default_cols_dir):
-    return lsdb.read_hats(small_sky_order1_default_cols_dir)
+    return lsdb.hats_catalog(small_sky_order1_default_cols_dir)
 
 
 @pytest.fixture
 def small_sky_order1_source_with_margin(small_sky_order1_source_dir, small_sky_order1_source_margin_dir):
-    return lsdb.read_hats(small_sky_order1_source_dir, margin_cache=small_sky_order1_source_margin_dir)
+    return lsdb.hats_catalog(small_sky_order1_source_dir, margin_cache=small_sky_order1_source_margin_dir)
 
 
 @pytest.fixture
 def small_sky_order1_source_margin_catalog(small_sky_order1_source_margin_dir):
-    return lsdb.read_hats(small_sky_order1_source_margin_dir)
+    return lsdb.hats_catalog(small_sky_order1_source_margin_dir)
 
 
 @pytest.fixture
 def small_sky_to_o1source_catalog(small_sky_to_order1_source_dir):
-    return lsdb.read_hats(small_sky_to_order1_source_dir)
+    return lsdb.hats_catalog(small_sky_to_order1_source_dir)
 
 
 @pytest.fixture
 def small_sky_to_o1source_soft_catalog(small_sky_to_order1_source_soft_dir):
-    return lsdb.read_hats(small_sky_to_order1_source_soft_dir)
+    return lsdb.hats_catalog(small_sky_to_order1_source_soft_dir)
 
 
 @pytest.fixture
@@ -314,24 +314,24 @@ def small_sky_source_df(test_data_dir):
 
 @pytest.fixture
 def small_sky_source_margin_catalog(test_data_dir):
-    return lsdb.read_hats(test_data_dir / SMALL_SKY_SOURCE_MARGIN_NAME)
+    return lsdb.hats_catalog(test_data_dir / SMALL_SKY_SOURCE_MARGIN_NAME)
 
 
 @pytest.fixture
 def small_sky_order3_source_margin_catalog(test_data_dir):
-    return lsdb.read_hats(test_data_dir / SMALL_SKY_ORDER3_SOURCE_MARGIN_NAME)
+    return lsdb.hats_catalog(test_data_dir / SMALL_SKY_ORDER3_SOURCE_MARGIN_NAME)
 
 
 @pytest.fixture
 def small_sky_with_nested_sources(small_sky_with_nested_sources_dir):
-    return lsdb.read_hats(small_sky_with_nested_sources_dir)
+    return lsdb.hats_catalog(small_sky_with_nested_sources_dir)
 
 
 @pytest.fixture
 def small_sky_with_nested_sources_with_margin(
     small_sky_with_nested_sources_dir, small_sky_with_nested_sources_margin_dir
 ):
-    return lsdb.read_hats(
+    return lsdb.hats_catalog(
         small_sky_with_nested_sources_dir, margin_cache=small_sky_with_nested_sources_margin_dir
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,12 +159,12 @@ def small_sky_source_dir(test_data_dir):
 
 @pytest.fixture
 def small_sky_source_catalog(small_sky_source_dir):
-    return lsdb.hats_catalog(small_sky_source_dir)
+    return lsdb.open_catalog(small_sky_source_dir)
 
 
 @pytest.fixture
 def small_sky_order1_source_collection_catalog(small_sky_order1_source_collection_dir):
-    return lsdb.hats_catalog(small_sky_order1_source_collection_dir)
+    return lsdb.open_catalog(small_sky_order1_source_collection_dir)
 
 
 @pytest.fixture
@@ -214,37 +214,37 @@ def small_sky_order1_id_index_dir(test_data_dir):
 
 @pytest.fixture
 def small_sky_catalog(small_sky_dir):
-    return lsdb.hats_catalog(small_sky_dir)
+    return lsdb.open_catalog(small_sky_dir)
 
 
 @pytest.fixture
 def small_sky_left_xmatch_catalog(small_sky_left_xmatch_dir):
-    return lsdb.hats_catalog(small_sky_left_xmatch_dir)
+    return lsdb.open_catalog(small_sky_left_xmatch_dir)
 
 
 @pytest.fixture
 def small_sky_xmatch_catalog(small_sky_xmatch_dir):
-    return lsdb.hats_catalog(small_sky_xmatch_dir)
+    return lsdb.open_catalog(small_sky_xmatch_dir)
 
 
 @pytest.fixture
 def small_sky_xmatch_margin_catalog(small_sky_xmatch_margin_dir):
-    return lsdb.hats_catalog(small_sky_xmatch_margin_dir)
+    return lsdb.open_catalog(small_sky_xmatch_margin_dir)
 
 
 @pytest.fixture
 def small_sky_xmatch_with_margin(small_sky_xmatch_dir, small_sky_xmatch_margin_dir):
-    return lsdb.hats_catalog(small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_dir)
+    return lsdb.open_catalog(small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_dir)
 
 
 @pytest.fixture
 def small_sky_to_xmatch_catalog(small_sky_to_xmatch_dir):
-    return lsdb.hats_catalog(small_sky_to_xmatch_dir)
+    return lsdb.open_catalog(small_sky_to_xmatch_dir)
 
 
 @pytest.fixture
 def small_sky_to_xmatch_soft_catalog(small_sky_to_xmatch_soft_dir):
-    return lsdb.hats_catalog(small_sky_to_xmatch_soft_dir)
+    return lsdb.open_catalog(small_sky_to_xmatch_soft_dir)
 
 
 @pytest.fixture
@@ -254,47 +254,47 @@ def small_sky_order1_hats_catalog(small_sky_order1_dir):
 
 @pytest.fixture
 def small_sky_order1_catalog(small_sky_order1_dir):
-    return lsdb.hats_catalog(small_sky_order1_dir)
+    return lsdb.open_catalog(small_sky_order1_dir)
 
 
 @pytest.fixture
 def small_sky_order1_collection_catalog(small_sky_order1_collection_dir):
-    return lsdb.hats_catalog(small_sky_order1_collection_dir)
+    return lsdb.open_catalog(small_sky_order1_collection_dir)
 
 
 @pytest.fixture
 def small_sky_order1_margin_1deg_catalog(small_sky_order1_margin_1deg_dir):
-    return lsdb.hats_catalog(small_sky_order1_margin_1deg_dir)
+    return lsdb.open_catalog(small_sky_order1_margin_1deg_dir)
 
 
 @pytest.fixture
 def small_sky_order1_margin_2deg_catalog(small_sky_order1_margin_2deg_dir):
-    return lsdb.hats_catalog(small_sky_order1_margin_2deg_dir)
+    return lsdb.open_catalog(small_sky_order1_margin_2deg_dir)
 
 
 @pytest.fixture
 def small_sky_order1_default_cols_catalog(small_sky_order1_default_cols_dir):
-    return lsdb.hats_catalog(small_sky_order1_default_cols_dir)
+    return lsdb.open_catalog(small_sky_order1_default_cols_dir)
 
 
 @pytest.fixture
 def small_sky_order1_source_with_margin(small_sky_order1_source_dir, small_sky_order1_source_margin_dir):
-    return lsdb.hats_catalog(small_sky_order1_source_dir, margin_cache=small_sky_order1_source_margin_dir)
+    return lsdb.open_catalog(small_sky_order1_source_dir, margin_cache=small_sky_order1_source_margin_dir)
 
 
 @pytest.fixture
 def small_sky_order1_source_margin_catalog(small_sky_order1_source_margin_dir):
-    return lsdb.hats_catalog(small_sky_order1_source_margin_dir)
+    return lsdb.open_catalog(small_sky_order1_source_margin_dir)
 
 
 @pytest.fixture
 def small_sky_to_o1source_catalog(small_sky_to_order1_source_dir):
-    return lsdb.hats_catalog(small_sky_to_order1_source_dir)
+    return lsdb.open_catalog(small_sky_to_order1_source_dir)
 
 
 @pytest.fixture
 def small_sky_to_o1source_soft_catalog(small_sky_to_order1_source_soft_dir):
-    return lsdb.hats_catalog(small_sky_to_order1_source_soft_dir)
+    return lsdb.open_catalog(small_sky_to_order1_source_soft_dir)
 
 
 @pytest.fixture
@@ -314,24 +314,24 @@ def small_sky_source_df(test_data_dir):
 
 @pytest.fixture
 def small_sky_source_margin_catalog(test_data_dir):
-    return lsdb.hats_catalog(test_data_dir / SMALL_SKY_SOURCE_MARGIN_NAME)
+    return lsdb.open_catalog(test_data_dir / SMALL_SKY_SOURCE_MARGIN_NAME)
 
 
 @pytest.fixture
 def small_sky_order3_source_margin_catalog(test_data_dir):
-    return lsdb.hats_catalog(test_data_dir / SMALL_SKY_ORDER3_SOURCE_MARGIN_NAME)
+    return lsdb.open_catalog(test_data_dir / SMALL_SKY_ORDER3_SOURCE_MARGIN_NAME)
 
 
 @pytest.fixture
 def small_sky_with_nested_sources(small_sky_with_nested_sources_dir):
-    return lsdb.hats_catalog(small_sky_with_nested_sources_dir)
+    return lsdb.open_catalog(small_sky_with_nested_sources_dir)
 
 
 @pytest.fixture
 def small_sky_with_nested_sources_with_margin(
     small_sky_with_nested_sources_dir, small_sky_with_nested_sources_margin_dir
 ):
-    return lsdb.hats_catalog(
+    return lsdb.open_catalog(
         small_sky_with_nested_sources_dir, margin_cache=small_sky_with_nested_sources_margin_dir
     )
 

--- a/tests/data/generate_data.ipynb
+++ b/tests/data/generate_data.ipynb
@@ -168,7 +168,7 @@
    "source": [
     "out_catalog_name = \"small_sky_order1_no_pandas_meta\"\n",
     "\n",
-    "sso1 = hats.read_hats(\"small_sky_order1\")\n",
+    "sso1 = hats.open_catalog(\"small_sky_order1\")\n",
     "for pixel in sso1.get_healpix_pixels():\n",
     "    path = hats.io.paths.pixel_catalog_file(sso1.catalog_base_dir, pixel)\n",
     "    out_path = hats.io.paths.pixel_catalog_file(out_catalog_name, pixel)\n",
@@ -205,7 +205,7 @@
     "out_catalog_name = \"small_sky_order1_default_columns\"\n",
     "out_catalog_path = get_upath(out_catalog_name)\n",
     "\n",
-    "sso1 = hats.read_hats(\"small_sky_order1\")\n",
+    "sso1 = hats.open_catalog(\"small_sky_order1\")\n",
     "sso1_dataset_path = get_upath(\"small_sky_order1\") / DATASET_DIR\n",
     "out_dataset_path = out_catalog_path / DATASET_DIR\n",
     "\n",
@@ -310,7 +310,7 @@
     "# but the suffix should make the file recognizable as parquet for compatibility with other libraries.\n",
     "npix_suffix = \".parq\"  # could also include the compression, e.g., \".snappy.parquet\"\n",
     "\n",
-    "sso = hats.read_hats(\"small_sky\")\n",
+    "sso = hats.open_catalog(\"small_sky\")\n",
     "paths = [hats.io.paths.pixel_catalog_file(sso.catalog_base_dir, pixel) for pixel in sso.get_healpix_pixels()]\n",
     "\n",
     "out_catalog_name = \"small_sky_npix_alt_suffix\"\n",
@@ -348,7 +348,7 @@
     "\n",
     "npix_suffix = \"/\"\n",
     "\n",
-    "sso = hats.read_hats(\"small_sky\")\n",
+    "sso = hats.open_catalog(\"small_sky\")\n",
     "paths = [hats.io.paths.pixel_catalog_file(sso.catalog_base_dir, pixel) for pixel in sso.get_healpix_pixels()]\n",
     "\n",
     "out_catalog_name = \"small_sky_npix_as_dir\"\n",
@@ -633,8 +633,8 @@
    "outputs": [],
    "source": [
     "remove_directory(\"small_sky_order1_nested_sources\")\n",
-    "small_sky_order1_catalog = lsdb.read_hats(\"small_sky_order1\")\n",
-    "small_sky_order1_source_with_margin = lsdb.read_hats(\n",
+    "small_sky_order1_catalog = lsdb.open_catalog(\"small_sky_order1\")\n",
+    "small_sky_order1_source_with_margin = lsdb.open_catalog(\n",
     "    \"small_sky_order1_source\", margin_cache=\"small_sky_order1_source_margin\"\n",
     ")\n",
     "small_sky_order1_nested = small_sky_order1_catalog.join_nested(\n",
@@ -939,7 +939,7 @@
    },
    "outputs": [],
    "source": [
-    "ss_source = hats.read_hats(\"small_sky_order1_source\")"
+    "ss_source = hats.open_catalog(\"small_sky_order1_source\")"
    ]
   },
   {
@@ -997,7 +997,7 @@
    },
    "outputs": [],
    "source": [
-    "ss_source_margin = hats.read_hats(\"small_sky_order1_source_margin\")"
+    "ss_source_margin = hats.open_catalog(\"small_sky_order1_source_margin\")"
    ]
   },
   {

--- a/tests/lsdb/catalog/test_association_catalog.py
+++ b/tests/lsdb/catalog/test_association_catalog.py
@@ -7,7 +7,7 @@ from lsdb.catalog.association_catalog import AssociationCatalog
 
 
 def test_load_association(small_sky_to_xmatch_dir):
-    small_sky_to_xmatch = lsdb.read_hats(small_sky_to_xmatch_dir)
+    small_sky_to_xmatch = lsdb.hats_catalog(small_sky_to_xmatch_dir)
     assert isinstance(small_sky_to_xmatch, AssociationCatalog)
     assert isinstance(small_sky_to_xmatch._ddf, nd.NestedFrame)
     assert small_sky_to_xmatch.get_healpix_pixels() == small_sky_to_xmatch.hc_structure.get_healpix_pixels()
@@ -25,7 +25,7 @@ def test_load_association(small_sky_to_xmatch_dir):
 
 
 def test_load_soft_association(small_sky_to_xmatch_soft_dir):
-    small_sky_to_xmatch_soft = lsdb.read_hats(small_sky_to_xmatch_soft_dir)
+    small_sky_to_xmatch_soft = lsdb.hats_catalog(small_sky_to_xmatch_soft_dir)
     assert isinstance(small_sky_to_xmatch_soft, AssociationCatalog)
     assert isinstance(small_sky_to_xmatch_soft._ddf, nd.NestedFrame)
     assert len(small_sky_to_xmatch_soft.compute()) == 0

--- a/tests/lsdb/catalog/test_association_catalog.py
+++ b/tests/lsdb/catalog/test_association_catalog.py
@@ -7,7 +7,7 @@ from lsdb.catalog.association_catalog import AssociationCatalog
 
 
 def test_load_association(small_sky_to_xmatch_dir):
-    small_sky_to_xmatch = lsdb.hats_catalog(small_sky_to_xmatch_dir)
+    small_sky_to_xmatch = lsdb.open_catalog(small_sky_to_xmatch_dir)
     assert isinstance(small_sky_to_xmatch, AssociationCatalog)
     assert isinstance(small_sky_to_xmatch._ddf, nd.NestedFrame)
     assert small_sky_to_xmatch.get_healpix_pixels() == small_sky_to_xmatch.hc_structure.get_healpix_pixels()
@@ -25,7 +25,7 @@ def test_load_association(small_sky_to_xmatch_dir):
 
 
 def test_load_soft_association(small_sky_to_xmatch_soft_dir):
-    small_sky_to_xmatch_soft = lsdb.hats_catalog(small_sky_to_xmatch_soft_dir)
+    small_sky_to_xmatch_soft = lsdb.open_catalog(small_sky_to_xmatch_soft_dir)
     assert isinstance(small_sky_to_xmatch_soft, AssociationCatalog)
     assert isinstance(small_sky_to_xmatch_soft._ddf, nd.NestedFrame)
     assert len(small_sky_to_xmatch_soft.compute()) == 0

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -339,7 +339,7 @@ def test_save_catalog(small_sky_catalog, tmp_path):
     base_catalog_path = Path(tmp_path) / new_catalog_name
     small_sky_catalog.to_hats(base_catalog_path, catalog_name=new_catalog_name)
 
-    expected_catalog = lsdb.read_hats(base_catalog_path)
+    expected_catalog = lsdb.hats_catalog(base_catalog_path)
     assert expected_catalog.hc_structure.schema.pandas_metadata is None
     assert expected_catalog.hc_structure.catalog_name == new_catalog_name
     assert expected_catalog.get_healpix_pixels() == small_sky_catalog.get_healpix_pixels()
@@ -377,7 +377,7 @@ def test_save_catalog_default_columns(small_sky_order1_default_cols_catalog, tmp
     new_catalog_name = "small_sky_order1"
     base_catalog_path = Path(tmp_path) / new_catalog_name
     cat.to_hats(base_catalog_path, catalog_name=new_catalog_name)
-    expected_catalog = lsdb.read_hats(base_catalog_path)
+    expected_catalog = lsdb.hats_catalog(base_catalog_path)
     assert expected_catalog.hc_structure.catalog_name == new_catalog_name
     assert expected_catalog.get_healpix_pixels() == cat.get_healpix_pixels()
     pd.testing.assert_frame_equal(expected_catalog.compute(), cat._ddf.compute())
@@ -391,7 +391,7 @@ def test_save_catalog_empty_default_columns(small_sky_order1_default_cols_catalo
     new_catalog_name = "small_sky_order1"
     base_catalog_path = Path(tmp_path) / new_catalog_name
     cat.to_hats(base_catalog_path, catalog_name=new_catalog_name)
-    expected_catalog = lsdb.read_hats(base_catalog_path)
+    expected_catalog = lsdb.hats_catalog(base_catalog_path)
     assert expected_catalog.hc_structure.catalog_info.default_columns is None
     assert expected_catalog.hc_structure.catalog_name == new_catalog_name
     assert expected_catalog.get_healpix_pixels() == cat.get_healpix_pixels()
@@ -413,7 +413,7 @@ def test_save_catalog_default_columns_cross_matched(
     with pytest.raises(ValueError, match="Original catalog schema is not available"):
         _ = cat.original_schema
     cat.to_hats(base_catalog_path, catalog_name=new_catalog_name)
-    expected_catalog = lsdb.read_hats(base_catalog_path)
+    expected_catalog = lsdb.hats_catalog(base_catalog_path)
     assert expected_catalog.original_schema is not None
     assert expected_catalog.hc_structure.catalog_name == new_catalog_name
     assert expected_catalog.get_healpix_pixels() == cat.get_healpix_pixels()
@@ -422,7 +422,7 @@ def test_save_catalog_default_columns_cross_matched(
     )
     helpers.assert_schema_correct(expected_catalog)
     helpers.assert_default_columns_in_columns(expected_catalog)
-    expected_catalog_all_cols = lsdb.read_hats(base_catalog_path, columns="all")
+    expected_catalog_all_cols = lsdb.hats_catalog(base_catalog_path, columns="all")
     assert expected_catalog_all_cols.hc_structure.catalog_name == new_catalog_name
     assert expected_catalog_all_cols.get_healpix_pixels() == cat.get_healpix_pixels()
     pd.testing.assert_frame_equal(expected_catalog_all_cols.compute(), cat._ddf.compute())
@@ -530,7 +530,7 @@ def test_save_catalog_with_some_empty_partitions(small_sky_order1_catalog, tmp_p
 
     # Confirm that we can read the catalog from disk, and that it was
     # written with no empty partitions
-    catalog = lsdb.read_hats(base_catalog_path)
+    catalog = lsdb.hats_catalog(base_catalog_path)
     assert catalog._ddf.npartitions == 1
     assert len(catalog._ddf.partitions[0]) > 0
     assert list(catalog._ddf_pixel_map.keys()) == non_empty_pixels

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -11,13 +11,10 @@ import nested_pandas as npd
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
-import pyarrow.parquet as pq
 import pytest
 from astropy.coordinates import SkyCoord
 from astropy.visualization.wcsaxes import WCSAxes
 from hats.inspection.visualize_catalog import get_fov_moc_from_wcs
-from hats.io.file_io import get_upath_for_protocol, read_fits_image
-from hats.io.paths import get_data_thumbnail_pointer
 from hats.pixel_math import HealpixPixel, spatial_index_to_healpix
 from mocpy import WCS
 
@@ -347,102 +344,6 @@ def test_read_hats(small_sky_catalog, tmp_path):
     pd.testing.assert_frame_equal(expected_catalog.compute(), small_sky_catalog._ddf.compute())
 
 
-def test_save_catalog(small_sky_catalog, tmp_path):
-    new_catalog_name = "small_sky"
-    base_catalog_path = Path(tmp_path) / new_catalog_name
-    small_sky_catalog.to_hats(base_catalog_path, catalog_name=new_catalog_name)
-
-    expected_catalog = lsdb.open_catalog(base_catalog_path)
-    assert expected_catalog.hc_structure.schema.pandas_metadata is None
-    assert expected_catalog.hc_structure.catalog_name == new_catalog_name
-    assert expected_catalog.get_healpix_pixels() == small_sky_catalog.get_healpix_pixels()
-    pd.testing.assert_frame_equal(expected_catalog.compute(), small_sky_catalog._ddf.compute())
-
-    # When saving a catalog with to_hats, we update the hats_max_rows
-    # to the maximum count of points per partition. In this case there
-    # is only one with 131 rows, so that is the value we expect.
-    original_info = small_sky_catalog.hc_structure.catalog_info
-    partition_sizes = small_sky_catalog._ddf.map_partitions(len).compute()
-    assert max(partition_sizes) == 131
-    assert expected_catalog.hc_structure.catalog_info == original_info.copy_and_update(hats_max_rows="131")
-
-    # The catalog has 1 partition, therefore the thumbnail has 1 row
-    data_thumbnail_pointer = get_data_thumbnail_pointer(base_catalog_path)
-    assert data_thumbnail_pointer.exists()
-    data_thumbnail = pq.read_table(data_thumbnail_pointer)
-    assert len(data_thumbnail) == 1
-    assert data_thumbnail.schema.equals(small_sky_catalog.hc_structure.schema)
-
-
-def test_save_catalog_initializes_upath_once(small_sky_catalog, tmp_path, mocker):
-    mock_method = "hats.io.file_io.file_pointer.get_upath_for_protocol"
-    mocked_upath_call = mocker.patch(mock_method, side_effect=get_upath_for_protocol)
-
-    new_catalog_name = "small_sky"
-    base_catalog_path = Path(tmp_path) / new_catalog_name
-    small_sky_catalog.to_hats(base_catalog_path, catalog_name=new_catalog_name)
-
-    mocked_upath_call.assert_called_once_with(base_catalog_path)
-
-
-def test_save_catalog_default_columns(small_sky_order1_default_cols_catalog, tmp_path, helpers):
-    cat = small_sky_order1_default_cols_catalog[["ra", "dec"]]
-    new_catalog_name = "small_sky_order1"
-    base_catalog_path = Path(tmp_path) / new_catalog_name
-    cat.to_hats(base_catalog_path, catalog_name=new_catalog_name)
-    expected_catalog = lsdb.open_catalog(base_catalog_path)
-    assert expected_catalog.hc_structure.catalog_name == new_catalog_name
-    assert expected_catalog.get_healpix_pixels() == cat.get_healpix_pixels()
-    pd.testing.assert_frame_equal(expected_catalog.compute(), cat._ddf.compute())
-    helpers.assert_schema_correct(expected_catalog)
-    helpers.assert_default_columns_in_columns(expected_catalog)
-
-
-def test_save_catalog_empty_default_columns(small_sky_order1_default_cols_catalog, tmp_path, helpers):
-    cat = small_sky_order1_default_cols_catalog[["ra", "dec"]]
-    cat.hc_structure.catalog_info.default_columns = []
-    new_catalog_name = "small_sky_order1"
-    base_catalog_path = Path(tmp_path) / new_catalog_name
-    cat.to_hats(base_catalog_path, catalog_name=new_catalog_name)
-    expected_catalog = lsdb.open_catalog(base_catalog_path)
-    assert expected_catalog.hc_structure.catalog_info.default_columns is None
-    assert expected_catalog.hc_structure.catalog_name == new_catalog_name
-    assert expected_catalog.get_healpix_pixels() == cat.get_healpix_pixels()
-    pd.testing.assert_frame_equal(expected_catalog.compute(), cat._ddf.compute())
-    helpers.assert_schema_correct(expected_catalog)
-    helpers.assert_default_columns_in_columns(expected_catalog)
-
-
-def test_save_catalog_default_columns_cross_matched(
-    small_sky_order1_default_cols_catalog, small_sky_xmatch_catalog, tmp_path, helpers
-):
-    cat = small_sky_order1_default_cols_catalog.crossmatch(
-        small_sky_xmatch_catalog, radius_arcsec=0.01 * 3600
-    )
-    new_catalog_name = "small_sky_order1"
-    base_catalog_path = Path(tmp_path) / new_catalog_name
-    # Before the catalog is serialized, verify that it won't have original schema.
-    # This is something that will be available after serialization.
-    with pytest.raises(ValueError, match="Original catalog schema is not available"):
-        _ = cat.original_schema
-    cat.to_hats(base_catalog_path, catalog_name=new_catalog_name)
-    expected_catalog = lsdb.open_catalog(base_catalog_path)
-    assert expected_catalog.original_schema is not None
-    assert expected_catalog.hc_structure.catalog_name == new_catalog_name
-    assert expected_catalog.get_healpix_pixels() == cat.get_healpix_pixels()
-    pd.testing.assert_frame_equal(
-        expected_catalog.compute(), cat._ddf.compute()[cat.hc_structure.catalog_info.default_columns]
-    )
-    helpers.assert_schema_correct(expected_catalog)
-    helpers.assert_default_columns_in_columns(expected_catalog)
-    expected_catalog_all_cols = lsdb.open_catalog(base_catalog_path, columns="all")
-    assert expected_catalog_all_cols.hc_structure.catalog_name == new_catalog_name
-    assert expected_catalog_all_cols.get_healpix_pixels() == cat.get_healpix_pixels()
-    pd.testing.assert_frame_equal(expected_catalog_all_cols.compute(), cat._ddf.compute())
-    helpers.assert_schema_correct(expected_catalog_all_cols)
-    helpers.assert_default_columns_in_columns(expected_catalog_all_cols)
-
-
 def test_advise_unloaded_columns(small_sky_order1_default_cols_catalog):
     cat = small_sky_order1_default_cols_catalog
     with pytest.raises(ValueError, match="Column `dec_error` is in the catalog but was not loaded."):
@@ -451,102 +352,6 @@ def test_advise_unloaded_columns(small_sky_order1_default_cols_catalog):
         ValueError, match="Columns `ra_error`, `dec_error` are in the catalog but were not loaded."
     ):
         _ = cat[["ra_error", "dec_error"]]
-
-
-def test_save_catalog_point_map(small_sky_order1_catalog, tmp_path):
-    new_catalog_name = "small_sky_order1"
-    base_catalog_path = Path(tmp_path) / new_catalog_name
-    small_sky_order1_catalog.to_hats(base_catalog_path, catalog_name=new_catalog_name)
-
-    point_map_path = base_catalog_path / "point_map.fits"
-    assert hc.io.file_io.does_file_or_directory_exist(point_map_path)
-    histogram = read_fits_image(point_map_path)
-
-    # The histogram and the sky map histogram match
-    assert len(small_sky_order1_catalog) == np.sum(histogram)
-    expected_histogram = small_sky_order1_catalog.skymap_histogram(lambda df, _: len(df), order=8)
-    npt.assert_array_equal(expected_histogram, histogram)
-
-
-def test_save_catalog_overwrite(small_sky_catalog, tmp_path):
-    base_catalog_path = tmp_path / "small_sky"
-    # Saving a catalog to disk when the directory does not yet exist
-    small_sky_catalog.to_hats(base_catalog_path)
-    # The output directory exists and it has content. Overwrite is
-    # set to False and, as such, the operation fails.
-    with pytest.raises(ValueError, match="set overwrite to True"):
-        small_sky_catalog.to_hats(base_catalog_path)
-    # With overwrite it succeeds because the directory is recreated
-    small_sky_catalog.to_hats(base_catalog_path, overwrite=True)
-
-
-def test_save_catalog_when_catalog_is_empty(small_sky_order1_catalog, tmp_path):
-    base_catalog_path = tmp_path / "small_sky"
-
-    # The result of this cone search is known to be empty
-    cone_search_catalog = small_sky_order1_catalog.cone_search(0, -80, 1)
-    assert cone_search_catalog._ddf.npartitions == 1
-
-    non_empty_pixels = []
-    for pixel, partition_index in cone_search_catalog._ddf_pixel_map.items():
-        if len(cone_search_catalog._ddf.partitions[partition_index]) > 0:
-            non_empty_pixels.append(pixel)
-    assert len(non_empty_pixels) == 0
-
-    # The catalog is not written to disk
-    with pytest.raises(RuntimeError, match="The output catalog is empty"):
-        cone_search_catalog.to_hats(base_catalog_path)
-
-
-def test_save_big_catalog(tmp_path):
-    """Load a catalog with many partitions, and save with to_hats."""
-    mock_partition_df = pd.DataFrame(
-        {
-            "ra": np.linspace(0, 360, 100_000),
-            "dec": np.linspace(-90, 90, 100_000),
-            "id": np.arange(100_000, 200_000),
-        }
-    )
-
-    base_catalog_path = tmp_path / "big_sky"
-
-    kwargs = {
-        "catalog_name": "big_sky",
-        "catalog_type": "object",
-        "lowest_order": 6,
-        "highest_order": 10,
-        "threshold": 500,
-    }
-
-    catalog = lsdb.from_dataframe(mock_partition_df, margin_threshold=None, **kwargs)
-
-    catalog.to_hats(base_catalog_path)
-
-    read_catalog = hc.read_hats(base_catalog_path)
-    assert len(read_catalog.get_healpix_pixels()) == len(catalog.get_healpix_pixels())
-
-
-def test_save_catalog_with_some_empty_partitions(small_sky_order1_catalog, tmp_path):
-    base_catalog_path = tmp_path / "small_sky"
-
-    # The result of this cone search is known to have one empty partition
-    cone_search_catalog = small_sky_order1_catalog.cone_search(0, -80, 15 * 3600)
-    assert cone_search_catalog._ddf.npartitions == 2
-
-    non_empty_pixels = []
-    for pixel, partition_index in cone_search_catalog._ddf_pixel_map.items():
-        if len(cone_search_catalog._ddf.partitions[partition_index]) > 0:
-            non_empty_pixels.append(pixel)
-    assert len(non_empty_pixels) == 1
-
-    cone_search_catalog.to_hats(base_catalog_path)
-
-    # Confirm that we can read the catalog from disk, and that it was
-    # written with no empty partitions
-    catalog = lsdb.open_catalog(base_catalog_path)
-    assert catalog._ddf.npartitions == 1
-    assert len(catalog._ddf.partitions[0]) > 0
-    assert list(catalog._ddf_pixel_map.keys()) == non_empty_pixels
 
 
 def test_prune_empty_partitions(small_sky_order1_catalog):

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -1,4 +1,6 @@
 # pylint: disable=too-many-lines
+from pathlib import Path
+
 import astropy.units as u
 import dask.array as da
 import dask.dataframe as dd
@@ -9,10 +11,13 @@ import nested_pandas as npd
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
+import pyarrow.parquet as pq
 import pytest
 from astropy.coordinates import SkyCoord
 from astropy.visualization.wcsaxes import WCSAxes
 from hats.inspection.visualize_catalog import get_fov_moc_from_wcs
+from hats.io.file_io import get_upath_for_protocol, read_fits_image
+from hats.io.paths import get_data_thumbnail_pointer
 from hats.pixel_math import HealpixPixel, spatial_index_to_healpix
 from mocpy import WCS
 

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -175,7 +175,7 @@ class TestCrossmatch:
     def test_kdtree_crossmatch_multiple_neighbors_margin(
         algo, small_sky_catalog, small_sky_xmatch_dir, small_sky_xmatch_margin_dir, xmatch_correct_3n_2t
     ):
-        small_sky_xmatch_catalog = lsdb.read_hats(
+        small_sky_xmatch_catalog = lsdb.hats_catalog(
             small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_dir
         )
         xmatched = small_sky_catalog.crossmatch(
@@ -199,7 +199,7 @@ class TestCrossmatch:
         small_sky_xmatch_margin_dir,
         xmatch_correct_3n_2t_negative,
     ):
-        small_sky_xmatch_catalog = lsdb.read_hats(
+        small_sky_xmatch_catalog = lsdb.hats_catalog(
             small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_dir
         )
         xmatched = small_sky_left_xmatch_catalog.crossmatch(
@@ -255,7 +255,7 @@ class TestBoundedCrossmatch:
         small_sky_xmatch_margin_dir,
         xmatch_correct_05_2_3n_margin,
     ):
-        small_sky_xmatch_catalog = lsdb.read_hats(
+        small_sky_xmatch_catalog = lsdb.hats_catalog(
             small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_dir
         )
         xmatched = small_sky_catalog.crossmatch(
@@ -315,7 +315,7 @@ class TestBoundedCrossmatch:
     @staticmethod
     def test_self_crossmatch(algo, small_sky_catalog, small_sky_dir):
         # Read a second small sky catalog to not have duplicate labels
-        small_sky_catalog_2 = lsdb.read_hats(small_sky_dir)
+        small_sky_catalog_2 = lsdb.hats_catalog(small_sky_dir)
         small_sky_catalog_2.hc_structure.catalog_name = "small_sky_2"
         with pytest.warns(RuntimeWarning, match="Results may be incomplete and/or inaccurate"):
             xmatched = small_sky_catalog.crossmatch(

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -175,7 +175,7 @@ class TestCrossmatch:
     def test_kdtree_crossmatch_multiple_neighbors_margin(
         algo, small_sky_catalog, small_sky_xmatch_dir, small_sky_xmatch_margin_dir, xmatch_correct_3n_2t
     ):
-        small_sky_xmatch_catalog = lsdb.hats_catalog(
+        small_sky_xmatch_catalog = lsdb.open_catalog(
             small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_dir
         )
         xmatched = small_sky_catalog.crossmatch(
@@ -199,7 +199,7 @@ class TestCrossmatch:
         small_sky_xmatch_margin_dir,
         xmatch_correct_3n_2t_negative,
     ):
-        small_sky_xmatch_catalog = lsdb.hats_catalog(
+        small_sky_xmatch_catalog = lsdb.open_catalog(
             small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_dir
         )
         xmatched = small_sky_left_xmatch_catalog.crossmatch(
@@ -255,7 +255,7 @@ class TestBoundedCrossmatch:
         small_sky_xmatch_margin_dir,
         xmatch_correct_05_2_3n_margin,
     ):
-        small_sky_xmatch_catalog = lsdb.hats_catalog(
+        small_sky_xmatch_catalog = lsdb.open_catalog(
             small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_dir
         )
         xmatched = small_sky_catalog.crossmatch(
@@ -315,7 +315,7 @@ class TestBoundedCrossmatch:
     @staticmethod
     def test_self_crossmatch(algo, small_sky_catalog, small_sky_dir):
         # Read a second small sky catalog to not have duplicate labels
-        small_sky_catalog_2 = lsdb.hats_catalog(small_sky_dir)
+        small_sky_catalog_2 = lsdb.open_catalog(small_sky_dir)
         small_sky_catalog_2.hc_structure.catalog_name = "small_sky_2"
         with pytest.warns(RuntimeWarning, match="Results may be incomplete and/or inaccurate"):
             xmatched = small_sky_catalog.crossmatch(

--- a/tests/lsdb/catalog/test_index_search.py
+++ b/tests/lsdb/catalog/test_index_search.py
@@ -81,7 +81,7 @@ def test_id_search_with_some_explicit_index_catalogs(
     collection_properties.all_indexes = {"object_id": "small_sky_order1_source_object_id_index"}
     collection_properties.to_properties_file(collection_base_dir)
 
-    collection = lsdb.hats_catalog(collection_base_dir)
+    collection = lsdb.open_catalog(collection_base_dir)
     cat = collection.id_search(
         values={"object_id": 810, "band": "r"},
         index_catalogs={"band": small_sky_order1_source_band_index_dir},

--- a/tests/lsdb/catalog/test_index_search.py
+++ b/tests/lsdb/catalog/test_index_search.py
@@ -81,7 +81,7 @@ def test_id_search_with_some_explicit_index_catalogs(
     collection_properties.all_indexes = {"object_id": "small_sky_order1_source_object_id_index"}
     collection_properties.to_properties_file(collection_base_dir)
 
-    collection = lsdb.read_hats(collection_base_dir)
+    collection = lsdb.hats_catalog(collection_base_dir)
     cat = collection.id_search(
         values={"object_id": 810, "band": "r"},
         index_catalogs={"band": small_sky_order1_source_band_index_dir},

--- a/tests/lsdb/catalog/test_join.py
+++ b/tests/lsdb/catalog/test_join.py
@@ -8,7 +8,7 @@ from hats.pixel_math import HealpixPixel
 from hats.pixel_math.spatial_index import SPATIAL_INDEX_COLUMN, spatial_index_to_healpix
 
 import lsdb.nested as nd
-from lsdb import hats_catalog
+from lsdb import open_catalog
 from lsdb.dask.merge_catalog_functions import align_catalogs
 
 
@@ -317,7 +317,7 @@ def merging_function(input_frame, map_input, *args, **kwargs):
 
 
 def test_merge_map(small_sky_catalog, test_data_dir):
-    map_catalog = hats_catalog(test_data_dir / "square_map")
+    map_catalog = open_catalog(test_data_dir / "square_map")
     merge_lazy = small_sky_catalog.merge_map(map_catalog, merging_function, unused_kwarg="ignored")
 
     merge_result = merge_lazy.compute()

--- a/tests/lsdb/catalog/test_join.py
+++ b/tests/lsdb/catalog/test_join.py
@@ -8,7 +8,7 @@ from hats.pixel_math import HealpixPixel
 from hats.pixel_math.spatial_index import SPATIAL_INDEX_COLUMN, spatial_index_to_healpix
 
 import lsdb.nested as nd
-from lsdb import read_hats
+from lsdb import hats_catalog
 from lsdb.dask.merge_catalog_functions import align_catalogs
 
 
@@ -317,7 +317,7 @@ def merging_function(input_frame, map_input, *args, **kwargs):
 
 
 def test_merge_map(small_sky_catalog, test_data_dir):
-    map_catalog = read_hats(test_data_dir / "square_map")
+    map_catalog = hats_catalog(test_data_dir / "square_map")
     merge_lazy = small_sky_catalog.merge_map(map_catalog, merging_function, unused_kwarg="ignored")
 
     merge_result = merge_lazy.compute()

--- a/tests/lsdb/catalog/test_margin_catalog.py
+++ b/tests/lsdb/catalog/test_margin_catalog.py
@@ -10,7 +10,7 @@ from lsdb.catalog.margin_catalog import MarginCatalog
 
 
 def test_read_margin_catalog(small_sky_xmatch_margin_dir):
-    margin = lsdb.hats_catalog(small_sky_xmatch_margin_dir)
+    margin = lsdb.open_catalog(small_sky_xmatch_margin_dir)
     assert isinstance(margin, MarginCatalog)
     assert isinstance(margin._ddf, nd.NestedFrame)
     hc_margin = hc.read_hats(small_sky_xmatch_margin_dir)
@@ -22,7 +22,7 @@ def test_read_margin_catalog(small_sky_xmatch_margin_dir):
 
 
 def test_margin_catalog_partitions_correct(small_sky_xmatch_margin_dir):
-    margin = lsdb.hats_catalog(small_sky_xmatch_margin_dir)
+    margin = lsdb.open_catalog(small_sky_xmatch_margin_dir)
     assert isinstance(margin, MarginCatalog)
     for healpix_pixel in margin.get_healpix_pixels():
         hp_order = healpix_pixel.order
@@ -41,7 +41,7 @@ def test_save_margin_catalog(small_sky_xmatch_margin_catalog, tmp_path):
     base_catalog_path = Path(tmp_path) / new_catalog_name
     small_sky_xmatch_margin_catalog.to_hats(base_catalog_path, catalog_name=new_catalog_name)
 
-    expected_catalog = lsdb.hats_catalog(base_catalog_path)
+    expected_catalog = lsdb.open_catalog(base_catalog_path)
     assert expected_catalog.hc_structure.catalog_name == new_catalog_name
     assert expected_catalog.get_healpix_pixels() == small_sky_xmatch_margin_catalog.get_healpix_pixels()
     pd.testing.assert_frame_equal(expected_catalog.compute(), small_sky_xmatch_margin_catalog._ddf.compute())

--- a/tests/lsdb/catalog/test_margin_catalog.py
+++ b/tests/lsdb/catalog/test_margin_catalog.py
@@ -10,7 +10,7 @@ from lsdb.catalog.margin_catalog import MarginCatalog
 
 
 def test_read_margin_catalog(small_sky_xmatch_margin_dir):
-    margin = lsdb.read_hats(small_sky_xmatch_margin_dir)
+    margin = lsdb.hats_catalog(small_sky_xmatch_margin_dir)
     assert isinstance(margin, MarginCatalog)
     assert isinstance(margin._ddf, nd.NestedFrame)
     hc_margin = hc.read_hats(small_sky_xmatch_margin_dir)
@@ -22,7 +22,7 @@ def test_read_margin_catalog(small_sky_xmatch_margin_dir):
 
 
 def test_margin_catalog_partitions_correct(small_sky_xmatch_margin_dir):
-    margin = lsdb.read_hats(small_sky_xmatch_margin_dir)
+    margin = lsdb.hats_catalog(small_sky_xmatch_margin_dir)
     assert isinstance(margin, MarginCatalog)
     for healpix_pixel in margin.get_healpix_pixels():
         hp_order = healpix_pixel.order
@@ -41,7 +41,7 @@ def test_save_margin_catalog(small_sky_xmatch_margin_catalog, tmp_path):
     base_catalog_path = Path(tmp_path) / new_catalog_name
     small_sky_xmatch_margin_catalog.to_hats(base_catalog_path, catalog_name=new_catalog_name)
 
-    expected_catalog = lsdb.read_hats(base_catalog_path)
+    expected_catalog = lsdb.hats_catalog(base_catalog_path)
     assert expected_catalog.hc_structure.catalog_name == new_catalog_name
     assert expected_catalog.get_healpix_pixels() == small_sky_xmatch_margin_catalog.get_healpix_pixels()
     pd.testing.assert_frame_equal(expected_catalog.compute(), small_sky_xmatch_margin_catalog._ddf.compute())

--- a/tests/lsdb/catalog/test_nested.py
+++ b/tests/lsdb/catalog/test_nested.py
@@ -272,7 +272,7 @@ def test_serialization_round_trip(tmp_path, small_sky_order1_catalog, small_sky_
     assert isinstance(cat.dtypes["lc"], NestedDtype)
     out_path = tmp_path / "test_cat"
     cat.to_hats(out_path)
-    read_catalog = lsdb.hats_catalog(out_path)
+    read_catalog = lsdb.open_catalog(out_path)
     assert isinstance(read_catalog.dtypes["lc"], NestedDtype)
     assert isinstance(read_catalog.compute().dtypes["lc"], NestedDtype)
 

--- a/tests/lsdb/catalog/test_nested.py
+++ b/tests/lsdb/catalog/test_nested.py
@@ -272,7 +272,7 @@ def test_serialization_round_trip(tmp_path, small_sky_order1_catalog, small_sky_
     assert isinstance(cat.dtypes["lc"], NestedDtype)
     out_path = tmp_path / "test_cat"
     cat.to_hats(out_path)
-    read_catalog = lsdb.read_hats(out_path)
+    read_catalog = lsdb.hats_catalog(out_path)
     assert isinstance(read_catalog.dtypes["lc"], NestedDtype)
     assert isinstance(read_catalog.compute().dtypes["lc"], NestedDtype)
 

--- a/tests/lsdb/loaders/hats/test_read_hats.py
+++ b/tests/lsdb/loaders/hats/test_read_hats.py
@@ -19,7 +19,7 @@ from lsdb.core.search import BoxSearch, ConeSearch, IndexSearch, OrderSearch, Po
 
 
 def test_read_hats(small_sky_order1_dir, small_sky_order1_hats_catalog, helpers):
-    catalog = lsdb.hats_catalog(small_sky_order1_dir)
+    catalog = lsdb.open_catalog(small_sky_order1_dir)
     assert isinstance(catalog, lsdb.Catalog)
     assert isinstance(catalog._ddf, nd.NestedFrame)
     assert catalog.hc_structure.catalog_base_dir == small_sky_order1_hats_catalog.catalog_base_dir
@@ -35,7 +35,7 @@ def test_read_hats(small_sky_order1_dir, small_sky_order1_hats_catalog, helpers)
 def test_read_hats_collection_with_default_margin(
     small_sky_order1_collection_dir, small_sky_order1_catalog, small_sky_order1_margin_1deg_catalog, helpers
 ):
-    catalog = lsdb.hats_catalog(small_sky_order1_collection_dir)
+    catalog = lsdb.open_catalog(small_sky_order1_collection_dir)
 
     assert isinstance(catalog, lsdb.Catalog)
     assert catalog.name == catalog.hc_collection.main_catalog.catalog_name
@@ -66,7 +66,7 @@ def test_read_hats_collection_with_margin_name(
     small_sky_order1_collection_dir, small_sky_order1_margin_2deg_catalog, helpers
 ):
     margin_name = small_sky_order1_margin_2deg_catalog.name
-    catalog = lsdb.hats_catalog(small_sky_order1_collection_dir, margin_cache=margin_name)
+    catalog = lsdb.open_catalog(small_sky_order1_collection_dir, margin_cache=margin_name)
 
     assert isinstance(catalog.margin, lsdb.MarginCatalog)
     assert catalog.margin.name != catalog.hc_collection.default_margin
@@ -90,7 +90,7 @@ def test_read_hats_collection_with_margin_absolute_path(
     helpers,
 ):
     margin_absolute_path = path_type(small_sky_order1_margin_2deg_dir)
-    catalog = lsdb.hats_catalog(small_sky_order1_collection_dir, margin_cache=margin_absolute_path)
+    catalog = lsdb.open_catalog(small_sky_order1_collection_dir, margin_cache=margin_absolute_path)
 
     assert isinstance(catalog.margin, lsdb.MarginCatalog)
     assert catalog.margin.name != catalog.hc_collection.default_margin
@@ -105,7 +105,7 @@ def test_read_hats_collection_with_margin_absolute_path(
 
 
 def test_read_hats_collection_with_extra_kwargs(small_sky_order1_collection_dir):
-    catalog = lsdb.hats_catalog(
+    catalog = lsdb.open_catalog(
         small_sky_order1_collection_dir, columns=["ra", "dec"], filters=[("ra", ">", 300)]
     )
 
@@ -126,7 +126,7 @@ def test_read_hats_initializes_upath_once(
     mock_method = "hats.io.file_io.file_pointer.get_upath_for_protocol"
     mocked_upath_call = mocker.patch(mock_method, side_effect=get_upath_for_protocol)
 
-    lsdb.hats_catalog(small_sky_order1_source_dir, margin_cache=small_sky_order1_source_margin_dir).compute()
+    lsdb.open_catalog(small_sky_order1_source_dir, margin_cache=small_sky_order1_source_margin_dir).compute()
 
     expected_calls = [
         call.get_upath_for_protocol(small_sky_order1_source_dir),
@@ -136,7 +136,7 @@ def test_read_hats_initializes_upath_once(
 
 
 def test_read_hats_default_cols(small_sky_order1_default_cols_dir, helpers):
-    catalog = lsdb.hats_catalog(small_sky_order1_default_cols_dir)
+    catalog = lsdb.open_catalog(small_sky_order1_default_cols_dir)
     assert isinstance(catalog, lsdb.Catalog)
     assert isinstance(catalog._ddf, nd.NestedFrame)
     assert catalog.hc_structure.catalog_info.default_columns is not None
@@ -151,7 +151,7 @@ def test_read_hats_default_cols(small_sky_order1_default_cols_dir, helpers):
 
 def test_read_hats_default_cols_specify_cols(small_sky_order1_default_cols_dir, helpers):
     filter_columns = ["ra", "dec"]
-    catalog = lsdb.hats_catalog(small_sky_order1_default_cols_dir, columns=filter_columns)
+    catalog = lsdb.open_catalog(small_sky_order1_default_cols_dir, columns=filter_columns)
     assert isinstance(catalog, lsdb.Catalog)
     assert isinstance(catalog._ddf, nd.NestedFrame)
     assert catalog.hc_structure.catalog_info.default_columns is not None
@@ -166,7 +166,7 @@ def test_read_hats_default_cols_specify_cols(small_sky_order1_default_cols_dir, 
 
 def test_read_hats_default_cols_all_cols(small_sky_order1_default_cols_dir, helpers):
     expected_all_cols = ["id", "ra", "dec", "ra_error", "dec_error"]
-    catalog = lsdb.hats_catalog(small_sky_order1_default_cols_dir, columns="all")
+    catalog = lsdb.open_catalog(small_sky_order1_default_cols_dir, columns="all")
     assert isinstance(catalog, lsdb.Catalog)
     assert isinstance(catalog._ddf, nd.NestedFrame)
     assert catalog.hc_structure.catalog_info.default_columns is not None
@@ -178,7 +178,7 @@ def test_read_hats_default_cols_all_cols(small_sky_order1_default_cols_dir, help
 
 
 def test_read_hats_no_pandas(small_sky_order1_no_pandas_dir, helpers):
-    catalog = lsdb.hats_catalog(small_sky_order1_no_pandas_dir)
+    catalog = lsdb.open_catalog(small_sky_order1_no_pandas_dir)
     assert isinstance(catalog, lsdb.Catalog)
     assert isinstance(catalog._ddf, nd.NestedFrame)
     assert len(catalog.compute().columns) == 5
@@ -189,7 +189,7 @@ def test_read_hats_no_pandas(small_sky_order1_no_pandas_dir, helpers):
 
 
 def test_read_hats_with_margin_extra_kwargs(small_sky_xmatch_dir, small_sky_xmatch_margin_dir):
-    catalog = lsdb.hats_catalog(
+    catalog = lsdb.open_catalog(
         small_sky_xmatch_dir,
         margin_cache=small_sky_xmatch_margin_dir,
         columns=["ra", "dec"],
@@ -210,7 +210,7 @@ def test_read_hats_with_margin_extra_kwargs(small_sky_xmatch_dir, small_sky_xmat
 def test_read_hats_npix_alt_suffix(
     small_sky_npix_alt_suffix_dir, small_sky_npix_alt_suffix_hats_catalog, helpers
 ):
-    catalog = lsdb.hats_catalog(small_sky_npix_alt_suffix_dir)
+    catalog = lsdb.open_catalog(small_sky_npix_alt_suffix_dir)
     # Show that npix_suffix is not the standard ".parquet" but is still valid.
     catalog_npix_suffix = catalog.hc_structure.catalog_info.npix_suffix
     assert isinstance(catalog_npix_suffix, str)
@@ -227,7 +227,7 @@ def test_read_hats_npix_alt_suffix(
 
 
 def test_read_hats_npix_as_dir(small_sky_npix_as_dir_dir, small_sky_npix_as_dir_hats_catalog, helpers):
-    catalog = lsdb.hats_catalog(small_sky_npix_as_dir_dir)
+    catalog = lsdb.open_catalog(small_sky_npix_as_dir_dir)
     # Show that npix_suffix indicates that Npix are directories and also matches the hats property.
     catalog_npix_suffix = catalog.hc_structure.catalog_info.npix_suffix
     assert catalog_npix_suffix == "/"
@@ -244,7 +244,7 @@ def test_read_hats_npix_as_dir(small_sky_npix_as_dir_dir, small_sky_npix_as_dir_
 
 def test_read_hats_with_columns(small_sky_order1_dir, helpers):
     filter_columns = ["ra", "dec"]
-    catalog = lsdb.hats_catalog(small_sky_order1_dir, columns=filter_columns)
+    catalog = lsdb.open_catalog(small_sky_order1_dir, columns=filter_columns)
     assert isinstance(catalog, lsdb.Catalog)
     npt.assert_array_equal(catalog.compute().columns.to_numpy(), filter_columns)
     helpers.assert_index_correct(catalog)
@@ -253,7 +253,7 @@ def test_read_hats_with_columns(small_sky_order1_dir, helpers):
 
 def test_read_hats_no_pandas_with_columns(small_sky_order1_no_pandas_dir, helpers):
     filter_columns = ["ra", "dec"]
-    catalog = lsdb.hats_catalog(small_sky_order1_no_pandas_dir, columns=filter_columns)
+    catalog = lsdb.open_catalog(small_sky_order1_no_pandas_dir, columns=filter_columns)
     assert isinstance(catalog, lsdb.Catalog)
     npt.assert_array_equal(catalog.compute().columns.to_numpy(), filter_columns)
     helpers.assert_index_correct(catalog)
@@ -262,7 +262,7 @@ def test_read_hats_no_pandas_with_columns(small_sky_order1_no_pandas_dir, helper
 
 def test_read_hats_no_pandas_with_index_column(small_sky_order1_no_pandas_dir, helpers):
     filter_columns = ["ra", "dec", "_healpix_29"]
-    catalog = lsdb.hats_catalog(small_sky_order1_no_pandas_dir, columns=filter_columns)
+    catalog = lsdb.open_catalog(small_sky_order1_no_pandas_dir, columns=filter_columns)
     assert isinstance(catalog, lsdb.Catalog)
     helpers.assert_index_correct(catalog)
     npt.assert_array_equal(catalog.compute().columns.to_numpy(), filter_columns)
@@ -270,30 +270,30 @@ def test_read_hats_no_pandas_with_index_column(small_sky_order1_no_pandas_dir, h
 
 
 def test_read_hats_with_extra_kwargs(small_sky_order1_dir):
-    catalog = lsdb.hats_catalog(small_sky_order1_dir, filters=[("ra", ">", 300)])
+    catalog = lsdb.open_catalog(small_sky_order1_dir, filters=[("ra", ">", 300)])
     assert isinstance(catalog, lsdb.Catalog)
     assert np.greater(catalog.compute()["ra"].to_numpy(), 300).all()
 
 
 def test_read_hats_with_mistaken_kwargs(small_sky_order1_dir, small_sky_xmatch_margin_dir):
     with pytest.raises(ValueError, match="Invalid keyword argument"):
-        lsdb.hats_catalog(small_sky_order1_dir, margins=small_sky_xmatch_margin_dir)
+        lsdb.open_catalog(small_sky_order1_dir, margins=small_sky_xmatch_margin_dir)
 
 
 def test_pixels_in_map_equal_catalog_pixels(small_sky_order1_dir, small_sky_order1_hats_catalog):
-    catalog = lsdb.hats_catalog(small_sky_order1_dir)
+    catalog = lsdb.open_catalog(small_sky_order1_dir)
     for healpix_pixel in small_sky_order1_hats_catalog.get_healpix_pixels():
         catalog.get_partition(healpix_pixel.order, healpix_pixel.pixel)
 
 
 def test_wrong_pixel_raises_value_error(small_sky_order1_dir):
-    catalog = lsdb.hats_catalog(small_sky_order1_dir)
+    catalog = lsdb.open_catalog(small_sky_order1_dir)
     with pytest.raises(ValueError):
         catalog.get_partition(-1, -1)
 
 
 def test_parquet_data_in_partitions_match_files(small_sky_order1_dir, small_sky_order1_hats_catalog):
-    catalog = lsdb.hats_catalog(small_sky_order1_dir)
+    catalog = lsdb.open_catalog(small_sky_order1_dir)
     for healpix_pixel in small_sky_order1_hats_catalog.get_healpix_pixels():
         hp_order = healpix_pixel.order
         hp_pixel = healpix_pixel.pixel
@@ -307,7 +307,7 @@ def test_parquet_data_in_partitions_match_files(small_sky_order1_dir, small_sky_
 
 
 def test_read_hats_specify_catalog_type(small_sky_catalog, small_sky_dir):
-    catalog = lsdb.hats_catalog(small_sky_dir)
+    catalog = lsdb.open_catalog(small_sky_dir)
     assert isinstance(catalog, lsdb.Catalog)
     assert isinstance(catalog._ddf, nd.NestedFrame)
     pd.testing.assert_frame_equal(catalog.compute(), small_sky_catalog.compute())
@@ -320,7 +320,7 @@ def test_catalog_with_margin(
     small_sky_xmatch_dir, small_sky_xmatch_margin_dir, small_sky_xmatch_margin_catalog, helpers
 ):
     assert isinstance(small_sky_xmatch_margin_dir, Path)
-    catalog = lsdb.hats_catalog(small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_dir)
+    catalog = lsdb.open_catalog(small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_dir)
     assert isinstance(catalog, lsdb.Catalog)
     assert isinstance(catalog.margin, lsdb.MarginCatalog)
     assert isinstance(catalog._ddf, nd.NestedFrame)
@@ -335,14 +335,14 @@ def test_catalog_with_margin(
 
 
 def test_catalog_without_margin_is_none(small_sky_xmatch_dir):
-    catalog = lsdb.hats_catalog(small_sky_xmatch_dir)
+    catalog = lsdb.open_catalog(small_sky_xmatch_dir)
     assert isinstance(catalog, lsdb.Catalog)
     assert catalog.margin is None
 
 
 def test_catalog_with_wrong_margin(small_sky_order1_dir, small_sky_order1_source_margin_dir):
     with pytest.raises(ValueError, match="must have the same schema"):
-        lsdb.hats_catalog(small_sky_order1_dir, margin_cache=small_sky_order1_source_margin_dir)
+        lsdb.open_catalog(small_sky_order1_dir, margin_cache=small_sky_order1_source_margin_dir)
 
 
 def test_read_hats_subset_with_cone_search(small_sky_order1_dir, small_sky_order1_catalog):
@@ -350,7 +350,7 @@ def test_read_hats_subset_with_cone_search(small_sky_order1_dir, small_sky_order
     # Filtering using catalog's cone_search
     cone_search_catalog = small_sky_order1_catalog.cone_search(ra=0, dec=-80, radius_arcsec=20 * 3600)
     # Filtering when calling `read_hats`
-    cone_search_catalog_2 = lsdb.hats_catalog(small_sky_order1_dir, search_filter=cone_search)
+    cone_search_catalog_2 = lsdb.open_catalog(small_sky_order1_dir, search_filter=cone_search)
     assert isinstance(cone_search_catalog_2, lsdb.Catalog)
     # The partitions of the catalogs are equivalent
     assert cone_search_catalog.get_healpix_pixels() == cone_search_catalog_2.get_healpix_pixels()
@@ -362,7 +362,7 @@ def test_read_hats_subset_with_box_search(small_sky_order1_dir, small_sky_order1
     # Filtering using catalog's box_search
     box_search_catalog = small_sky_order1_catalog.box_search(ra=(300, 320), dec=(-40, -10))
     # Filtering when calling `read_hats`
-    box_search_catalog_2 = lsdb.hats_catalog(small_sky_order1_dir, search_filter=box_search)
+    box_search_catalog_2 = lsdb.open_catalog(small_sky_order1_dir, search_filter=box_search)
     assert isinstance(box_search_catalog_2, lsdb.Catalog)
     # The partitions of the catalogs are equivalent
     assert box_search_catalog.get_healpix_pixels() == box_search_catalog_2.get_healpix_pixels()
@@ -376,7 +376,7 @@ def test_read_hats_subset_with_polygon_search(small_sky_order1_dir, small_sky_or
     # Filtering using catalog's polygon_search
     polygon_search_catalog = small_sky_order1_catalog.polygon_search(vertices)
     # Filtering when calling `read_hats`
-    polygon_search_catalog_2 = lsdb.hats_catalog(small_sky_order1_dir, search_filter=polygon_search)
+    polygon_search_catalog_2 = lsdb.open_catalog(small_sky_order1_dir, search_filter=polygon_search)
     assert isinstance(polygon_search_catalog_2, lsdb.Catalog)
     # The partitions of the catalogs are equivalent
     assert polygon_search_catalog.get_healpix_pixels() == polygon_search_catalog_2.get_healpix_pixels()
@@ -395,7 +395,7 @@ def test_read_hats_subset_with_index_search(
     )
     # Filtering when calling `read_hats`
     index_search = IndexSearch(values={"id": 700}, index_catalogs={"id": catalog_index})
-    index_search_catalog_2 = lsdb.hats_catalog(small_sky_order1_dir, search_filter=index_search)
+    index_search_catalog_2 = lsdb.open_catalog(small_sky_order1_dir, search_filter=index_search)
     assert isinstance(index_search_catalog_2, lsdb.Catalog)
     # The partitions of the catalogs are equivalent
     assert index_search_catalog.get_healpix_pixels() == index_search_catalog_2.get_healpix_pixels()
@@ -406,7 +406,7 @@ def test_read_hats_subset_with_order_search(small_sky_source_catalog, small_sky_
     # Filtering using catalog's order_search
     order_search_catalog = small_sky_source_catalog.order_search(min_order=1, max_order=2)
     # Filtering when calling `read_hats`
-    order_search_catalog_2 = lsdb.hats_catalog(small_sky_source_dir, search_filter=order_search)
+    order_search_catalog_2 = lsdb.open_catalog(small_sky_source_dir, search_filter=order_search)
     assert isinstance(order_search_catalog_2, lsdb.Catalog)
     # The partitions of the catalogs are equivalent
     assert order_search_catalog.get_healpix_pixels() == order_search_catalog_2.get_healpix_pixels()
@@ -416,7 +416,7 @@ def test_read_hats_subset_no_partitions(small_sky_order1_dir, small_sky_order1_i
     with pytest.raises(ValueError, match="no coverage"):
         catalog_index = hc.read_hats(small_sky_order1_id_index_dir)
         index_search = IndexSearch(values={"id": 900}, index_catalogs={"id": catalog_index})
-        lsdb.hats_catalog(small_sky_order1_dir, search_filter=index_search)
+        lsdb.open_catalog(small_sky_order1_dir, search_filter=index_search)
 
 
 def test_read_hats_with_margin_subset(
@@ -426,7 +426,7 @@ def test_read_hats_with_margin_subset(
     # Filtering using catalog's cone_search
     cone_search_catalog = small_sky_order1_source_with_margin.cone_search(ra=315, dec=-66, radius_arcsec=20)
     # Filtering when calling `read_hats`
-    cone_search_catalog_2 = lsdb.hats_catalog(
+    cone_search_catalog_2 = lsdb.open_catalog(
         small_sky_order1_source_dir,
         search_filter=cone_search,
         margin_cache=small_sky_order1_source_margin_dir,
@@ -443,7 +443,7 @@ def test_read_hats_margin_catalog_subset(
     small_sky_order1_source_margin_dir, small_sky_order1_source_margin_catalog, helpers
 ):
     search_filter = ConeSearch(ra=315, dec=-60, radius_arcsec=10)
-    margin = lsdb.hats_catalog(small_sky_order1_source_margin_dir, search_filter=search_filter)
+    margin = lsdb.open_catalog(small_sky_order1_source_margin_dir, search_filter=search_filter)
 
     margin_info = margin.hc_structure.catalog_info
     small_sky_order1_source_margin_info = small_sky_order1_source_margin_catalog.hc_structure.catalog_info
@@ -465,11 +465,11 @@ def test_read_hats_margin_catalog_subset(
 def test_read_hats_margin_catalog_subset_is_empty(small_sky_order1_source_margin_dir):
     search_filter = ConeSearch(ra=100, dec=80, radius_arcsec=1)
     with pytest.raises(ValueError, match="no coverage"):
-        lsdb.hats_catalog(small_sky_order1_source_margin_dir, search_filter=search_filter)
+        lsdb.open_catalog(small_sky_order1_source_margin_dir, search_filter=search_filter)
 
 
 def test_read_hats_map_catalog(test_data_dir):
-    margin_catalog = lsdb.hats_catalog(test_data_dir / "square_map")
+    margin_catalog = lsdb.open_catalog(test_data_dir / "square_map")
     assert len(margin_catalog.get_healpix_pixels()) == 12
     assert len(margin_catalog._ddf_pixel_map) == 12
     assert len(margin_catalog.compute()) == 12
@@ -478,17 +478,17 @@ def test_read_hats_map_catalog(test_data_dir):
 
 def test_read_hats_schema_not_found(small_sky_no_metadata_dir):
     with pytest.raises(ValueError, match="catalog schema could not be loaded"):
-        lsdb.hats_catalog(small_sky_no_metadata_dir)
+        lsdb.open_catalog(small_sky_no_metadata_dir)
 
 
 def test_all_columns_read_columns(small_sky_order1_dir, small_sky_order1_catalog):
-    cat = lsdb.hats_catalog(small_sky_order1_dir, columns=["ra", "dec"])
+    cat = lsdb.open_catalog(small_sky_order1_dir, columns=["ra", "dec"])
     assert len(cat.columns) < len(cat.all_columns)
     assert np.all(cat.all_columns == small_sky_order1_catalog.columns)
 
 
 def test_original_schema_read_columns(small_sky_order1_dir, small_sky_order1_catalog):
-    cat = lsdb.hats_catalog(small_sky_order1_dir, columns=["ra", "dec"])
+    cat = lsdb.open_catalog(small_sky_order1_dir, columns=["ra", "dec"])
     assert len(cat.original_schema) == len(small_sky_order1_catalog.hc_structure.schema)
     for field in cat.original_schema:
         assert field in small_sky_order1_catalog.hc_structure.schema
@@ -496,7 +496,7 @@ def test_original_schema_read_columns(small_sky_order1_dir, small_sky_order1_cat
 
 
 def test_read_nested_column_selection(small_sky_with_nested_sources_dir):
-    cat = lsdb.hats_catalog(
+    cat = lsdb.open_catalog(
         small_sky_with_nested_sources_dir, columns=["ra", "dec", "sources.source_id", "sources.source_ra"]
     )
     assert np.all(cat.columns == ["ra", "dec", "sources"])
@@ -508,15 +508,15 @@ def test_read_nested_column_selection(small_sky_with_nested_sources_dir):
 
 def test_read_nested_column_selection_errors(small_sky_with_nested_sources_dir):
     with pytest.raises(ArrowInvalid):
-        lsdb.hats_catalog(
+        lsdb.open_catalog(
             small_sky_with_nested_sources_dir, columns=["ra", "dec", "sources.source_id", "sources.wrong"]
         )
     with pytest.raises(ArrowInvalid):
-        lsdb.hats_catalog(
+        lsdb.open_catalog(
             small_sky_with_nested_sources_dir,
             columns=["ra", "wrong", "sources.source_id", "sources.source_ra"],
         )
     with pytest.raises(ArrowInvalid):
-        lsdb.hats_catalog(
+        lsdb.open_catalog(
             small_sky_with_nested_sources_dir, columns=["ra", "dec", "wrong.source_id", "sources.source_ra"]
         )

--- a/tests/lsdb/loaders/hats/test_read_hats.py
+++ b/tests/lsdb/loaders/hats/test_read_hats.py
@@ -19,7 +19,7 @@ from lsdb.core.search import BoxSearch, ConeSearch, IndexSearch, OrderSearch, Po
 
 
 def test_read_hats(small_sky_order1_dir, small_sky_order1_hats_catalog, helpers):
-    catalog = lsdb.read_hats(small_sky_order1_dir)
+    catalog = lsdb.hats_catalog(small_sky_order1_dir)
     assert isinstance(catalog, lsdb.Catalog)
     assert isinstance(catalog._ddf, nd.NestedFrame)
     assert catalog.hc_structure.catalog_base_dir == small_sky_order1_hats_catalog.catalog_base_dir
@@ -35,7 +35,7 @@ def test_read_hats(small_sky_order1_dir, small_sky_order1_hats_catalog, helpers)
 def test_read_hats_collection_with_default_margin(
     small_sky_order1_collection_dir, small_sky_order1_catalog, small_sky_order1_margin_1deg_catalog, helpers
 ):
-    catalog = lsdb.read_hats(small_sky_order1_collection_dir)
+    catalog = lsdb.hats_catalog(small_sky_order1_collection_dir)
 
     assert isinstance(catalog, lsdb.Catalog)
     assert catalog.name == catalog.hc_collection.main_catalog.catalog_name
@@ -66,7 +66,7 @@ def test_read_hats_collection_with_margin_name(
     small_sky_order1_collection_dir, small_sky_order1_margin_2deg_catalog, helpers
 ):
     margin_name = small_sky_order1_margin_2deg_catalog.name
-    catalog = lsdb.read_hats(small_sky_order1_collection_dir, margin_cache=margin_name)
+    catalog = lsdb.hats_catalog(small_sky_order1_collection_dir, margin_cache=margin_name)
 
     assert isinstance(catalog.margin, lsdb.MarginCatalog)
     assert catalog.margin.name != catalog.hc_collection.default_margin
@@ -90,7 +90,7 @@ def test_read_hats_collection_with_margin_absolute_path(
     helpers,
 ):
     margin_absolute_path = path_type(small_sky_order1_margin_2deg_dir)
-    catalog = lsdb.read_hats(small_sky_order1_collection_dir, margin_cache=margin_absolute_path)
+    catalog = lsdb.hats_catalog(small_sky_order1_collection_dir, margin_cache=margin_absolute_path)
 
     assert isinstance(catalog.margin, lsdb.MarginCatalog)
     assert catalog.margin.name != catalog.hc_collection.default_margin
@@ -105,7 +105,7 @@ def test_read_hats_collection_with_margin_absolute_path(
 
 
 def test_read_hats_collection_with_extra_kwargs(small_sky_order1_collection_dir):
-    catalog = lsdb.read_hats(
+    catalog = lsdb.hats_catalog(
         small_sky_order1_collection_dir, columns=["ra", "dec"], filters=[("ra", ">", 300)]
     )
 
@@ -126,7 +126,7 @@ def test_read_hats_initializes_upath_once(
     mock_method = "hats.io.file_io.file_pointer.get_upath_for_protocol"
     mocked_upath_call = mocker.patch(mock_method, side_effect=get_upath_for_protocol)
 
-    lsdb.read_hats(small_sky_order1_source_dir, margin_cache=small_sky_order1_source_margin_dir).compute()
+    lsdb.hats_catalog(small_sky_order1_source_dir, margin_cache=small_sky_order1_source_margin_dir).compute()
 
     expected_calls = [
         call.get_upath_for_protocol(small_sky_order1_source_dir),
@@ -136,7 +136,7 @@ def test_read_hats_initializes_upath_once(
 
 
 def test_read_hats_default_cols(small_sky_order1_default_cols_dir, helpers):
-    catalog = lsdb.read_hats(small_sky_order1_default_cols_dir)
+    catalog = lsdb.hats_catalog(small_sky_order1_default_cols_dir)
     assert isinstance(catalog, lsdb.Catalog)
     assert isinstance(catalog._ddf, nd.NestedFrame)
     assert catalog.hc_structure.catalog_info.default_columns is not None
@@ -151,7 +151,7 @@ def test_read_hats_default_cols(small_sky_order1_default_cols_dir, helpers):
 
 def test_read_hats_default_cols_specify_cols(small_sky_order1_default_cols_dir, helpers):
     filter_columns = ["ra", "dec"]
-    catalog = lsdb.read_hats(small_sky_order1_default_cols_dir, columns=filter_columns)
+    catalog = lsdb.hats_catalog(small_sky_order1_default_cols_dir, columns=filter_columns)
     assert isinstance(catalog, lsdb.Catalog)
     assert isinstance(catalog._ddf, nd.NestedFrame)
     assert catalog.hc_structure.catalog_info.default_columns is not None
@@ -166,7 +166,7 @@ def test_read_hats_default_cols_specify_cols(small_sky_order1_default_cols_dir, 
 
 def test_read_hats_default_cols_all_cols(small_sky_order1_default_cols_dir, helpers):
     expected_all_cols = ["id", "ra", "dec", "ra_error", "dec_error"]
-    catalog = lsdb.read_hats(small_sky_order1_default_cols_dir, columns="all")
+    catalog = lsdb.hats_catalog(small_sky_order1_default_cols_dir, columns="all")
     assert isinstance(catalog, lsdb.Catalog)
     assert isinstance(catalog._ddf, nd.NestedFrame)
     assert catalog.hc_structure.catalog_info.default_columns is not None
@@ -178,7 +178,7 @@ def test_read_hats_default_cols_all_cols(small_sky_order1_default_cols_dir, help
 
 
 def test_read_hats_no_pandas(small_sky_order1_no_pandas_dir, helpers):
-    catalog = lsdb.read_hats(small_sky_order1_no_pandas_dir)
+    catalog = lsdb.hats_catalog(small_sky_order1_no_pandas_dir)
     assert isinstance(catalog, lsdb.Catalog)
     assert isinstance(catalog._ddf, nd.NestedFrame)
     assert len(catalog.compute().columns) == 5
@@ -189,7 +189,7 @@ def test_read_hats_no_pandas(small_sky_order1_no_pandas_dir, helpers):
 
 
 def test_read_hats_with_margin_extra_kwargs(small_sky_xmatch_dir, small_sky_xmatch_margin_dir):
-    catalog = lsdb.read_hats(
+    catalog = lsdb.hats_catalog(
         small_sky_xmatch_dir,
         margin_cache=small_sky_xmatch_margin_dir,
         columns=["ra", "dec"],
@@ -210,7 +210,7 @@ def test_read_hats_with_margin_extra_kwargs(small_sky_xmatch_dir, small_sky_xmat
 def test_read_hats_npix_alt_suffix(
     small_sky_npix_alt_suffix_dir, small_sky_npix_alt_suffix_hats_catalog, helpers
 ):
-    catalog = lsdb.read_hats(small_sky_npix_alt_suffix_dir)
+    catalog = lsdb.hats_catalog(small_sky_npix_alt_suffix_dir)
     # Show that npix_suffix is not the standard ".parquet" but is still valid.
     catalog_npix_suffix = catalog.hc_structure.catalog_info.npix_suffix
     assert isinstance(catalog_npix_suffix, str)
@@ -227,7 +227,7 @@ def test_read_hats_npix_alt_suffix(
 
 
 def test_read_hats_npix_as_dir(small_sky_npix_as_dir_dir, small_sky_npix_as_dir_hats_catalog, helpers):
-    catalog = lsdb.read_hats(small_sky_npix_as_dir_dir)
+    catalog = lsdb.hats_catalog(small_sky_npix_as_dir_dir)
     # Show that npix_suffix indicates that Npix are directories and also matches the hats property.
     catalog_npix_suffix = catalog.hc_structure.catalog_info.npix_suffix
     assert catalog_npix_suffix == "/"
@@ -244,7 +244,7 @@ def test_read_hats_npix_as_dir(small_sky_npix_as_dir_dir, small_sky_npix_as_dir_
 
 def test_read_hats_with_columns(small_sky_order1_dir, helpers):
     filter_columns = ["ra", "dec"]
-    catalog = lsdb.read_hats(small_sky_order1_dir, columns=filter_columns)
+    catalog = lsdb.hats_catalog(small_sky_order1_dir, columns=filter_columns)
     assert isinstance(catalog, lsdb.Catalog)
     npt.assert_array_equal(catalog.compute().columns.to_numpy(), filter_columns)
     helpers.assert_index_correct(catalog)
@@ -253,7 +253,7 @@ def test_read_hats_with_columns(small_sky_order1_dir, helpers):
 
 def test_read_hats_no_pandas_with_columns(small_sky_order1_no_pandas_dir, helpers):
     filter_columns = ["ra", "dec"]
-    catalog = lsdb.read_hats(small_sky_order1_no_pandas_dir, columns=filter_columns)
+    catalog = lsdb.hats_catalog(small_sky_order1_no_pandas_dir, columns=filter_columns)
     assert isinstance(catalog, lsdb.Catalog)
     npt.assert_array_equal(catalog.compute().columns.to_numpy(), filter_columns)
     helpers.assert_index_correct(catalog)
@@ -262,7 +262,7 @@ def test_read_hats_no_pandas_with_columns(small_sky_order1_no_pandas_dir, helper
 
 def test_read_hats_no_pandas_with_index_column(small_sky_order1_no_pandas_dir, helpers):
     filter_columns = ["ra", "dec", "_healpix_29"]
-    catalog = lsdb.read_hats(small_sky_order1_no_pandas_dir, columns=filter_columns)
+    catalog = lsdb.hats_catalog(small_sky_order1_no_pandas_dir, columns=filter_columns)
     assert isinstance(catalog, lsdb.Catalog)
     helpers.assert_index_correct(catalog)
     npt.assert_array_equal(catalog.compute().columns.to_numpy(), filter_columns)
@@ -270,30 +270,30 @@ def test_read_hats_no_pandas_with_index_column(small_sky_order1_no_pandas_dir, h
 
 
 def test_read_hats_with_extra_kwargs(small_sky_order1_dir):
-    catalog = lsdb.read_hats(small_sky_order1_dir, filters=[("ra", ">", 300)])
+    catalog = lsdb.hats_catalog(small_sky_order1_dir, filters=[("ra", ">", 300)])
     assert isinstance(catalog, lsdb.Catalog)
     assert np.greater(catalog.compute()["ra"].to_numpy(), 300).all()
 
 
 def test_read_hats_with_mistaken_kwargs(small_sky_order1_dir, small_sky_xmatch_margin_dir):
     with pytest.raises(ValueError, match="Invalid keyword argument"):
-        lsdb.read_hats(small_sky_order1_dir, margins=small_sky_xmatch_margin_dir)
+        lsdb.hats_catalog(small_sky_order1_dir, margins=small_sky_xmatch_margin_dir)
 
 
 def test_pixels_in_map_equal_catalog_pixels(small_sky_order1_dir, small_sky_order1_hats_catalog):
-    catalog = lsdb.read_hats(small_sky_order1_dir)
+    catalog = lsdb.hats_catalog(small_sky_order1_dir)
     for healpix_pixel in small_sky_order1_hats_catalog.get_healpix_pixels():
         catalog.get_partition(healpix_pixel.order, healpix_pixel.pixel)
 
 
 def test_wrong_pixel_raises_value_error(small_sky_order1_dir):
-    catalog = lsdb.read_hats(small_sky_order1_dir)
+    catalog = lsdb.hats_catalog(small_sky_order1_dir)
     with pytest.raises(ValueError):
         catalog.get_partition(-1, -1)
 
 
 def test_parquet_data_in_partitions_match_files(small_sky_order1_dir, small_sky_order1_hats_catalog):
-    catalog = lsdb.read_hats(small_sky_order1_dir)
+    catalog = lsdb.hats_catalog(small_sky_order1_dir)
     for healpix_pixel in small_sky_order1_hats_catalog.get_healpix_pixels():
         hp_order = healpix_pixel.order
         hp_pixel = healpix_pixel.pixel
@@ -307,7 +307,7 @@ def test_parquet_data_in_partitions_match_files(small_sky_order1_dir, small_sky_
 
 
 def test_read_hats_specify_catalog_type(small_sky_catalog, small_sky_dir):
-    catalog = lsdb.read_hats(small_sky_dir)
+    catalog = lsdb.hats_catalog(small_sky_dir)
     assert isinstance(catalog, lsdb.Catalog)
     assert isinstance(catalog._ddf, nd.NestedFrame)
     pd.testing.assert_frame_equal(catalog.compute(), small_sky_catalog.compute())
@@ -320,7 +320,7 @@ def test_catalog_with_margin(
     small_sky_xmatch_dir, small_sky_xmatch_margin_dir, small_sky_xmatch_margin_catalog, helpers
 ):
     assert isinstance(small_sky_xmatch_margin_dir, Path)
-    catalog = lsdb.read_hats(small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_dir)
+    catalog = lsdb.hats_catalog(small_sky_xmatch_dir, margin_cache=small_sky_xmatch_margin_dir)
     assert isinstance(catalog, lsdb.Catalog)
     assert isinstance(catalog.margin, lsdb.MarginCatalog)
     assert isinstance(catalog._ddf, nd.NestedFrame)
@@ -335,14 +335,14 @@ def test_catalog_with_margin(
 
 
 def test_catalog_without_margin_is_none(small_sky_xmatch_dir):
-    catalog = lsdb.read_hats(small_sky_xmatch_dir)
+    catalog = lsdb.hats_catalog(small_sky_xmatch_dir)
     assert isinstance(catalog, lsdb.Catalog)
     assert catalog.margin is None
 
 
 def test_catalog_with_wrong_margin(small_sky_order1_dir, small_sky_order1_source_margin_dir):
     with pytest.raises(ValueError, match="must have the same schema"):
-        lsdb.read_hats(small_sky_order1_dir, margin_cache=small_sky_order1_source_margin_dir)
+        lsdb.hats_catalog(small_sky_order1_dir, margin_cache=small_sky_order1_source_margin_dir)
 
 
 def test_read_hats_subset_with_cone_search(small_sky_order1_dir, small_sky_order1_catalog):
@@ -350,7 +350,7 @@ def test_read_hats_subset_with_cone_search(small_sky_order1_dir, small_sky_order
     # Filtering using catalog's cone_search
     cone_search_catalog = small_sky_order1_catalog.cone_search(ra=0, dec=-80, radius_arcsec=20 * 3600)
     # Filtering when calling `read_hats`
-    cone_search_catalog_2 = lsdb.read_hats(small_sky_order1_dir, search_filter=cone_search)
+    cone_search_catalog_2 = lsdb.hats_catalog(small_sky_order1_dir, search_filter=cone_search)
     assert isinstance(cone_search_catalog_2, lsdb.Catalog)
     # The partitions of the catalogs are equivalent
     assert cone_search_catalog.get_healpix_pixels() == cone_search_catalog_2.get_healpix_pixels()
@@ -362,7 +362,7 @@ def test_read_hats_subset_with_box_search(small_sky_order1_dir, small_sky_order1
     # Filtering using catalog's box_search
     box_search_catalog = small_sky_order1_catalog.box_search(ra=(300, 320), dec=(-40, -10))
     # Filtering when calling `read_hats`
-    box_search_catalog_2 = lsdb.read_hats(small_sky_order1_dir, search_filter=box_search)
+    box_search_catalog_2 = lsdb.hats_catalog(small_sky_order1_dir, search_filter=box_search)
     assert isinstance(box_search_catalog_2, lsdb.Catalog)
     # The partitions of the catalogs are equivalent
     assert box_search_catalog.get_healpix_pixels() == box_search_catalog_2.get_healpix_pixels()
@@ -376,7 +376,7 @@ def test_read_hats_subset_with_polygon_search(small_sky_order1_dir, small_sky_or
     # Filtering using catalog's polygon_search
     polygon_search_catalog = small_sky_order1_catalog.polygon_search(vertices)
     # Filtering when calling `read_hats`
-    polygon_search_catalog_2 = lsdb.read_hats(small_sky_order1_dir, search_filter=polygon_search)
+    polygon_search_catalog_2 = lsdb.hats_catalog(small_sky_order1_dir, search_filter=polygon_search)
     assert isinstance(polygon_search_catalog_2, lsdb.Catalog)
     # The partitions of the catalogs are equivalent
     assert polygon_search_catalog.get_healpix_pixels() == polygon_search_catalog_2.get_healpix_pixels()
@@ -395,7 +395,7 @@ def test_read_hats_subset_with_index_search(
     )
     # Filtering when calling `read_hats`
     index_search = IndexSearch(values={"id": 700}, index_catalogs={"id": catalog_index})
-    index_search_catalog_2 = lsdb.read_hats(small_sky_order1_dir, search_filter=index_search)
+    index_search_catalog_2 = lsdb.hats_catalog(small_sky_order1_dir, search_filter=index_search)
     assert isinstance(index_search_catalog_2, lsdb.Catalog)
     # The partitions of the catalogs are equivalent
     assert index_search_catalog.get_healpix_pixels() == index_search_catalog_2.get_healpix_pixels()
@@ -406,7 +406,7 @@ def test_read_hats_subset_with_order_search(small_sky_source_catalog, small_sky_
     # Filtering using catalog's order_search
     order_search_catalog = small_sky_source_catalog.order_search(min_order=1, max_order=2)
     # Filtering when calling `read_hats`
-    order_search_catalog_2 = lsdb.read_hats(small_sky_source_dir, search_filter=order_search)
+    order_search_catalog_2 = lsdb.hats_catalog(small_sky_source_dir, search_filter=order_search)
     assert isinstance(order_search_catalog_2, lsdb.Catalog)
     # The partitions of the catalogs are equivalent
     assert order_search_catalog.get_healpix_pixels() == order_search_catalog_2.get_healpix_pixels()
@@ -416,7 +416,7 @@ def test_read_hats_subset_no_partitions(small_sky_order1_dir, small_sky_order1_i
     with pytest.raises(ValueError, match="no coverage"):
         catalog_index = hc.read_hats(small_sky_order1_id_index_dir)
         index_search = IndexSearch(values={"id": 900}, index_catalogs={"id": catalog_index})
-        lsdb.read_hats(small_sky_order1_dir, search_filter=index_search)
+        lsdb.hats_catalog(small_sky_order1_dir, search_filter=index_search)
 
 
 def test_read_hats_with_margin_subset(
@@ -426,7 +426,7 @@ def test_read_hats_with_margin_subset(
     # Filtering using catalog's cone_search
     cone_search_catalog = small_sky_order1_source_with_margin.cone_search(ra=315, dec=-66, radius_arcsec=20)
     # Filtering when calling `read_hats`
-    cone_search_catalog_2 = lsdb.read_hats(
+    cone_search_catalog_2 = lsdb.hats_catalog(
         small_sky_order1_source_dir,
         search_filter=cone_search,
         margin_cache=small_sky_order1_source_margin_dir,
@@ -443,7 +443,7 @@ def test_read_hats_margin_catalog_subset(
     small_sky_order1_source_margin_dir, small_sky_order1_source_margin_catalog, helpers
 ):
     search_filter = ConeSearch(ra=315, dec=-60, radius_arcsec=10)
-    margin = lsdb.read_hats(small_sky_order1_source_margin_dir, search_filter=search_filter)
+    margin = lsdb.hats_catalog(small_sky_order1_source_margin_dir, search_filter=search_filter)
 
     margin_info = margin.hc_structure.catalog_info
     small_sky_order1_source_margin_info = small_sky_order1_source_margin_catalog.hc_structure.catalog_info
@@ -465,11 +465,11 @@ def test_read_hats_margin_catalog_subset(
 def test_read_hats_margin_catalog_subset_is_empty(small_sky_order1_source_margin_dir):
     search_filter = ConeSearch(ra=100, dec=80, radius_arcsec=1)
     with pytest.raises(ValueError, match="no coverage"):
-        lsdb.read_hats(small_sky_order1_source_margin_dir, search_filter=search_filter)
+        lsdb.hats_catalog(small_sky_order1_source_margin_dir, search_filter=search_filter)
 
 
 def test_read_hats_map_catalog(test_data_dir):
-    margin_catalog = lsdb.read_hats(test_data_dir / "square_map")
+    margin_catalog = lsdb.hats_catalog(test_data_dir / "square_map")
     assert len(margin_catalog.get_healpix_pixels()) == 12
     assert len(margin_catalog._ddf_pixel_map) == 12
     assert len(margin_catalog.compute()) == 12
@@ -478,17 +478,17 @@ def test_read_hats_map_catalog(test_data_dir):
 
 def test_read_hats_schema_not_found(small_sky_no_metadata_dir):
     with pytest.raises(ValueError, match="catalog schema could not be loaded"):
-        lsdb.read_hats(small_sky_no_metadata_dir)
+        lsdb.hats_catalog(small_sky_no_metadata_dir)
 
 
 def test_all_columns_read_columns(small_sky_order1_dir, small_sky_order1_catalog):
-    cat = lsdb.read_hats(small_sky_order1_dir, columns=["ra", "dec"])
+    cat = lsdb.hats_catalog(small_sky_order1_dir, columns=["ra", "dec"])
     assert len(cat.columns) < len(cat.all_columns)
     assert np.all(cat.all_columns == small_sky_order1_catalog.columns)
 
 
 def test_original_schema_read_columns(small_sky_order1_dir, small_sky_order1_catalog):
-    cat = lsdb.read_hats(small_sky_order1_dir, columns=["ra", "dec"])
+    cat = lsdb.hats_catalog(small_sky_order1_dir, columns=["ra", "dec"])
     assert len(cat.original_schema) == len(small_sky_order1_catalog.hc_structure.schema)
     for field in cat.original_schema:
         assert field in small_sky_order1_catalog.hc_structure.schema
@@ -496,7 +496,7 @@ def test_original_schema_read_columns(small_sky_order1_dir, small_sky_order1_cat
 
 
 def test_read_nested_column_selection(small_sky_with_nested_sources_dir):
-    cat = lsdb.read_hats(
+    cat = lsdb.hats_catalog(
         small_sky_with_nested_sources_dir, columns=["ra", "dec", "sources.source_id", "sources.source_ra"]
     )
     assert np.all(cat.columns == ["ra", "dec", "sources"])
@@ -508,15 +508,15 @@ def test_read_nested_column_selection(small_sky_with_nested_sources_dir):
 
 def test_read_nested_column_selection_errors(small_sky_with_nested_sources_dir):
     with pytest.raises(ArrowInvalid):
-        lsdb.read_hats(
+        lsdb.hats_catalog(
             small_sky_with_nested_sources_dir, columns=["ra", "dec", "sources.source_id", "sources.wrong"]
         )
     with pytest.raises(ArrowInvalid):
-        lsdb.read_hats(
+        lsdb.hats_catalog(
             small_sky_with_nested_sources_dir,
             columns=["ra", "wrong", "sources.source_id", "sources.source_ra"],
         )
     with pytest.raises(ArrowInvalid):
-        lsdb.read_hats(
+        lsdb.hats_catalog(
             small_sky_with_nested_sources_dir, columns=["ra", "dec", "wrong.source_id", "sources.source_ra"]
         )


### PR DESCRIPTION
`lsdb.read_hats` remains a thin wrapper to `lsdb.hats_catalog`, with its own docstring indicating that it is one (rather than a direct alias).

This PR is in two commits, one which makes the small and simple rename, and the second, which renames all the `.read_hats` calls and references within the project.

Closes #464 .