### PR TITLE
Make upath dependency very explicit.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "nested-pandas>=0.4.3,<0.5.0",
     "pyarrow>=14.0.1",
     "scipy>=1.7.2", # kdtree
+    "universal-pathlib>=0.2.2",
 ]
 
 [project.urls]


### PR DESCRIPTION
This adds explicit dependency on the upath package, which 
a) is used by this package (not just a transitive dependency)
b) adds a minimum supported version