### PR TITLE
Rename `read_hats` in documentation

### DIFF
--- a/docs/_static/lazy_diagram.svg
+++ b/docs/_static/lazy_diagram.svg
@@ -24,19 +24,19 @@
 <polygon fill="none" stroke="black" points="45,-8 45,-84.5 275,-84.5 275,-8 45,-8"/>
 <text text-anchor="middle" x="160" y="-67.2" font-family="Times,serif" font-size="14.00">Read data / Do compute</text>
 </g>
-<!-- read_hats -->
+<!-- open_catalog -->
 <g id="node1" class="node">
-<title>read_hats</title>
-<text text-anchor="middle" x="160" y="-197.95" font-family="Courier,monospace" font-size="14.00">read_hats, from_dataframe, ...</text>
+<title>open_catalog</title>
+<text text-anchor="middle" x="160" y="-197.95" font-family="Courier,monospace" font-size="14.00">open_catalog, from_dataframe, ...</text>
 </g>
 <!-- crossmatch -->
 <g id="node2" class="node">
 <title>crossmatch</title>
 <text text-anchor="middle" x="160" y="-113.45" font-family="Courier,monospace" font-size="14.00">crossmatch, cone_search, ...</text>
 </g>
-<!-- read_hats&#45;&gt;crossmatch -->
+<!-- open_catalog&#45;&gt;crossmatch -->
 <g id="edge1" class="edge">
-<title>read_hats&#45;&gt;crossmatch</title>
+<title>open_catalog&#45;&gt;crossmatch</title>
 <path fill="none" stroke="black" d="M160,-177C160,-175 160,-173 160,-171"/>
 <polygon fill="black" stroke="black" points="163.5,-180.51 160,-170.51 156.5,-180.51 163.5,-180.51"/>
 </g>

--- a/docs/tutorials/catalog_object.ipynb
+++ b/docs/tutorials/catalog_object.ipynb
@@ -146,7 +146,7 @@
     "\n",
     "- **Load catalogs with their respective margin caches**, when available. These margins are necessary to obtain accurate results in several operations such as joining and crossmatching. If you're working with catalogs from [data.lsdb.io](https://data.lsdb.io), the margin cache will be included in the `open_catalog()` call for you to copy if it is available. For more information about margins please visit our [Margins](margins.ipynb) topic notebook.\n",
     "\n",
-    "Let's define the set of columns we need and add the margin catalog's path to our `read_hats` call."
+    "Let's define the set of columns we need and add the margin catalog's path to our `open_catalog` call."
    ]
   },
   {

--- a/docs/tutorials/pre_executed/ztf-alerts-sne.ipynb
+++ b/docs/tutorials/pre_executed/ztf-alerts-sne.ipynb
@@ -74,7 +74,7 @@
     "import matplotlib.pyplot as plt  # Plotting\n",
     "import numpy as np  # Array operations\n",
     "from dask.distributed import Client  # Create multi-processing cluster and connect to it\n",
-    "from lsdb import read_hats  # LSDB entry-point, load HATS catalog\n",
+    "from lsdb import open_catalog  # LSDB entry-point, load HATS catalog\n",
     "from matplotlib.ticker import MaxNLocator  # Fix ticks on plots"
    ]
   },
@@ -748,7 +748,7 @@
     "ZTF_ALERTS = \"https://data.lsdb.io/hats/alerce/\"\n",
     "\n",
     "# Load catalog with nested lists\n",
-    "raw_catalog = read_hats(\n",
+    "raw_catalog = open_catalog(\n",
     "    ZTF_ALERTS,\n",
     ")\n",
     "display(raw_catalog)\n",

--- a/docs/tutorials/pre_executed/zubercal-ps1-snad.ipynb
+++ b/docs/tutorials/pre_executed/zubercal-ps1-snad.ipynb
@@ -61,7 +61,7 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
-    "from lsdb import read_hats, from_dataframe\n",
+    "from lsdb import open_catalog, from_dataframe\n",
     "from upath import UPath"
    ]
   },
@@ -483,7 +483,7 @@
    "source": [
     "### 2.3. Load PS1 catalog structure and metadata\n",
     "\n",
-    "`lsdb.read_hats` doesn't load the data immediately, it just reads the metadata and structure of the catalog.\n",
+    "`lsdb.open_catalog` doesn't load the data immediately, it just reads the metadata and structure of the catalog.\n",
     "Here we use it to load PS1 DR2 object and detection catalogs, selecting only a few columns to speed up the pipeline."
    ]
   },
@@ -709,7 +709,7 @@
    ],
    "source": [
     "# Load PS1 catalogs metadata\n",
-    "ps1_object = read_hats(\n",
+    "ps1_object = open_catalog(\n",
     "    PS1_OBJECT,\n",
     "    columns=[\n",
     "        \"objID\",  # PS1 ID\n",
@@ -720,7 +720,7 @@
     ")\n",
     "display(ps1_object)\n",
     "\n",
-    "ps1_detection = read_hats(\n",
+    "ps1_detection = open_catalog(\n",
     "    PS1_DETECTION,\n",
     "    columns=[\n",
     "        \"objID\",  # PS1 object ID\n",
@@ -860,7 +860,7 @@
    ],
    "source": [
     "# Load Zubercal metadata\n",
-    "zubercal = read_hats(\n",
+    "zubercal = open_catalog(\n",
     "    ZUBERCAL_PATH,\n",
     "    columns=[\n",
     "        \"objectid\",  # matches to PS1 objID\n",


### PR DESCRIPTION
Rename missing `read_hats` calls in the documentation pages and tutorials. Closes #854.