### PR TITLE
Allow any column in include_columns

### DIFF
--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -212,8 +212,6 @@ class HealpixDataset(Dataset):
         include_pixels: list[HealpixPixel] | None = None,
     ) -> list[HealpixPixel]:
         """Read footer statistics in parquet metadata, and report on global min/max values."""
-        self._check_unloaded_columns(exclude_columns)
-        self._check_unloaded_columns(include_columns)
         if use_default_columns and include_columns is None:
             include_columns = self.hc_structure.catalog_info.default_columns
 
@@ -235,8 +233,6 @@ class HealpixDataset(Dataset):
         include_pixels: list[HealpixPixel] | None = None,
     ) -> list[HealpixPixel]:
         """Read footer statistics in parquet metadata, and report on global min/max values."""
-        self._check_unloaded_columns(exclude_columns)
-        self._check_unloaded_columns(include_columns)
         if use_default_columns and include_columns is None:
             include_columns = self.hc_structure.catalog_info.default_columns
 


### PR DESCRIPTION
I would like to find the statistics of a single column, regardless of the loaded default columns. Since this method will only look at the `_metadata` file and no other data partitions, the set of initially-requested columns is irrelevant.