### PR TITLE
Add version pinning notes for dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,17 +8,3 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    allow:
-      # NOTE: package PINNED at <21.0.0, see https://github.com/astronomy-commons/lsdb/issues/974
-      - dependency-name: "pyarrow"
-        versions: "<21.0.0"
-      # NOTE: package PINNED at <0.3.0, see https://github.com/astronomy-commons/lsdb/issues/1047
-      - dependency-name: "universal-pathlib"
-        versions: "<0.3.0"
-    ignore:
-      # Ignore major updates for pyarrow, see https://github.com/astronomy-commons/lsdb/issues/974
-      - dependency-name: "pyarrow"
-        update-types: ["version-update:semver-major"]
-      # Ignore major updates for universal-pathlib, see https://github.com/astronomy-commons/lsdb/issues/1047
-      - dependency-name: "universal-pathlib"
-        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,13 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     allow:
       # NOTE: package PINNED at <21.0.0, see https://github.com/astronomy-commons/lsdb/issues/974
       - dependency-name: "pyarrow"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,20 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+    allow:
+      # NOTE: package PINNED at <21.0.0, see https://github.com/astronomy-commons/lsdb/issues/974
+      - dependency-name: "pyarrow"
+        versions: "<21.0.0"
+      # NOTE: package PINNED at <0.3.0, see https://github.com/astronomy-commons/lsdb/issues/1047
+      - dependency-name: "universal-pathlib"
+        versions: "<0.3.0"
+    ignore:
+      # Ignore major updates for pyarrow, see https://github.com/astronomy-commons/lsdb/issues/974
+      - dependency-name: "pyarrow"
+        update-types: ["version-update:semver-major"]
+      # Ignore major updates for universal-pathlib, see https://github.com/astronomy-commons/lsdb/issues/1047
+      - dependency-name: "universal-pathlib"
+        update-types: ["version-update:semver-major"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,14 @@ dependencies = [
     "deprecated",
     "hats>=0.6.5,<0.7.0",
     "nested-pandas>=0.4.7,<0.6.0",
+    
+    # NOTE: package PINNED at <21.0.0, see https://github.com/astronomy-commons/lsdb/issues/974
     "pyarrow>=14.0.1,<21.0.0; platform_system == 'Windows'",
+    
     "pyarrow>=14.0.1; platform_system != 'Windows'",
     "scipy>=1.7.2", # kdtree
+
+    # NOTE: package PINNED at <0.3.0, see https://github.com/astronomy-commons/lsdb/issues/1047
     "universal-pathlib>=0.2.2,<0.3.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,10 @@ dependencies = [
     "deprecated",
     "hats>=0.6.5,<0.7.0",
     "nested-pandas>=0.4.7,<0.6.0",
-    
+
     # NOTE: package PINNED at <21.0.0, see https://github.com/astronomy-commons/lsdb/issues/974
     "pyarrow>=14.0.1,<21.0.0; platform_system == 'Windows'",
-    
+
     "pyarrow>=14.0.1; platform_system != 'Windows'",
     "scipy>=1.7.2", # kdtree
 


### PR DESCRIPTION
Added notes regarding package version pinning for pyarrow and universal-pathlib, to help future maintainers avoid waving through mistaken dependabot suggestions.