### PR TITLE
Make most of map_rows arguments to be keyword-only

### DIFF
--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -1206,6 +1206,7 @@ class Catalog(HealpixDataset):
         self,
         func,
         columns=None,
+        *,
         row_container="dict",
         output_names=None,
         infer_nesting=True,

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -1215,6 +1215,7 @@ class HealpixDataset:
         self,
         func,
         columns=None,
+        *,
         row_container="dict",
         output_names=None,
         infer_nesting=True,

--- a/src/lsdb/nested/core.py
+++ b/src/lsdb/nested/core.py
@@ -487,6 +487,7 @@ Refer to the docstring for guidance on dtype requirements and assignment."""
         self,
         func,
         columns=None,
+        *,
         row_container="dict",
         output_names=None,
         infer_nesting=True,


### PR DESCRIPTION
Fixes #1176 