### PR TITLE
Nested-Pandas v0.6 Compatibility

### DIFF
--- a/docs/tutorials/pre_executed/nestedframe.ipynb
+++ b/docs/tutorials/pre_executed/nestedframe.ipynb
@@ -1501,7 +1501,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "96262092",
    "metadata": {},
    "outputs": [
@@ -1517,7 +1517,7 @@
     }
    ],
    "source": [
-    "nf.lightcurve.nest.fields"
+    "nf.lightcurve.nest.columns"
    ]
   },
   {
@@ -2103,12 +2103,12 @@
    "id": "9960a788",
    "metadata": {},
    "source": [
-    "In this case, nf_flat has a matched index with nf_base, and we can easily nest it using `add_nested`:"
+    "In this case, nf_flat has a matched index with nf_base, and we can easily nest it using `join_nested`:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "44545efc",
    "metadata": {},
    "outputs": [
@@ -2213,7 +2213,7 @@
     }
    ],
    "source": [
-    "nf_nested = nf_base.add_nested(nf_flat, name=\"packed\")\n",
+    "nf_nested = nf_base.join_nested(nf_flat, name=\"packed\")\n",
     "nf_nested"
    ]
   },
@@ -2257,7 +2257,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "sep",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -2271,7 +2271,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/pre_executed/timeseries.ipynb
+++ b/docs/tutorials/pre_executed/timeseries.ipynb
@@ -646,7 +646,7 @@
    "source": [
     "We'd also like to ignore time series data that has fewer than 10 detections.\n",
     "\n",
-    "We can't use `nepochs` for anymore, since it included observations for which `catflags != 0`.  What we'll do instead is use a function from `nested_pandas` called `count_nested`, which is able to count all of the points per nested field.  This function adds a column to its input, named `n_{column}`, or `n_lc` in this case, since we're counting the length of the fields within `lc`.\n",
+    "We can't use `nepochs` for anymore, since it included observations for which `catflags != 0`.  What we'll do instead is use a function from `nested_pandas` called `count_nested`, which is able to count all of the points per nested field.  This function adds a column to its input, named `n_{column}`, or `n_lc` in this case, since we're counting the length of the sub-columns within `lc`.\n",
     "\n",
     "We'll apply this function using `.map_partitions`, which, like `.reduce`, applies a function in parallel across the partitions of the catalog, but with a slightly different syntax.\n",
     "\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "dask[complete]>=2025.3.0",
     "deprecated",
     "hats>=0.6.6,<0.7.0",
-    "nested-pandas>=0.4.7,<0.6.0",
+    "nested-pandas>=0.6.0,<0.7.0",
 
     # NOTE: package PINNED at <21.0.0, see https://github.com/astronomy-commons/lsdb/issues/974
     "pyarrow>=14.0.1,<21.0.0; platform_system == 'Windows'",

--- a/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
+++ b/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
@@ -252,6 +252,6 @@ class AbstractCrossmatchAlgorithm(ABC):
         right_join_part["new_index_col"] = left_idx
         right_join_part = right_join_part.set_index("new_index_col")
         self._append_extra_columns(right_join_part, extra_cols)
-        out = left_join_part.add_nested(right_join_part, nested_column_name)
+        out = left_join_part.join_nested(right_join_part, nested_column_name)
         out.set_index(index_name, inplace=True)
         return npd.NestedFrame(out)

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -621,7 +621,7 @@ def generate_meta_df_for_nested_tables(
     hive_cols_to_drop = [c for c in paths.HIVE_COLUMNS if c in nested_catalog_meta.columns]
     nested_catalog_meta = nested_catalog_meta.drop(columns=hive_cols_to_drop)
 
-    meta_df = npd.NestedFrame(meta_df).add_nested(nested_catalog_meta, nested_column_name)
+    meta_df = npd.NestedFrame(meta_df).join_nested(nested_catalog_meta, nested_column_name)
 
     # Use nested-pandas to make the resulting meta with the nested catalog meta as a nested column
     return meta_df

--- a/src/lsdb/nested/accessor.py
+++ b/src/lsdb/nested/accessor.py
@@ -33,40 +33,40 @@ class DaskNestSeriesAccessor(npd.NestSeriesAccessor):
             raise AttributeError(f"Can only use .nest accessor with a Series of NestedDtype, got {dtype}")
 
     @property
-    def fields(self) -> list[str]:
+    def columns(self) -> list[str]:
         """Names of the nested columns"""
 
-        return list(self._series.dtype.fields)
+        return list(self._series.dtype.column_dtypes)
 
-    def to_lists(self, fields: list[str] | None = None) -> dd.DataFrame:
+    def to_lists(self, columns: list[str] | None = None) -> dd.DataFrame:
         """Convert nested series into dataframe of list-array columns
 
         Parameters
         ----------
-        fields : list[str] or None, optional
-            Names of the fields to include. Default is None, which means all fields.
+        columns : list[str] or None, optional
+            Names of the columns to include. Default is None, which means all columns.
 
         Returns
         -------
         dd.DataFrame
             Dataframe of list-arrays.
         """
-        return self._series.map_partitions(lambda x: x.nest.to_lists(fields=fields))
+        return self._series.map_partitions(lambda x: x.nest.to_lists(columns=columns))
 
-    def to_flat(self, fields: list[str] | None = None) -> dd.DataFrame:
+    def to_flat(self, columns: list[str] | None = None) -> dd.DataFrame:
         """Convert nested series into dataframe of flat arrays
 
         Parameters
         ----------
-        fields : list[str] or None, optional
-            Names of the fields to include. Default is None, which means all fields.
+        columns : list[str] or None, optional
+            Names of the columns to include. Default is None, which means all columns.
 
         Returns
         -------
         dd.DataFrame
             Dataframe of flat arrays.
         """
-        return self._series.map_partitions(lambda x: x.nest.to_flat(fields=fields))
+        return self._series.map_partitions(lambda x: x.nest.to_flat(columns=columns))
 
     def clear(self):
         """Clear method implementation"""

--- a/src/lsdb/nested/core.py
+++ b/src/lsdb/nested/core.py
@@ -68,7 +68,7 @@ class NestedFrame(
     >>> import lsdb.nested as nd # doctest: +SKIP
     >>> base = nd.NestedFrame(base_data) # doctest: +SKIP
     >>> layer = nd.NestedFrame(layer_data) # doctest: +SKIP
-    >>> base.add_nested(layer, "layer") # doctest: +SKIP
+    >>> base.join_nested(layer, "layer") # doctest: +SKIP
     """
 
     _partition_type = npd.NestedFrame  # Tracks the underlying data type
@@ -465,8 +465,7 @@ Refer to the docstring for guidance on dtype requirements and assignment."""
             return False
         return False
 
-    # NOTE: Named join_nested in LSDB
-    def add_nested(self, nested, name, how="outer") -> NestedFrame:  # type: ignore[name-defined] # noqa: F821
+    def join_nested(self, nested, name, how="outer") -> NestedFrame:  # type: ignore[name-defined] # noqa: F821
         """Packs a dataframe into a nested column
 
         Parameters

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -468,7 +468,9 @@ class Helpers:
                 assert (col_name, dtype) in joined_cat.dtypes.items()
         for col_name, dtype in right_cat.dtypes.items():
             if col_name not in right_ignore_columns and col_name not in paths.HIVE_COLUMNS:
-                assert (col_name, dtype.pyarrow_dtype) in joined_cat[nested_colname].dtypes.fields.items()
+                assert (col_name, dtype.pyarrow_dtype) in joined_cat[
+                    nested_colname
+                ].dtypes.column_dtypes.items()
 
     @staticmethod
     def assert_catalog_info_is_correct(expected_catalog_info, catalog_info, **properties_to_update):
@@ -510,12 +512,12 @@ def test_dataset():
     base_nd = nd.NestedFrame.from_pandas(base_nf, npartitions=5)
     layer_nd = nd.NestedFrame.from_pandas(layer_nf, npartitions=10)
 
-    return base_nd.add_nested(layer_nd, "nested")
+    return base_nd.join_nested(layer_nd, "nested")
 
 
 @pytest.fixture
 def test_dataset_with_nans():
-    """stop before add_nested"""
+    """stop before join_nested"""
     n_base = 50
     layer_size = 500
     randomstate = np.random.RandomState(seed=1)  # pylint: disable=no-member
@@ -540,12 +542,12 @@ def test_dataset_with_nans():
     base_nd = nd.NestedFrame.from_pandas(base_nf, npartitions=5)
     layer_nd = nd.NestedFrame.from_pandas(layer_nf, npartitions=10)
 
-    return base_nd.add_nested(layer_nd, "nested")
+    return base_nd.join_nested(layer_nd, "nested")
 
 
 @pytest.fixture
-def test_dataset_no_add_nested():
-    """stop before add_nested"""
+def test_dataset_no_join_nested():
+    """stop before join_nested"""
     n_base = 50
     layer_size = 500
     randomstate = np.random.RandomState(seed=1)  # pylint: disable=no-member

--- a/tests/lsdb/catalog/test_nested.py
+++ b/tests/lsdb/catalog/test_nested.py
@@ -29,7 +29,7 @@ def test_nest_lists(small_sky_with_nested_sources):
     assert "id" in cat_ndf_renested.columns
     assert "ra" in cat_ndf_renested.columns
     assert "dec" in cat_ndf_renested.columns
-    assert cat_ndf_renested._ddf["nested"].nest.fields == cat_ndf["sources"].nest.fields
+    assert cat_ndf_renested._ddf["nested"].nest.columns == cat_ndf["sources"].nest.columns
 
     # try a compute call
     renested_flat = cat_ndf_renested.compute()["nested"].nest.to_flat()
@@ -49,14 +49,14 @@ def test_nest_lists_only_list_columns(small_sky_with_nested_sources):
 
     # Use the columns from the original catalog as the list columns. All other
     # columns are inferred to be "base" columns.
-    cat_ndf_renested = small_sky_with_nested_sources.nest_lists(list_columns=cat_ndf["sources"].nest.fields)
+    cat_ndf_renested = small_sky_with_nested_sources.nest_lists(list_columns=cat_ndf["sources"].nest.columns)
 
     # check column structure
     assert "nested" in cat_ndf_renested.columns
     assert "id" in cat_ndf_renested.columns
     assert "ra" in cat_ndf_renested.columns
     assert "dec" in cat_ndf_renested.columns
-    assert cat_ndf_renested._ddf["nested"].nest.fields == cat_ndf["sources"].nest.fields
+    assert cat_ndf_renested._ddf["nested"].nest.columns == cat_ndf["sources"].nest.columns
 
     # try a compute call
     renested_flat = cat_ndf_renested.compute()["nested"].nest.to_flat()
@@ -181,7 +181,7 @@ def test_reduce_infer_nesting(small_sky_with_nested_sources):
     res_true = small_sky_with_nested_sources.reduce(mean_mag, "ra", "dec", "sources.mag", meta=true_meta)
 
     assert "new_nested" in res_true.columns and "new_nested" in res_true._ddf.nested_columns
-    assert list(res_true["new_nested"].nest.fields) == ["ra_mag", "dec_mag"]
+    assert list(res_true["new_nested"].nest.columns) == ["ra_mag", "dec_mag"]
 
     # Without inferred nesting:
     false_meta = (

--- a/tests/lsdb/nested/test_accessor.py
+++ b/tests/lsdb/nested/test_accessor.py
@@ -23,9 +23,9 @@ def test_nest_accessor(test_dataset):
         _ = test_dataset.ra.nest
 
 
-def test_fields(test_dataset):
-    """test the fields accessor property"""
-    assert test_dataset.nested.nest.fields == ["t", "flux", "band"]
+def test_columns(test_dataset):
+    """test the columns accessor property"""
+    assert test_dataset.nested.nest.columns == ["t", "flux", "band"]
 
 
 def test_to_flat():
@@ -49,11 +49,11 @@ def test_to_flat():
     assert one_row["band"] == "r"
 
 
-def test_to_flat_with_fields():
+def test_to_flat_with_columns():
     """test the to_flat function"""
     nf = nd.datasets.generate_data(10, 100, npartitions=2, seed=1)
 
-    flat_nf = nf.nested.nest.to_flat(fields=["t", "flux"])
+    flat_nf = nf.nested.nest.to_flat(columns=["t", "flux"])
 
     assert "band" not in flat_nf.columns
 
@@ -94,10 +94,10 @@ def test_to_lists():
     assert one_row["band"][0] == "g"
 
 
-def test_to_lists_with_fields():
+def test_to_lists_with_columns():
     """test the to_lists function"""
     nf = nd.datasets.generate_data(10, 100, npartitions=2, seed=1)
-    list_nf = nf.nested.nest.to_lists(fields=["t", "flux"])
+    list_nf = nf.nested.nest.to_lists(columns=["t", "flux"])
 
     assert "band" not in list_nf.columns
 

--- a/tests/lsdb/nested/test_io.py
+++ b/tests/lsdb/nested/test_io.py
@@ -31,7 +31,7 @@ def test_read_parquet(test_dataset, tmp_path):
 
     # this is read as a large_string, just make it a string
     nested = nested.astype({"band": pd.ArrowDtype(pa.string())})
-    base = base.add_nested(nested, "nested")
+    base = base.join_nested(nested, "nested")
 
     # Check the loaded dataset against the original
     assert base.divisions == test_dataset.divisions  # equal divisions

--- a/tests/lsdb/nested/test_nestedframe.py
+++ b/tests/lsdb/nested/test_nestedframe.py
@@ -95,7 +95,7 @@ def test_set_new_nested_col():
     ndf["new_nested.t_plus_flux"] = ndf["nested.t"] + ndf["nested.flux"]
 
     assert "new_nested" in ndf.nested_columns
-    assert "t_plus_flux" in ndf["new_nested"].nest.fields
+    assert "t_plus_flux" in ndf["new_nested"].nest.columns
 
     assert np.array_equal(
         ndf["new_nested.t_plus_flux"].compute().values.to_numpy(),
@@ -103,11 +103,11 @@ def test_set_new_nested_col():
     )
 
 
-def test_add_nested(test_dataset_no_add_nested):
-    """test the add_nested function"""
-    base, layer = test_dataset_no_add_nested
+def test_join_nested(test_dataset_no_join_nested):
+    """test the join_nested function"""
+    base, layer = test_dataset_no_join_nested
 
-    base_with_nested = base.add_nested(layer, "nested")
+    base_with_nested = base.join_nested(layer, "nested")
 
     # Check that the result is a nestedframe
     assert isinstance(base_with_nested, nd.NestedFrame)
@@ -140,55 +140,55 @@ def test_from_flat():
     # Check full inputs
     ndf = nd.NestedFrame.from_flat(nf, base_columns=["a", "b"], nested_columns=["c", "d"])
     assert list(ndf.columns) == ["a", "b", "nested"]
-    assert list(ndf["nested"].nest.fields) == ["c", "d"]
+    assert list(ndf["nested"].nest.columns) == ["c", "d"]
     ndf_comp = ndf.compute()
     assert list(ndf.columns) == list(ndf_comp.columns)
-    assert list(ndf["nested"].nest.fields) == list(ndf["nested"].nest.fields)
+    assert list(ndf["nested"].nest.columns) == list(ndf["nested"].nest.columns)
     assert len(ndf_comp) == 2
 
     # Check omitting a base column
     ndf = nd.NestedFrame.from_flat(nf, base_columns=["a"], nested_columns=["c", "d"])
     assert list(ndf.columns) == ["a", "nested"]
-    assert list(ndf["nested"].nest.fields) == ["c", "d"]
+    assert list(ndf["nested"].nest.columns) == ["c", "d"]
     ndf_comp = ndf.compute()
     assert list(ndf.columns) == list(ndf_comp.columns)
-    assert list(ndf["nested"].nest.fields) == list(ndf["nested"].nest.fields)
+    assert list(ndf["nested"].nest.columns) == list(ndf["nested"].nest.columns)
     assert len(ndf_comp) == 2
 
     # Check omitting a nested column
     ndf = nd.NestedFrame.from_flat(nf, base_columns=["a", "b"], nested_columns=["d"])
     assert list(ndf.columns) == ["a", "b", "nested"]
-    assert list(ndf["nested"].nest.fields) == ["d"]
+    assert list(ndf["nested"].nest.columns) == ["d"]
     ndf_comp = ndf.compute()
     assert list(ndf.columns) == list(ndf_comp.columns)
-    assert list(ndf["nested"].nest.fields) == list(ndf["nested"].nest.fields)
+    assert list(ndf["nested"].nest.columns) == list(ndf["nested"].nest.columns)
     assert len(ndf_comp) == 2
 
     # Check no base columns
     ndf = nd.NestedFrame.from_flat(nf, base_columns=[], nested_columns=["c", "d"])
     assert list(ndf.columns) == ["nested"]
-    assert list(ndf["nested"].nest.fields) == ["c", "d"]
+    assert list(ndf["nested"].nest.columns) == ["c", "d"]
     ndf_comp = ndf.compute()
     assert list(ndf.columns) == list(ndf_comp.columns)
-    assert list(ndf["nested"].nest.fields) == list(ndf["nested"].nest.fields)
+    assert list(ndf["nested"].nest.columns) == list(ndf["nested"].nest.columns)
     assert len(ndf_comp) == 2
 
     # Check inferred nested columns
     ndf = nd.NestedFrame.from_flat(nf, base_columns=["a", "b"])
     assert list(ndf.columns) == ["a", "b", "nested"]
-    assert list(ndf["nested"].nest.fields) == ["c", "d"]
+    assert list(ndf["nested"].nest.columns) == ["c", "d"]
     ndf_comp = ndf.compute()
     assert list(ndf.columns) == list(ndf_comp.columns)
-    assert list(ndf["nested"].nest.fields) == list(ndf["nested"].nest.fields)
+    assert list(ndf["nested"].nest.columns) == list(ndf["nested"].nest.columns)
     assert len(ndf_comp) == 2
 
     # Check using an index
     ndf = nd.NestedFrame.from_flat(nf, base_columns=["b"], on="a")
     assert list(ndf.columns) == ["b", "nested"]
-    assert list(ndf["nested"].nest.fields) == ["c", "d"]
+    assert list(ndf["nested"].nest.columns) == ["c", "d"]
     ndf_comp = ndf.compute()
     assert list(ndf.columns) == list(ndf_comp.columns)
-    assert list(ndf["nested"].nest.fields) == list(ndf["nested"].nest.fields)
+    assert list(ndf["nested"].nest.columns) == list(ndf["nested"].nest.columns)
     assert len(ndf_comp) == 2
 
 
@@ -211,35 +211,35 @@ def test_from_lists():
     # Check with just base_columns
     ndf = nd.NestedFrame.from_lists(nf, base_columns=["c", "d"])
     assert list(ndf.columns) == ["c", "d", "nested"]
-    assert list(ndf["nested"].nest.fields) == ["e", "f"]
+    assert list(ndf["nested"].nest.columns) == ["e", "f"]
     ndf_comp = ndf.compute()
     assert list(ndf.columns) == list(ndf_comp.columns)
-    assert list(ndf["nested"].nest.fields) == list(ndf["nested"].nest.fields)
+    assert list(ndf["nested"].nest.columns) == list(ndf["nested"].nest.columns)
     assert_frame_equal(ndf_comp.iloc[:0], ndf.meta)
 
     # Check with just list_columns
     ndf = nd.NestedFrame.from_lists(nf, list_columns=["e", "f"])
     assert list(ndf.columns) == ["c", "d", "nested"]
-    assert list(ndf["nested"].nest.fields) == ["e", "f"]
+    assert list(ndf["nested"].nest.columns) == ["e", "f"]
     ndf_comp = ndf.compute()
     assert list(ndf.columns) == list(ndf_comp.columns)
-    assert list(ndf["nested"].nest.fields) == list(ndf["nested"].nest.fields)
+    assert list(ndf["nested"].nest.columns) == list(ndf["nested"].nest.columns)
 
     # Check with base subset
     ndf = nd.NestedFrame.from_lists(nf, base_columns=["c"], list_columns=["e", "f"])
     assert list(ndf.columns) == ["c", "nested"]
-    assert list(ndf["nested"].nest.fields) == ["e", "f"]
+    assert list(ndf["nested"].nest.columns) == ["e", "f"]
     ndf_comp = ndf.compute()
     assert list(ndf.columns) == list(ndf_comp.columns)
-    assert list(ndf["nested"].nest.fields) == list(ndf["nested"].nest.fields)
+    assert list(ndf["nested"].nest.columns) == list(ndf["nested"].nest.columns)
 
     # Check with list subset
     ndf = nd.NestedFrame.from_lists(nf, base_columns=["c", "d"], list_columns=["f"])
     assert list(ndf.columns) == ["c", "d", "nested"]
-    assert list(ndf["nested"].nest.fields) == ["f"]
+    assert list(ndf["nested"].nest.columns) == ["f"]
     ndf_comp = ndf.compute()
     assert list(ndf.columns) == list(ndf_comp.columns)
-    assert list(ndf["nested"].nest.fields) == list(ndf["nested"].nest.fields)
+    assert list(ndf["nested"].nest.columns) == list(ndf["nested"].nest.columns)
 
 
 def test_from_lists_errors():
@@ -336,7 +336,7 @@ def test_reduce_output_type(meta):
     a = npd.NestedFrame({"a": pd.Series([1, 2, 3], dtype=pd.ArrowDtype(pa.int64()))}, index=[0, 0, 1])
     b = npd.NestedFrame({"b": pd.Series([1, 2], dtype=pd.ArrowDtype(pa.int64()))}, index=[0, 1])
 
-    ndf = b.add_nested(a, name="test")
+    ndf = b.join_nested(a, name="test")
     nddf = nd.NestedFrame.from_pandas(ndf, npartitions=1)
 
     if meta == "df":
@@ -430,7 +430,7 @@ def test_to_parquet_by_layer(test_dataset, tmp_path):
 
     # this is read as a large_string, just make it a string
     loaded_nested = loaded_nested.astype({"band": pd.ArrowDtype(pa.string())})
-    loaded_dataset = loaded_base.add_nested(loaded_nested, "nested")
+    loaded_dataset = loaded_base.join_nested(loaded_nested, "nested")
 
     # Check for equivalence
     assert test_dataset.divisions == loaded_dataset.divisions
@@ -460,7 +460,7 @@ def test_from_epyc():
         .persist()
     )
 
-    object_ndf = object_ndf.add_nested(source_ndf, "ztf_source")
+    object_ndf = object_ndf.join_nested(source_ndf, "ztf_source")
 
     # Apply a mean function
     meta = pd.DataFrame(columns=[0], dtype=float)
@@ -481,7 +481,7 @@ def test_from_pandas(pkg, with_nested):
         df = npd.NestedFrame({"a": [1, 2, 3]}, index=[1, 2, 3])
         if with_nested:
             nested = npd.NestedFrame({"b": [5, 10, 15, 20, 25, 30]}, index=[1, 1, 2, 2, 3, 3])
-            df = df.add_nested(nested, "nested")
+            df = df.join_nested(nested, "nested")
 
     ndf = nd.NestedFrame.from_pandas(df)
     assert isinstance(ndf, nd.NestedFrame)


### PR DESCRIPTION
- [ ] Direct renaming changes
- [ ] Scrub LSDB code of underlying usage of deprecated nested-pandas function names
- [ ] Reduce->map_rows, implementing map_rows wrapper and deprecating reduce