### PR TITLE
Change `read_pixels` to avoid passing `HATS Catalog` object to dask graph

### DIFF
--- a/src/lsdb/loaders/hats/read_hats.py
+++ b/src/lsdb/loaders/hats/read_hats.py
@@ -396,8 +396,8 @@ def _load_dask_df_and_map(catalog: HCHealpixDataset, config) -> tuple[nd.NestedF
 def read_pixel(
     pixel: HealpixPixel,
     catalog_base_dir: str | Path | UPath,
+    npix_suffix: str,
     *,
-    npix_suffix: str | None = None,
     query_url_params: dict | None = None,
     columns=None,
     schema=None,

--- a/src/lsdb/loaders/hats/read_hats.py
+++ b/src/lsdb/loaders/hats/read_hats.py
@@ -11,7 +11,6 @@ from hats.catalog import CatalogType
 from hats.catalog.catalog_collection import CatalogCollection
 from hats.catalog.healpix_dataset.healpix_dataset import HealpixDataset as HCHealpixDataset
 from hats.io.file_io import file_io, get_upath
-from hats.pixel_math import HealpixPixel
 from hats.pixel_math.healpix_pixel_function import get_pixel_argsort
 from hats.pixel_math.spatial_index import SPATIAL_INDEX_COLUMN
 from nested_pandas.nestedframe.io import from_pyarrow


### PR DESCRIPTION
In working with the Zubercal dataset, users were running into issues with a memory leak during the `read_pixel` dask task. This led to workflows failing due to running out of memory. This change updates the `read_hats` behavior to avoid passing the `hats` `Catalog` object to the dask task graph, which seems to solve the memory leak problem.

My best guess is that the MOC object that is part of the hats Catalog could be causing this, since we've ran into issues with how they are cloud pickled before and how the Rust interaction works in dask distributed, but further investigation is necessary to confirm this.