### PR TITLE
Find ra/dec columns in `from_dataframe`

### DIFF
--- a/src/lsdb/core/crossmatch/crossmatch.py
+++ b/src/lsdb/core/crossmatch/crossmatch.py
@@ -18,29 +18,6 @@ def _validate_and_convert_to_catalog(
     if not isinstance(data, (pd.DataFrame, npd.NestedFrame)):
         raise TypeError(f"Argument must be a DataFrame, NestedFrame, or Catalog, not {type(data)}.")
 
-    # Check for "ra" and "dec" columns. If they do not exist, try "RA" and "DEC" before raising an error.
-    if "ra_column" not in data_args:
-        if "ra" in data.columns:
-            data_args["ra_column"] = "ra"
-        elif "RA" in data.columns:
-            data_args["ra_column"] = "RA"
-        elif "Ra" in data.columns:
-            data_args["ra_column"] = "Ra"
-        else:
-            raise ValueError("No 'ra', 'Ra', or 'RA' column found in DataFrame; specify 'ra_column' param.")
-
-    if "dec_column" not in data_args:
-        if "dec" in data.columns:
-            data_args["dec_column"] = "dec"
-        elif "DEC" in data.columns:
-            data_args["dec_column"] = "DEC"
-        elif "Dec" in data.columns:
-            data_args["dec_column"] = "Dec"
-        else:
-            raise ValueError(
-                "No 'dec', 'Dec', or 'DEC' column found in DataFrame; specify 'dec_column' param."
-            )
-
     # Pick catalog name: either use the user-specified suffixes, or default to "left" or "right".
     if "catalog_name" not in data_args:
         data_args["catalog_name"] = suffix if suffix else default_suffix

--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import re
 import warnings
 
 import astropy.units as u
@@ -40,8 +41,8 @@ class DataframeCatalogLoader:
         self,
         dataframe: pd.DataFrame,
         *,
-        ra_column: str = "ra",
-        dec_column: str = "dec",
+        ra_column: str | None = None,
+        dec_column: str | None = None,
         lowest_order: int = 0,
         highest_order: int = 7,
         drop_empty_siblings: bool = False,
@@ -57,8 +58,10 @@ class DataframeCatalogLoader:
 
         Args:
             dataframe (pd.Dataframe): Catalog Pandas Dataframe.
-            ra_column (str): The name of the right ascension column. Defaults to ra.
-            dec_column (str): The name of the declination column. Defaults to dec.
+            ra_column (str): The name of the right ascension column. By default,
+                case-insensitive versions of 'ra' are detected.
+            dec_column (str): The name of the declination column. By default,
+                case-insensitive versions of 'dec' are detected.
             lowest_order (int): The lowest partition order. Defaults to 3.
             highest_order (int): The highest partition order. Defaults to 7.
             drop_empty_siblings (bool): When determining final partitionining,
@@ -80,6 +83,12 @@ class DataframeCatalogLoader:
         self.highest_order = highest_order
         self.drop_empty_siblings = drop_empty_siblings
         self.threshold = self._calculate_threshold(partition_size, threshold)
+
+        if ra_column is None:
+            ra_column = self._find_column("ra")
+        if dec_column is None:
+            dec_column = self._find_column("dec")
+
         self.catalog_info = self._create_catalog_info(
             ra_column=ra_column,
             dec_column=dec_column,
@@ -91,6 +100,28 @@ class DataframeCatalogLoader:
         self.moc_max_order = moc_max_order
         self.use_pyarrow_types = use_pyarrow_types
         self.schema = schema
+
+    def _find_column(self, search_term: str) -> str:
+        """Finds the column in the data frame matching the search term.
+
+        The search is case-insensitive and unambiguous. An error is raised
+        if there are zero or multiple matches.
+
+        Args:
+            search_term (str): The column name to search for.
+
+        Returns:
+            The column name.
+        """
+        matches = [
+            c for c in self.dataframe.columns if re.fullmatch(re.escape(search_term), c, re.IGNORECASE)
+        ]
+        n_matches = len(matches)
+        if n_matches == 0:
+            raise ValueError(f"No column found for {search_term}")
+        if n_matches > 1:
+            raise ValueError(f"Found {n_matches} possible columns for {search_term}")
+        return matches[0]
 
     def _calculate_threshold(self, partition_size: int | None = None, threshold: int | None = None) -> int:
         """Calculates the number of pixels per HEALPix pixel (threshold) for the

--- a/src/lsdb/loaders/dataframe/from_dataframe.py
+++ b/src/lsdb/loaders/dataframe/from_dataframe.py
@@ -12,8 +12,8 @@ from lsdb.loaders.dataframe.margin_catalog_generator import MarginCatalogGenerat
 def from_dataframe(
     dataframe: pd.DataFrame,
     *,
-    ra_column: str = "ra",
-    dec_column: str = "dec",
+    ra_column: str | None = None,
+    dec_column: str | None = None,
     lowest_order: int = 0,
     highest_order: int = 7,
     drop_empty_siblings: bool = True,
@@ -35,8 +35,10 @@ def from_dataframe(
 
     Args:
         dataframe (pd.Dataframe): The catalog Pandas Dataframe.
-        ra_column (str): The name of the right ascension column. Defaults to ra.
-        dec_column (str): The name of the declination column. Defaults to dec.
+        ra_column (str): The name of the right ascension column. By default,
+            case-insensitive versions of 'ra' are detected.
+        dec_column (str): The name of the declination column. By default,
+            case-insensitive versions of 'dec' are detected.
         lowest_order (int): The lowest partition order. Defaults to 0.
         highest_order (int): The highest partition order. Defaults to 7.
         drop_empty_siblings (bool): When determining final partitionining,

--- a/tests/lsdb/core/test_crossmatch_method.py
+++ b/tests/lsdb/core/test_crossmatch_method.py
@@ -121,13 +121,13 @@ def test_ra_dec_columns_crossmatch(algo, small_sky_catalog, small_sky_xmatch_cat
     right_dataframe_abnormal_dec_col = right_dataframe.rename(columns={"dec": "abnormal_dec_col_name"})
 
     # Crossmatch method attempts to use default column names and fails
-    with pytest.raises(ValueError, match="No 'ra', 'Ra', or 'RA' column found"):
+    with pytest.raises(ValueError, match="No column found for ra"):
         lsdb.crossmatch(
             left_dataframe,
             right_dataframe_abnormal_ra_col,
             algorithm=algo,
         )
-    with pytest.raises(ValueError, match="No 'dec', 'Dec', or 'DEC' column found"):
+    with pytest.raises(ValueError, match="No column found for dec"):
         lsdb.crossmatch(
             left_dataframe,
             right_dataframe_abnormal_dec_col,


### PR DESCRIPTION
Find case-insensitive ra/dec columns in `from_dataframe` if they were not specified by the user. Closes #889.