### PR TITLE
Move search functions from LSDB -> HATS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-hats @ git+https://github.com/astronomy-commons/hats.git@mv-search-funcs
+hats @ git+https://github.com/astronomy-commons/hats.git@main


### PR DESCRIPTION
Moved lsdb.core.search submodule functions into a new hats.search submodule. The classes in the lsdb.core.search submodule remain in LSDB, as these are specifically implemented to work with LSDB catalogs.

Updated all relevant imports to import from hats.search and not lsdb.core.search.

This addresses part of https://github.com/astronomy-commons/lsdb/issues/325, and helps to meet stcal usage needs (enabling only HATS as a dependency).