### PR TITLE
include ra/dec columns in columns list

### DIFF
--- a/src/lsdb/loaders/hats/read_hats.py
+++ b/src/lsdb/loaders/hats/read_hats.py
@@ -92,7 +92,8 @@ def open_catalog(
         path (UPath | Path): The path that locates the root of the HATS collection or stand-alone catalog.
         search_filter (Type[AbstractSearch]): Default `None`. The filter method to be applied.
         columns (list[str] | str): Default `None`. The set of columns to filter the catalog on. If None,
-            the catalog's default columns will be loaded. To load all catalog columns, use `columns="all"`.
+            the catalog's default columns will be loaded. To load all catalog columns, use `columns="all"`. 
+            RA and dec columns will be added if they are not present in specified or default columns.
         margin_cache (path-like): Default `None`. The margin for the main catalog, provided as a path.
         dtype_backend (str): Backend data type to apply to the catalog.
             Defaults to "pyarrow". If None, no type conversion is performed.
@@ -166,6 +167,14 @@ def _load_catalog(
         columns = None
     elif pd.api.types.is_list_like(columns):
         columns = list(columns)  # type: ignore[arg-type]
+    
+    ra_col = hc_catalog.catalog_info.ra_column
+    dec_col = hc_catalog.catalog_info.dec_column
+    if columns is not None:
+        if ra_col not in columns:
+            columns.append(ra_col)
+        if dec_col not in columns:
+            columns.append(dec_col)
 
     # Creates a config object to store loading parameters from all keyword arguments.
     config = HatsLoadingConfig(

--- a/tests/lsdb/loaders/hats/test_read_hats.py
+++ b/tests/lsdb/loaders/hats/test_read_hats.py
@@ -16,6 +16,9 @@ import lsdb
 import lsdb.nested as nd
 from lsdb.core.search import BoxSearch, ConeSearch, IndexSearch, OrderSearch, PolygonSearch
 
+def test_no_ra_dec(small_sky_order1_collection_dir):
+    catalog = lsdb.open_catalog(small_sky_order1_collection_dir, columns = "all")
+    assert "ra" in catalog.columns and "dec" in catalog.columns
 
 def test_read_hats(small_sky_order1_dir, small_sky_order1_hats_catalog, helpers):
     catalog = lsdb.open_catalog(small_sky_order1_dir)
@@ -524,3 +527,4 @@ def test_read_nested_column_selection_errors(small_sky_with_nested_sources_dir):
         lsdb.open_catalog(
             small_sky_with_nested_sources_dir, columns=["ra", "dec", "wrong.source_id", "sources.source_ra"]
         )
+        


### PR DESCRIPTION
Includes ra/dec column when loading a catalog if these are not present in specified columns or default_columns.

Closes #556 