### PR TITLE
Mention available columns

### DIFF
--- a/src/lsdb/catalog/dataset/dataset.py
+++ b/src/lsdb/catalog/dataset/dataset.py
@@ -37,7 +37,7 @@ class Dataset:
         return (
             f"<div><strong>lsdb Catalog {self.name}:</strong></div>"
             f"{data}"
-            f"<div>{loaded_cols} out of {available_cols} columns in the catalog have been loaded "
+            f"<div>{loaded_cols} out of {available_cols} available columns in the catalog have been loaded "
             f"<strong>lazily</strong>, meaning no data has been read, only the catalog schema</div>"
         )
 

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -44,7 +44,7 @@ def test_catalog_html_repr(small_sky_order1_catalog):
     assert small_sky_order1_catalog.name in full_html
     assert str(small_sky_order1_catalog.get_ordered_healpix_pixels()[0]) in full_html
     assert str(small_sky_order1_catalog.get_ordered_healpix_pixels()[-1]) in full_html
-    assert "columns in the catalog have been loaded <strong>lazily</strong>" in full_html
+    assert "available columns in the catalog have been loaded <strong>lazily</strong>" in full_html
 
 
 def test_catalog_compute_equals_ddf_compute(small_sky_order1_catalog):


### PR DESCRIPTION
Change the representation of a dataset to say:

"X out of Y available columns in the catalog have been loaded"

rather than simply

"X out of Y columns in the catalog have been loaded"

The latter utterance implies to some users that those columns are known but never were imported.