### PR TITLE
Add more imports to top-level init.

### DIFF
--- a/src/lsdb/__init__.py
+++ b/src/lsdb/__init__.py
@@ -1,6 +1,9 @@
+from hats.pixel_math import HealpixPixel
+
 from ._version import __version__
 from .catalog import Catalog, MarginCatalog
 from .core.crossmatch.crossmatch import crossmatch
 from .core.search import BoxSearch, ConeSearch, PixelSearch, PolygonSearch
 from .loaders.dataframe.from_dataframe import from_dataframe
 from .loaders.hats.read_hats import open_catalog, read_hats
+from .nested.datasets import generate_catalog


### PR DESCRIPTION
In implementing the notebook for #733, I wanted to just do `import lsdb` and get all of the other things imported from that top-level namespace. Those are the most critical functions, after all!