### PR TITLE
Remove mention of tract, patch for now

### DIFF
--- a/docs/tutorials/region_selection.ipynb
+++ b/docs/tutorials/region_selection.ipynb
@@ -15,9 +15,7 @@
     "- Select data from regions in the sky\n",
     "    - cone\n",
     "    - radec box\n",
-    "    - polygon\n",
-    "\n",
-    "To search by LSST tract and/or patch, use the [lsdb-rubin](https://github.com/astronomy-commons/lsdb-rubin) package."
+    "    - polygon"
    ]
   },
   {


### PR DESCRIPTION
Remove mention of tract, patch selection for now, while we are not fully ready with lsst.rubin package. I expect that we will be ready quite soon when we will integrate the documentation fully. 