### PR TITLE
Unpin `universal-pathlib`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "nested-pandas>=0.6.0,<0.7.0",
     "scipy>=1.7.2", # kdtree
     "tabulate>=0.7.0",
-    "universal-pathlib>=0.3.1",
+    "universal-pathlib",
 ]
 
 [project.urls]


### PR DESCRIPTION
Related to https://github.com/astronomy-commons/hats/issues/589. On the next release we should increase the minimum pinned version for hats!