### PR TITLE
Change is_builtin_algorithm to accept enum variants

### DIFF
--- a/src/lsdb/core/crossmatch/crossmatch_algorithms.py
+++ b/src/lsdb/core/crossmatch/crossmatch_algorithms.py
@@ -11,12 +11,15 @@ class BuiltInCrossmatchAlgorithm(str, Enum):
     BOUNDED_KD_TREE = "bounded_kd_tree"
 
 
-def is_builtin_algorithm(algorithm_type) -> bool:
-    """Check if a given algorithm is built-in."""
-    return algorithm_type in builtin_crossmatch_algorithms.values()
-
-
 builtin_crossmatch_algorithms = {
     BuiltInCrossmatchAlgorithm.KD_TREE: KdTreeCrossmatch,
     BuiltInCrossmatchAlgorithm.BOUNDED_KD_TREE: BoundedKdTreeCrossmatch,
 }
+
+
+def is_builtin_algorithm(algorithm_type) -> bool:
+    """Check if a given algorithm is built-in."""
+    return (
+        algorithm_type in builtin_crossmatch_algorithms
+        or algorithm_type in builtin_crossmatch_algorithms.values()
+    )

--- a/tests/lsdb/core/test_crossmatch_function.py
+++ b/tests/lsdb/core/test_crossmatch_function.py
@@ -3,10 +3,11 @@ import numpy as np
 import pytest
 
 import lsdb
+from lsdb.core.crossmatch.crossmatch_algorithms import BuiltInCrossmatchAlgorithm
 from lsdb.core.crossmatch.kdtree_match import KdTreeCrossmatch
 
 
-@pytest.mark.parametrize("algo", [KdTreeCrossmatch])
+@pytest.mark.parametrize("algo", [KdTreeCrossmatch, BuiltInCrossmatchAlgorithm.KD_TREE])
 @pytest.mark.parametrize(
     "left, right",
     [


### PR DESCRIPTION
It should fix problems with `crossmatch(radius_arcsec=larger_than_five)`