### PR TITLE
Address smoke test failure.

### DIFF
--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -138,7 +138,7 @@ class DataframeCatalogLoader:
             catalog_name: it is recommended to provide a new name for your catalog
             ra_column: column to find right ascension coordinate
             dec_column: column to find declination coordinate
-            catalog_type: type of table being created (e.g. OBJECT, MARGIN, INDEX)
+            catalog_type: type of table being created (e.g. OBJECT, SOURCE, MAP)
             **kwargs: Arguments to pass to the creation of the catalog info
 
         Returns:
@@ -147,6 +147,8 @@ class DataframeCatalogLoader:
         if kwargs is None:
             kwargs = {}
         kwargs = kwargs | _extra_property_dict(self.df_total_memory)
+        if catalog_type and catalog_type not in (CatalogType.OBJECT, CatalogType.SOURCE, CatalogType.MAP):
+            raise ValueError(f"Cannot create {catalog_type} type catalog via from_dataframe.")
         return TableProperties(
             catalog_name=catalog_name,
             ra_column=ra_column,

--- a/tests/lsdb/loaders/dataframe/test_from_dataframe.py
+++ b/tests/lsdb/loaders/dataframe/test_from_dataframe.py
@@ -65,13 +65,13 @@ def test_from_dataframe(small_sky_order1_df, small_sky_order1_catalog, helpers):
 
 def test_from_dataframe_catalog_of_invalid_type(small_sky_order1_df, small_sky_order1_catalog):
     """Tests that an exception is thrown if the catalog is not of type OBJECT or SOURCE"""
-    valid_catalog_types = [CatalogType.OBJECT, CatalogType.SOURCE]
+    valid_catalog_types = [CatalogType.OBJECT, CatalogType.SOURCE, CatalogType.MAP]
     for catalog_type in CatalogType.all_types():
         kwargs = get_catalog_kwargs(small_sky_order1_catalog, catalog_type=catalog_type)
         if catalog_type in valid_catalog_types:
             lsdb.from_dataframe(small_sky_order1_df, margin_threshold=None, **kwargs)
         else:
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match="Cannot create"):
                 lsdb.from_dataframe(small_sky_order1_df, margin_threshold=None, **kwargs)
         # Drop spatial_index that might have been created in place
         small_sky_order1_df.reset_index(drop=True, inplace=True)


### PR DESCRIPTION
Well this was a funky problem.

Prior to the hipscat->HATS renaming, we explicitly checked for two valid catalog types, OBJECT and SOURCE. During that transition, we started using `TableProperties`, instead of the `catalog_info.json`. Construction of the `TableProperties` checked that all of the type-specific kwargs were provided, and also that we **weren't** providing values for certain properties that were invalid for that catalog type (and to try to check for typos). The check inside `TableProperties` was what was preventing an ASSOCIATION (or MARGIN, or INDEX, or MAP) type from being created, as it was either missing required fields, or contained invalid fields.

PR https://github.com/astronomy-commons/hats/pull/511 removed that last bit of logic to allow any property keys (even ones that might not make sense for the type, or be a typo - this is intended so we can add new keys, or catalog providers can throw their own in there willy-nilly and we won't have errors). For MAP types, we passed the `TableProperties` check, and there was no longer a valid type check inside `from_dataframe`. 

This PR adds back a valid type check inside `from_dataframe`, allowing object, source, or map type catalogs. Margin catalogs can be created via the margin dataframe loader, and association tables are written out specially via `to_association`. No logic appears in LSDB for creating index tables.