### PR TITLE
Regression in windows pyarrow for chunked array

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "deprecated",
     "hats>=0.6.4",
     "nested-pandas>=0.4.7,<0.5.0",
-    "pyarrow>=14.0.1",
+    "pyarrow>=14.0.1,<21.0.0",
     "scipy>=1.7.2", # kdtree
     "universal-pathlib>=0.2.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
     "deprecated",
     "hats>=0.6.4",
     "nested-pandas>=0.4.7,<0.5.0",
-    "pyarrow>=14.0.1,<21.0.0",
+    "pyarrow>=14.0.1,<21.0.0; platform_system == 'Windows'",
+    "pyarrow>=14.0.1; platform_system != 'Windows'",
     "scipy>=1.7.2", # kdtree
     "universal-pathlib>=0.2.2",
 ]


### PR DESCRIPTION
The length of the array is 103, while the length of the index is 101. This is some kind of subtle regression in pyarrow v21.0.0 that I haven't been able to pinpoint exactly.

Closes #974 