### PR TITLE
Add hats upper version pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     # dask diagnostics is required to spin up the dashboard for profiling.
     "dask[complete]>=2025.3.0",
     "deprecated",
-    "hats>=0.6.5",
+    "hats>=0.6.5,<0.7.0",
     "nested-pandas>=0.4.7,<0.5.0",
     "pyarrow>=14.0.1,<21.0.0; platform_system == 'Windows'",
     "pyarrow>=14.0.1; platform_system != 'Windows'",


### PR DESCRIPTION
Adds an upper version pin for the `hats` requirement, the same way we do with `nested-pandas` to avoid breaking changes in hats causing errors when a user installs a pinned lsdb version. Fixes #1024 