### PR TITLE
Update hats-builder property

### DIFF
--- a/src/lsdb/io/to_hats.py
+++ b/src/lsdb/io/to_hats.py
@@ -14,6 +14,8 @@ from hats.pixel_math import HealpixPixel, spatial_index_to_healpix
 from hats.pixel_math.sparse_histogram import HistogramAggregator, SparseHistogram
 from upath import UPath
 
+import lsdb
+
 if TYPE_CHECKING:
     from lsdb.catalog.dataset.healpix_dataset import HealpixDataset
 
@@ -130,6 +132,7 @@ def to_hats(
         total_rows=int(np.sum(counts)),
         default_columns=default_columns,
         hats_max_rows=hats_max_rows,
+        hats_builder=get_hats_builder_property(),
     )
     new_hc_structure.catalog_info.to_properties_file(base_catalog_path)
     # Save the point distribution map
@@ -210,3 +213,8 @@ def create_modified_catalog_structure(
     new_hc_structure.catalog_info = new_hc_structure.catalog_info.copy_and_update(**kwargs)
     new_hc_structure.catalog_info.catalog_name = catalog_name
     return new_hc_structure
+
+
+def get_hats_builder_property() -> str:
+    """Generate the hats-builder property with the current versions of LSDB and HATS"""
+    return f"lsdb v{lsdb.__version__}, hats v{hc.__version__}"

--- a/src/lsdb/loaders/dataframe/from_dataframe_utils.py
+++ b/src/lsdb/loaders/dataframe/from_dataframe_utils.py
@@ -7,9 +7,9 @@ from dask import delayed
 from hats.pixel_math import HealpixPixel
 from hats.pixel_math.spatial_index import SPATIAL_INDEX_COLUMN
 
-import lsdb
 import lsdb.nested as nd
 from lsdb.dask.divisions import get_pixels_divisions
+from lsdb.io.to_hats import get_hats_builder_property
 
 
 def _generate_dask_dataframe(
@@ -69,14 +69,12 @@ def _format_margin_partition_dataframe(dataframe: npd.NestedFrame) -> npd.Nested
 def _extra_property_dict(est_size_bytes: int):
     """Create a dictionary of additional fields to store in the properties file."""
     properties = {}
-    properties["hats_builder"] = f"lsdb v{lsdb.__version__}"
-
+    properties["hats_builder"] = get_hats_builder_property()
     now = datetime.now(tz=timezone.utc)
     properties["hats_creation_date"] = now.strftime("%Y-%m-%dT%H:%M%Z")
     properties["hats_estsize"] = f"{int(est_size_bytes / 1024)}"
     properties["hats_release_date"] = "2024-09-18"
     properties["hats_version"] = "v0.1"
-
     return properties
 
 

--- a/tests/lsdb/catalog/test_margin_catalog.py
+++ b/tests/lsdb/catalog/test_margin_catalog.py
@@ -51,7 +51,11 @@ def test_save_margin_catalog(small_sky_xmatch_margin_catalog, tmp_path):
     original_info = small_sky_xmatch_margin_catalog.hc_structure.catalog_info
     partition_sizes = small_sky_xmatch_margin_catalog._ddf.map_partitions(len).compute()
     assert max(partition_sizes) == 10
-    assert expected_catalog.hc_structure.catalog_info == original_info.copy_and_update(hats_max_rows="10")
+    assert expected_catalog.hc_structure.catalog_info == original_info.copy_and_update(
+        hats_max_rows="10",
+        # Also check that the builder was properly set
+        hats_builder=f"lsdb v{lsdb.__version__}, hats v{hc.__version__}",
+    )
 
     # Sneak in test on data thumbnails: only main catalogs have them
     data_thumbnail_pointer = get_data_thumbnail_pointer(base_catalog_path)

--- a/tests/lsdb/io/test_to_hats.py
+++ b/tests/lsdb/io/test_to_hats.py
@@ -29,7 +29,11 @@ def test_save_catalog(small_sky_catalog, tmp_path):
     original_info = small_sky_catalog.hc_structure.catalog_info
     partition_sizes = small_sky_catalog._ddf.map_partitions(len).compute()
     assert max(partition_sizes) == 131
-    assert expected_catalog.hc_structure.catalog_info == original_info.copy_and_update(hats_max_rows="131")
+    assert expected_catalog.hc_structure.catalog_info == original_info.copy_and_update(
+        hats_max_rows="131",
+        # Also check that the builder was properly set
+        hats_builder=f"lsdb v{lsdb.__version__}, hats v{hc.__version__}",
+    )
 
     # The catalog has 1 partition, therefore the thumbnail has 1 row
     data_thumbnail_pointer = get_data_thumbnail_pointer(base_catalog_path)

--- a/tests/lsdb/loaders/dataframe/test_from_dataframe.py
+++ b/tests/lsdb/loaders/dataframe/test_from_dataframe.py
@@ -46,6 +46,10 @@ def test_from_dataframe(small_sky_order1_df, small_sky_order1_catalog, helpers):
         catalog.hc_structure.catalog_info.explicit_dict()
         == small_sky_order1_catalog.hc_structure.catalog_info.explicit_dict()
     )
+    # The hats builder property is set correctly
+    assert (
+        catalog.hc_structure.catalog_info.hats_builder == f"lsdb v{lsdb.__version__}, hats v{hc.__version__}"
+    )
     # The pixel threshold was specified properly
     assert catalog.hc_structure.catalog_info.hats_max_rows == 50
     # Index is set to spatial index
@@ -59,7 +63,6 @@ def test_from_dataframe(small_sky_order1_df, small_sky_order1_catalog, helpers):
     helpers.assert_divisions_are_correct(catalog)
     # The arrow schema was automatically inferred
     helpers.assert_schema_correct(catalog)
-
     assert isinstance(catalog.compute(), npd.NestedFrame)
 
 


### PR DESCRIPTION
Update the `hats_builder` property when:

- Loading catalogs with `from_dataframe`
- Saving catalogs to disk

Closes #774.