### PR TITLE
Join through association

### DIFF
--- a/src/lsdb/dask/join_catalog_data.py
+++ b/src/lsdb/dask/join_catalog_data.py
@@ -17,12 +17,14 @@ from lsdb.catalog.association_catalog import AssociationCatalog
 from lsdb.dask.merge_catalog_functions import (
     align_and_apply,
     align_catalogs,
+    align_catalogs_with_association,
     concat_partition_and_margin,
     construct_catalog_args,
     filter_by_spatial_index_to_pixel,
     generate_meta_df_for_joined_tables,
     generate_meta_df_for_nested_tables,
     get_healpix_pixels_from_alignment,
+    get_healpix_pixels_from_association,
 )
 from lsdb.types import DaskDFPixelMap
 
@@ -382,18 +384,15 @@ def join_catalog_data_through(
             RuntimeWarning,
         )
 
-    alignment = align_catalogs(left, right)
-    left_pixels, right_pixels = get_healpix_pixels_from_alignment(alignment)
-
-    alignment_association = align_catalogs(left, association)
-    _, pixels_association = get_healpix_pixels_from_alignment(alignment_association)
+    alignment = align_catalogs_with_association(left, association, right)
+    left_pixels, assoc_pixels, right_pixels = get_healpix_pixels_from_association(alignment)
 
     joined_partitions = align_and_apply(
         [
             (left, left_pixels),
             (right, right_pixels),
             (right.margin, right_pixels),
-            (association, pixels_association),
+            (association, assoc_pixels),
         ],
         perform_join_through,
         suffixes,

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -17,6 +17,7 @@ from hats.pixel_tree import PixelAlignment, PixelAlignmentType, align_trees
 from hats.pixel_tree.moc_utils import copy_moc
 from hats.pixel_tree.pixel_alignment import align_with_mocs
 
+import lsdb
 import lsdb.nested as nd
 from lsdb.dask.divisions import get_pixels_divisions
 from lsdb.types import DaskDFPixelMap
@@ -60,12 +61,14 @@ def remove_hips_columns(df: npd.NestedFrame | None):
     return df.drop(columns=hive_columns_in_df)
 
 
-def align_catalogs(left: Catalog, right: Catalog, add_right_margin: bool = True) -> PixelAlignment:
+def align_catalogs(
+    left: HealpixDataset, right: HealpixDataset, add_right_margin: bool = True
+) -> PixelAlignment:
     """Aligns two catalogs, also using the right catalog's margin if it exists
 
     Args:
-        left (lsdb.Catalog): The left catalog to align
-        right (lsdb.Catalog): The right catalog to align
+        left (HealpixDataset): The left catalog to align
+        right (HealpixDataset): The right catalog to align
         add_right_margin (bool): If True, when using MOCs to align catalogs, adds a border to the
             right catalog's moc to include the margin of the right catalog, if it exists. Defaults to True.
     Returns:
@@ -74,7 +77,7 @@ def align_catalogs(left: Catalog, right: Catalog, add_right_margin: bool = True)
 
     right_added_radius = None
 
-    if right.margin is not None:
+    if isinstance(right, lsdb.Catalog) and right.margin is not None:
         right_tree = align_trees(
             right.hc_structure.pixel_tree,
             right.margin.hc_structure.pixel_tree,

--- a/tests/lsdb/io/test_to_association.py
+++ b/tests/lsdb/io/test_to_association.py
@@ -53,7 +53,7 @@ def test_crossmatch_to_association(xmatch_result, association_kwargs, tmp_path):
 
 
 def test_join_through_crossmatch_association(
-    xmatch_result, association_kwargs, small_sky_catalog, small_sky_xmatch_catalog, tmp_path
+    xmatch_result, association_kwargs, small_sky_catalog, small_sky_xmatch_with_margin, tmp_path
 ):
     to_association(
         xmatch_result,
@@ -64,7 +64,7 @@ def test_join_through_crossmatch_association(
     )
     association_table = lsdb.read_hats(tmp_path)
     assert isinstance(association_table, AssociationCatalog)
-    xmatch_cat = small_sky_catalog.join(small_sky_xmatch_catalog, through=association_table)
+    xmatch_cat = small_sky_catalog.join(small_sky_xmatch_with_margin, through=association_table)
     assert association_table.get_healpix_pixels() == xmatch_cat.get_healpix_pixels()
     assert xmatch_cat.hc_structure.moc is not None
     xmatch_df = xmatch_cat.compute()


### PR DESCRIPTION
The association tables may need to be repartitioned such that its pixels are different from the inner alignment between the primary and the join catalogs. If that's the case we need to recompute the alignment for the join. 

This PR adds some logic to do that: `align_catalog_with_association` first aligns the primary catalog with the association catalog and then it aligns the result to the join catalog to obtain the pixels that need to be joined between the three. 

This is a step toward https://github.com/astronomy-commons/lsdb/issues/795. However, I am looking for feedback since this solution will introduce new `assoc_Norder` and `assoc_Npix` columns in the partition join info (apart from the already existing Norder, Npix and join_Norder, join_Npix).