### PR TITLE
Improve the row-filtering tutorial.

### DIFF
--- a/docs/tutorials/pre_executed/map_partitions.ipynb
+++ b/docs/tutorials/pre_executed/map_partitions.ipynb
@@ -1308,9 +1308,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Derek's Python 3.12",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "dtj1s-py3.12"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1322,7 +1322,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/row_filtering.ipynb
+++ b/docs/tutorials/row_filtering.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "## Introduction\n",
     "\n",
-    "When a catalog is opened, it is available for operations, but these operations are lazily loaded, and unrealized, until computation is called for explicitly (with `.compute()` or implicitly, with data preview functions."
+    "When a catalog is opened, it is available for operations.  However, its data is is lazily loaded, and operations on it are unrealized, until computation is called for explicitly (using the `.compute()` method) or implicitly, with data preview functions."
    ]
   },
   {
@@ -106,7 +106,7 @@
     "\n",
     "Computing an entire catalog requires loading all of its resulting data into memory, which is expensive and may lead to out-of-memory issues. \n",
     "\n",
-    "Often, our goal is to have a peek at a slice of data to make sure the workflow output is reasonable (e.g., to assess if some new created columns are present and their values have been properly processed). `head()` is a pandas-like method which allows us to preview part of the data for this purpose. It iterates over the existing catalog partitions, in sequence, and finds up to `n` number of rows from the first partition(s) which have are able to supply those rows. Related methods include `.tail()` and `.sample()`.\n",
+    "Often, our goal is to have a peek at a slice of data to make sure the workflow output is reasonable (e.g., to assess if some new created columns are present and their values have been properly processed). `head()` is a Pandas-like method which allows us to preview part of the data for this purpose. It iterates over the existing catalog partitions, in sequence, and finds up to `n` number of rows from the first partition(s) which have are able to supply those rows. Related methods include `.tail()` and `.sample()`.\n",
     "\n",
     "There is also `.random_sample()`, but that method fetches rows from many partitions (rather than from first qualified), and so it can be much more expensive, even while it may be more representative.\n",
     "\n",
@@ -136,7 +136,9 @@
     "\n",
     "The column names that are not valid Python variables names should be wrapped in backticks, and any variable values can be injected using f-strings. The use of '@' to reference variables is not supported.\n",
     "\n",
-    "More information about Pandas query strings is available [here](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.query.html)."
+    "More information about Pandas query strings is available [here](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.query.html).\n",
+    "\n",
+    "In the following query, we want to find objects in the catalog whose magnitude is brighter than 16:"
    ]
   },
   {
@@ -146,8 +148,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "low_mag = ztf_object.query(\"mean_mag_i < 16\")\n",
-    "low_mag"
+    "bright = ztf_object.query(\"mean_mag_i < 16\")\n",
+    "bright"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6bb84560-1449-43d1-8939-e974dbe12bb0",
+   "metadata": {},
+   "source": [
+    "We'll use `.head()` for a quick sanity check to be sure that no `mean_mag_i` is dimmer than 16. Since it's only a few rows, it's not a guarantee, but it does help us to be sure that we didn't make any obvious mistake with our query expression."
    ]
   },
   {
@@ -157,8 +167,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Sanity check to be sure that no `mean_mag_i` is 16 or greater\n",
-    "low_mag.head()"
+    "%%time\n",
+    "bright.head(10)"
    ]
   },
   {
@@ -166,7 +176,7 @@
    "id": "ec9d809d-31cc-46ff-b48f-795ba8831340",
    "metadata": {},
    "source": [
-    "You can use parentheses, logical operators, and more than one column in your expressions. Here, we alter the query to include not only those objects with a `mean_mag_i` of less than 16, but which have at least 15 observations in that band:"
+    "You can use parentheses, logical operators, and more than one column name in your expressions. Here, we alter the query to include not only those objects with a `mean_mag_i` that is brighter than 16, but which have at least 50 observations in that band. Note that this query takes longer than the original, mostly because it takes longer to find rows that satisfy this stricter query."
    ]
   },
   {
@@ -176,8 +186,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "low_mag_hi_obs = ztf_object.query(\"mean_mag_i < 16 and nobs_i > 100\")\n",
-    "low_mag_hi_obs.head()"
+    "%%time\n",
+    "bright_hi_obs = ztf_object.query(\"mean_mag_i < 16 and nobs_i > 50\")\n",
+    "bright_hi_obs.head(10)"
    ]
   },
   {
@@ -195,7 +206,9 @@
     "The below expression produces the same result as the earlier `.query()` example, and whether it is more tractable than `.query()` depends on your expression and what it includes. But there are a couple of fixes we need to make, things which `.query()` does for you.\n",
     "\n",
     "  * The use of `&` instead of `and` (also, `|` vs. `or`). The Python logicals don't work here.\n",
-    "  * Having to use `(` and `)` to ensure the proper precedence of the logical operators."
+    "  * Having to use `(` and `)` to ensure the intended precedence of the operators. (`&` and `|` are bitwise operators and, without parentheses, bind higher than the logical operators `and` and `or`.)\n",
+    "\n",
+    "Note that the time taken is basically identical to that of the `.query` method. There is no particular performance advantage to either approach, as the underlying computations are vectorized the same way."
    ]
   },
   {
@@ -205,8 +218,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "low_mag_ex = ztf_object[(ztf_object[\"mean_mag_i\"] < 16) & (ztf_object[\"nobs_i\"] > 15)]\n",
-    "low_mag_ex.head()"
+    "%%time\n",
+    "bright_ex = ztf_object[(ztf_object[\"mean_mag_i\"] < 16) & (ztf_object[\"nobs_i\"] > 50)]\n",
+    "bright_ex.head()"
    ]
   },
   {

--- a/docs/tutorials/row_filtering.ipynb
+++ b/docs/tutorials/row_filtering.ipynb
@@ -9,10 +9,17 @@
    "source": [
     "# Row Filtering\n",
     "\n",
+    "## Learning Objectives\n",
+    "\n",
     "In this tutorial, we will demonstrate how to:\n",
     "\n",
-    "- Set up a Dask client and load an object catalog \n",
-    "- Filter data by column values\n"
+    "- Set up a Dask client and open an object catalog\n",
+    "- Filter rows of data by expressions involving column values\n",
+    "- Do quick previews of catalog data and query results\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "When a catalog is opened, it is available for operations, but these operations are lazily loaded, and unrealized, until computation is called for explicitly (with `.compute()` or implicitly, with data preview functions."
    ]
   },
   {
@@ -33,9 +40,9 @@
     "tags": []
    },
    "source": [
-    "## 1. Load a catalog\n",
+    "## 1. Open a catalog\n",
     "\n",
-    "We create a basic dask client, and load an existing HATS catalog - the ZTF DR22 catalog."
+    "We create a basic dask client, and open an existing HATS catalog—the ZTF DR22 catalog."
    ]
   },
   {
@@ -60,6 +67,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "e016346d-bf3e-43eb-a988-ec975823b09f",
+   "metadata": {},
+   "source": [
+    "Create a basic Dask client, limiting the number of workers. This keeps subsequent operations from using more of our compute resources than we might intend, which is helpful in any case but especially when working on a shared resource."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "e16078b4-47b8-4939-83c4-1ad28bf1592e",
@@ -77,9 +92,35 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ztf_object_path = \"https://data.lsdb.io/hats/ztf_dr22/ztf_lc\"\n",
+    "ztf_object_path = \"https://data.lsdb.io/hats/ztf_dr14/ztf_object\"\n",
     "ztf_object = lsdb.open_catalog(ztf_object_path)\n",
     "ztf_object"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1594babc-7ce7-4b9c-ae63-424f3e863059",
+   "metadata": {},
+   "source": [
+    "### 1.1. Previewing part of the data\n",
+    "\n",
+    "Computing an entire catalog requires loading all of its resulting data into memory, which is expensive and may lead to out-of-memory issues. \n",
+    "\n",
+    "Often, our goal is to have a peek at a slice of data to make sure the workflow output is reasonable (e.g., to assess if some new created columns are present and their values have been properly processed). `head()` is a pandas-like method which allows us to preview part of the data for this purpose. It iterates over the existing catalog partitions, in sequence, and finds up to `n` number of rows from the first partition(s) which have are able to supply those rows. Related methods include `.tail()` and `.sample()`.\n",
+    "\n",
+    "There is also `.random_sample()`, but that method fetches rows from many partitions (rather than from first qualified), and so it can be much more expensive, even while it may be more representative.\n",
+    "\n",
+    "Notice that all these previewing methods implicitly call `compute()`, and will implicitly use the `Client` we created earlier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c337414d-9b79-4715-82d1-b10b26472668",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ztf_object.head()"
    ]
   },
   {
@@ -87,11 +128,11 @@
    "id": "9a573c7c",
    "metadata": {},
    "source": [
-    "## 2. Selecting data by column query\n",
+    "## 2. Selecting data rows by querying column values\n",
     "\n",
-    "We filter by column values via `query()`.\n",
+    "We can filter by column values via `query()`.\n",
     "\n",
-    "The expression inside () follows the same syntax accepted by Pandas `.query()`, which supports a subset of Python expressions for filtering DataFrames.\n",
+    "The expression in the string given to `.query()` follows the same syntax accepted by Pandas' `.query()`, which supports a subset of Python expressions for filtering DataFrames.\n",
     "\n",
     "The column names that are not valid Python variables names should be wrapped in backticks, and any variable values can be injected using f-strings. The use of '@' to reference variables is not supported.\n",
     "\n",
@@ -105,21 +146,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ztf_object.query(\"mean_mag_i < 16\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1594babc-7ce7-4b9c-ae63-424f3e863059",
-   "metadata": {},
-   "source": [
-    "## 3. Previewing part of the data\n",
-    "\n",
-    "Computing an entire catalog requires loading all of its resulting data into memory, which is expensive and may lead to out-of-memory issues. \n",
-    "\n",
-    "Often, our goal is to have a peek at a slice of data to make sure the workflow output is reasonable (e.g., to assess if some new created columns are present and their values have been properly processed). `head()` is a pandas-like method which allows us to preview part of the data for this purpose. It iterates over the existing catalog partitions, in sequence, and finds up to `n` number of rows.\n",
-    "\n",
-    "Notice that this method implicitly calls `compute()`."
+    "low_mag = ztf_object.query(\"mean_mag_i < 16\")\n",
+    "low_mag"
    ]
   },
   {
@@ -129,7 +157,34 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ztf_object.head()"
+    "# Sanity check to be sure that no `mean_mag_i` is 16 or greater\n",
+    "low_mag.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02ca6bb6-172e-4521-b012-fbec8e254b80",
+   "metadata": {},
+   "source": [
+    "## 4. Filtering using Python expressions\n",
+    "\n",
+    "In some cases it may be more readable to query using Python expressions, Pandas-style. In this form, the catalog is indexed using an expression, selecting the rows for which the expression is true. The form of this query is `filtered = collection[expr_with_collection]`, where `expr_with_collection` needs to evaluate to something which is:\n",
+    "\n",
+    "  * of the same size as `collection`; and\n",
+    "  * convertible to boolean\n",
+    "\n",
+    "The below expression produces the same result as the earlier `.query()` example, and whether it is more tractable than `.query()` depends on your expression and what it includes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c865a480-fefd-4c28-b2fc-d783a27bc62b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "low_mag_ex = ztf_object[ztf_object[\"mean_mag_i\"] < 16]\n",
+    "low_mag_ex.head()"
    ]
   },
   {
@@ -173,7 +228,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hats",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -187,7 +242,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/row_filtering.ipynb
+++ b/docs/tutorials/row_filtering.ipynb
@@ -163,6 +163,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ec9d809d-31cc-46ff-b48f-795ba8831340",
+   "metadata": {},
+   "source": [
+    "You can use parentheses, logical operators, and more than one column in your expressions. Here, we alter the query to include not only those objects with a `mean_mag_i` of less than 16, but which have at least 15 observations in that band:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e34db34a-79d0-446c-8702-b86d5c9452ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "low_mag_hi_obs = ztf_object.query(\"mean_mag_i < 16 and nobs_i > 100\")\n",
+    "low_mag_hi_obs.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "02ca6bb6-172e-4521-b012-fbec8e254b80",
    "metadata": {},
    "source": [
@@ -173,7 +192,10 @@
     "  * of the same size as `collection`; and\n",
     "  * convertible to boolean\n",
     "\n",
-    "The below expression produces the same result as the earlier `.query()` example, and whether it is more tractable than `.query()` depends on your expression and what it includes."
+    "The below expression produces the same result as the earlier `.query()` example, and whether it is more tractable than `.query()` depends on your expression and what it includes. But there are a couple of fixes we need to make, things which `.query()` does for you.\n",
+    "\n",
+    "  * The use of `&` instead of `and` (also, `|` vs. `or`). The Python logicals don't work here.\n",
+    "  * Having to use `(` and `)` to ensure the proper precedence of the logical operators."
    ]
   },
   {
@@ -183,7 +205,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "low_mag_ex = ztf_object[ztf_object[\"mean_mag_i\"] < 16]\n",
+    "low_mag_ex = ztf_object[(ztf_object[\"mean_mag_i\"] < 16) & (ztf_object[\"nobs_i\"] > 15)]\n",
     "low_mag_ex.head()"
    ]
   },


### PR DESCRIPTION
Follow current tutorial structure, show simple and slightly-less-simple queries, both with `.query` and with Python expressions.

Closes #672.