### PR TITLE
Set default `margin_threshold` on crossmatch of dataframes

### DIFF
--- a/src/lsdb/core/crossmatch/crossmatch.py
+++ b/src/lsdb/core/crossmatch/crossmatch.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from lsdb.catalog import Catalog
 from lsdb.core.crossmatch.abstract_crossmatch_algorithm import AbstractCrossmatchAlgorithm
-from lsdb.core.crossmatch.crossmatch_algorithms import BuiltInCrossmatchAlgorithm
+from lsdb.core.crossmatch.crossmatch_algorithms import BuiltInCrossmatchAlgorithm, is_builtin_algorithm
 from lsdb.loaders.dataframe.from_dataframe import from_dataframe
 
 
@@ -103,6 +103,13 @@ def crossmatch(
     # Check for conflicting right margin arguments.
     if require_right_margin and right_args.get("margin_threshold") is None:
         raise ValueError("If require_right_margin is True, margin_threshold must not be None.")
+
+    # Check if the margin should be generated according to the
+    # maximum radius specified for the crossmatch.
+    if is_builtin_algorithm(algorithm) and "radius_arcsec" in kwargs:
+        radius_arcsec = kwargs.get("radius_arcsec")
+        if "margin_threshold" not in right_args:
+            right_args["margin_threshold"] = radius_arcsec
 
     # Update left_args and right_args with ra_column and dec_column if given.
     if ra_column:

--- a/src/lsdb/core/crossmatch/crossmatch_algorithms.py
+++ b/src/lsdb/core/crossmatch/crossmatch_algorithms.py
@@ -11,6 +11,11 @@ class BuiltInCrossmatchAlgorithm(str, Enum):
     BOUNDED_KD_TREE = "bounded_kd_tree"
 
 
+def is_builtin_algorithm(algorithm_type) -> bool:
+    """Check if a given algorithm is built-in."""
+    return algorithm_type in builtin_crossmatch_algorithms.values()
+
+
 builtin_crossmatch_algorithms = {
     BuiltInCrossmatchAlgorithm.KD_TREE: KdTreeCrossmatch,
     BuiltInCrossmatchAlgorithm.BOUNDED_KD_TREE: BoundedKdTreeCrossmatch,

--- a/tests/lsdb/core/test_crossmatch_method.py
+++ b/tests/lsdb/core/test_crossmatch_method.py
@@ -25,7 +25,6 @@ def test_dataframe_or_catalog_crossmatch(
 
     # Determine which args to pass
     left_args = {} if left == "catalog" else {"margin_threshold": 100}
-    right_args = {} if right == "catalog" else {"margin_threshold": 100}
 
     # Perform the crossmatch
     result = lsdb.crossmatch(
@@ -35,7 +34,7 @@ def test_dataframe_or_catalog_crossmatch(
         algorithm=algo,
         radius_arcsec=0.01 * 3600,
         left_args=left_args,
-        right_args=right_args,
+        right_args={},
     ).compute()
 
     # Assertions


### PR DESCRIPTION
When crossmatching two dataframes with the built-in algorithms, set the right catalog's `margin_threshold` to equal the radius set for the crossmatch. Closes #649. 