### PR TITLE
Don't really plot images in unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ target-version = ["py38"]
 [tool.isort]
 profile = "black"
 line_length = 110
+skip_glob = ["benchmarks/env/*"]
 
 [tool.coverage.run]
 omit=["src/lsdb/_version.py"]

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -5,6 +5,7 @@ import astropy.units as u
 import dask.dataframe as dd
 import hats as hc
 import hats.pixel_math.healpix_shim as hp
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import nested_pandas as npd
 import numpy as np
@@ -22,6 +23,8 @@ import lsdb
 import lsdb.nested as nd
 from lsdb import Catalog, MarginCatalog
 from lsdb.core.search.moc_search import MOCSearch
+
+mpl.use("Agg")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Noticing issues in another PR I'm working on with intermittent failures of the windows workflow with errors like:

```
FAILED tests/lsdb/catalog/test_catalog.py::test_plot_points_wcs - _tkinter.TclError: Can't find a usable init.tcl in the following directories: 
    {C:\hostedtoolcache\windows\Python\3.10.11\x64\tcl\tcl8.6}

C:/hostedtoolcache/windows/Python/3.10.11/x64/tcl/tcl8.6/init.tcl: couldn't read file "C:/hostedtoolcache/windows/Python/3.10.11/x64/tcl/tcl8.6/init.tcl": No error
couldn't read file "C:/hostedtoolcache/windows/Python/3.10.11/x64/tcl/tcl8.6/init.tcl": No error
    while executing
"source C:/hostedtoolcache/windows/Python/3.10.11/x64/tcl/tcl8.6/init.tcl"
    ("uplevel" body line 1)
    invoked from within
"uplevel #0 [list source $tclfile]"


This probably means that Tcl wasn't installed properly.
```

The internet says this is related to the library that's trying to draw the image in an actual windows window, and for a unit test, the backend-only version is fine.