### PR TITLE
Catalog Loader from Astropy Tables

### DIFF
--- a/docs/reference/io.rst
+++ b/docs/reference/io.rst
@@ -10,6 +10,7 @@ Construction
 
     open_catalog
     from_dataframe
+    from_astropy
     nested.datasets.generation.generate_catalog
 
 Materializing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ documentation = "https://lsdb.readthedocs.io/"
 [project.optional-dependencies]
 dev = [
     "asv[virtualenv]==0.6.5", # Used to compute performance benchmarks
+    "astropy", # Needed for testing astropy table loading
     "black", # Used for static linting of files
     "jupyter", # Clears output from Jupyter notebooks
     "mypy", # Used for static type checking of files

--- a/src/lsdb/__init__.py
+++ b/src/lsdb/__init__.py
@@ -4,6 +4,7 @@ from ._version import __version__
 from .catalog import Catalog, MarginCatalog
 from .core.crossmatch.crossmatch import crossmatch
 from .core.search.region_search import BoxSearch, ConeSearch, PixelSearch, PolygonSearch
+from .loaders.dataframe.from_astropy import from_astropy
 from .loaders.dataframe.from_dataframe import from_dataframe
 from .loaders.hats.read_hats import open_catalog, read_hats
 from .nested.datasets import generate_catalog, generate_data

--- a/src/lsdb/loaders/dataframe/from_astropy.py
+++ b/src/lsdb/loaders/dataframe/from_astropy.py
@@ -28,7 +28,7 @@ def from_astropy(
     Parameters
     ----------
     table : astropy.table.Table
-        The catalog Astropy Table.
+        The Astropy Table (or QTable).
     ra_column : str, optional
         The name of the right ascension column. By default,
         case-insensitive versions of 'ra' are detected.
@@ -65,6 +65,7 @@ def from_astropy(
         using `pa.Schema.from_pandas`.
     **kwargs
         Additional arguments to pass to the Dataframe loader.
+
     Returns
     -------
     Catalog

--- a/src/lsdb/loaders/dataframe/from_astropy.py
+++ b/src/lsdb/loaders/dataframe/from_astropy.py
@@ -81,10 +81,11 @@ def from_astropy(
     >>> table = Table(data)
     >>> catalog = lsdb.from_astropy(table, ra_column="ra", dec_column="dec")
     >>> catalog.head()
-       ra   dec  magnitude
-    0 10.0 -10.0      15.0
-    1 20.0 -20.0      16.5
-    2 30.0 -30.0      14.2
+                           ra   dec  magnitude
+    _healpix_29
+    1212933045629049957  10.0 -10.0       15.0
+    1176808107119886823  20.0 -20.0       16.5
+    2510306432296314470  30.0 -30.0       14.2
     """
 
     dataframe = table.to_pandas()

--- a/src/lsdb/loaders/dataframe/from_astropy.py
+++ b/src/lsdb/loaders/dataframe/from_astropy.py
@@ -60,8 +60,9 @@ def from_astropy(
     use_pyarrow_types : bool, default True
         If True, uses PyArrow backed types in the resulting catalog.
     schema : pa.Schema or None, default None
-        An optional PyArrow schema to use when converting the Astropy Table
-        to a Pandas Dataframe.
+        The arrow schema to create the catalog with. If None, the schema is
+        automatically inferred from the DataFrame conversion of the table
+        using `pa.Schema.from_pandas`.
     **kwargs
         Additional arguments to pass to the Dataframe loader.
     Returns
@@ -82,7 +83,7 @@ def from_astropy(
     >>> catalog = lsdb.from_astropy(table, ra_column="ra", dec_column="dec")
     >>> catalog.head()
                            ra   dec  magnitude
-    _healpix_29
+    _healpix_29                               
     1212933045629049957  10.0 -10.0       15.0
     1176808107119886823  20.0 -20.0       16.5
     2510306432296314470  30.0 -30.0       14.2

--- a/src/lsdb/loaders/dataframe/from_astropy.py
+++ b/src/lsdb/loaders/dataframe/from_astropy.py
@@ -1,5 +1,3 @@
-import pandas as pd
-
 from lsdb.loaders.dataframe.from_dataframe import from_dataframe
 
 
@@ -60,8 +58,7 @@ def from_astropy(
     moc_max_order : int, default 10
         The maximum order to use when generating the MOC.
     use_pyarrow_types : bool, default True
-        If True, attempts to use PyArrow types when converting the Astropy Table
-        to a Pandas Dataframe.
+        If True, uses PyArrow backed types in the resulting catalog.
     schema : pa.Schema or None, default None
         An optional PyArrow schema to use when converting the Astropy Table
         to a Pandas Dataframe.

--- a/src/lsdb/loaders/dataframe/from_astropy.py
+++ b/src/lsdb/loaders/dataframe/from_astropy.py
@@ -68,6 +68,23 @@ def from_astropy(
     -------
     Catalog
         The loaded catalog.
+
+    Examples
+    --------
+    >>> from astropy.table import Table
+    >>> import lsdb
+    >>> data = {
+    ...     "ra": [10.0, 20.0, 30.0],
+    ...     "dec": [-10.0, -20.0, -30.0],
+    ...     "magnitude": [15.0, 16.5, 14.2],
+    ... }
+    >>> table = Table(data)
+    >>> catalog = lsdb.from_astropy(table, ra_column="ra", dec_column="dec")
+    >>> catalog.head()
+       ra   dec  magnitude
+    0 10.0 -10.0      15.0
+    1 20.0 -20.0      16.5
+    2 30.0 -30.0      14.2
     """
 
     dataframe = table.to_pandas()

--- a/src/lsdb/loaders/dataframe/from_astropy.py
+++ b/src/lsdb/loaders/dataframe/from_astropy.py
@@ -1,0 +1,94 @@
+import pandas as pd
+
+from lsdb.loaders.dataframe.from_dataframe import from_dataframe
+
+
+def from_astropy(
+    table,
+    *,
+    ra_column: str | None = None,
+    dec_column: str | None = None,
+    lowest_order: int = 0,
+    highest_order: int = 7,
+    drop_empty_siblings: bool = True,
+    partition_rows: int | None = None,
+    partition_bytes: int | None = None,
+    margin_order: int = -1,
+    margin_threshold: float | None = 5.0,
+    should_generate_moc: bool = True,
+    moc_max_order: int = 10,
+    use_pyarrow_types: bool = True,
+    schema=None,
+    **kwargs,
+):
+    """Load a catalog from an Astropy Table.
+
+    Note that this is only suitable for small datasets (< 1million rows and
+    < 1GB dataframe in-memory). If you need to deal with large datasets, consider
+    using the hats-import package: https://hats-import.readthedocs.io/
+
+    Parameters
+    ----------
+    table : astropy.table.Table
+        The catalog Astropy Table.
+    ra_column : str, optional
+        The name of the right ascension column. By default,
+        case-insensitive versions of 'ra' are detected.
+    dec_column : str, optional
+        The name of the declination column. By default,
+        case-insensitive versions of 'dec' are detected.
+    lowest_order : int, default 0
+        The lowest partition order. Defaults to 0.
+    highest_order : int, default 7
+        The highest partition order. Defaults to 7.
+    drop_empty_siblings : bool, default True
+        When determining final partitionining, if 3 of 4 pixels are empty,
+        keep only the non-empty pixel
+    partition_rows : int or None, default None
+        The desired partition size, in number of rows. Only one of
+        `partition_rows` or `partition_bytes` should be specified.
+    partition_bytes : int or None, default None
+        The desired partition size, in bytes. Only one of
+        `partition_rows` or `partition_bytes` should be specified.
+    margin_order : int, default -1
+        The order at which to generate the margin cache.
+    margin_threshold : float or None, default 5
+        The threshold (in arcseconds) for including sources in the margin cache. If None, and
+        margin_order is specified, the margin cache will include all sources in the margin pixels.
+    should_generate_moc : bool, default True
+        If True, generates a MOC for the catalog.
+    moc_max_order : int, default 10
+        The maximum order to use when generating the MOC.
+    use_pyarrow_types : bool, default True
+        If True, attempts to use PyArrow types when converting the Astropy Table
+        to a Pandas Dataframe.
+    schema : pa.Schema or None, default None
+        An optional PyArrow schema to use when converting the Astropy Table
+        to a Pandas Dataframe.
+    **kwargs
+        Additional arguments to pass to the Dataframe loader.
+    Returns
+    -------
+    Catalog
+        The loaded catalog.
+    """
+
+    dataframe = table.to_pandas()
+
+    return from_dataframe(
+        dataframe,
+        ra_column=ra_column,
+        dec_column=dec_column,
+        lowest_order=lowest_order,
+        highest_order=highest_order,
+        drop_empty_siblings=drop_empty_siblings,
+        partition_rows=partition_rows,
+        partition_bytes=partition_bytes,
+        margin_order=margin_order,
+        margin_threshold=margin_threshold,
+        should_generate_moc=should_generate_moc,
+        moc_max_order=moc_max_order,
+        use_pyarrow_types=use_pyarrow_types,
+        schema=schema,
+        **kwargs,
+    )

--- a/src/lsdb/loaders/dataframe/from_astropy.py
+++ b/src/lsdb/loaders/dataframe/from_astropy.py
@@ -1,7 +1,8 @@
-from lsdb.loaders.dataframe.from_dataframe import from_dataframe
-from nested_pandas.nestedframe.io import from_pyarrow
 import numpy as np
 import pyarrow as pa
+from nested_pandas.nestedframe.io import from_pyarrow
+
+from lsdb.loaders.dataframe.from_dataframe import from_dataframe
 
 
 def from_astropy(
@@ -87,12 +88,13 @@ def from_astropy(
     >>> catalog = lsdb.from_astropy(table, ra_column="ra", dec_column="dec")
     >>> catalog.head()
                            ra   dec  magnitude
-    _healpix_29                               
+    _healpix_29
     1212933045629049957  10.0 -10.0       15.0
     1176808107119886823  20.0 -20.0       16.5
     2510306432296314470  30.0 -30.0       14.2
     """
     # Go through pyarrow to convert the table to a dataframe.
+    # Don't use table.to_pandas() as that would lose multidimensional column support
     arrow_table = _astropy_to_pyarrow_table(table, flatten_tensors=False)
     dataframe = from_pyarrow(arrow_table)
 
@@ -114,7 +116,10 @@ def from_astropy(
         **kwargs,
     )
 
-# Placeholder grabbed from hats-import, consider moving to hats
+
+# TODO: Code pulled from hats-import, potentially should move to hats
+# In which case, remove this and use the hats version directly
+# https://github.com/astronomy-commons/hats-import/issues/623
 def _np_to_pyarrow_array(array: np.ndarray, *, flatten_tensors: bool) -> pa.Array:
     """Convert a numpy array to a pyarrow"""
     # We usually have the "wrong" byte order from FITS

--- a/src/lsdb/loaders/dataframe/from_astropy.py
+++ b/src/lsdb/loaders/dataframe/from_astropy.py
@@ -88,7 +88,7 @@ def from_astropy(
     >>> catalog = lsdb.from_astropy(table, ra_column="ra", dec_column="dec")
     >>> catalog.head()
                            ra   dec  magnitude
-    _healpix_29
+    _healpix_29                               
     1212933045629049957  10.0 -10.0       15.0
     1176808107119886823  20.0 -20.0       16.5
     2510306432296314470  30.0 -30.0       14.2

--- a/src/lsdb/loaders/dataframe/from_astropy.py
+++ b/src/lsdb/loaders/dataframe/from_astropy.py
@@ -21,6 +21,7 @@ def from_astropy(
     moc_max_order: int = 10,
     use_pyarrow_types: bool = True,
     schema=None,
+    flatten_tensors: bool = False,
     **kwargs,
 ):
     """Load a catalog from an Astropy Table.
@@ -67,6 +68,9 @@ def from_astropy(
         The arrow schema to create the catalog with. If None, the schema is
         automatically inferred from the DataFrame conversion of the table
         using `pa.Schema.from_pandas`.
+    flatten_tensors : bool, default False
+        If True, flattens multidimensional columns to 2D arrays in the
+        resulting catalog.
     **kwargs
         Additional arguments to pass to the Dataframe loader.
 
@@ -95,7 +99,7 @@ def from_astropy(
     """
     # Go through pyarrow to convert the table to a dataframe.
     # Don't use table.to_pandas() as that would lose multidimensional column support
-    arrow_table = _astropy_to_pyarrow_table(table, flatten_tensors=False)
+    arrow_table = _astropy_to_pyarrow_table(table, flatten_tensors=flatten_tensors)
     dataframe = from_pyarrow(arrow_table)
 
     return from_dataframe(

--- a/src/lsdb/loaders/dataframe/from_astropy.py
+++ b/src/lsdb/loaders/dataframe/from_astropy.py
@@ -5,6 +5,7 @@ from nested_pandas.nestedframe.io import from_pyarrow
 from lsdb.loaders.dataframe.from_dataframe import from_dataframe
 
 
+# pylint: disable=too-many-arguments
 def from_astropy(
     table,
     *,

--- a/src/lsdb/loaders/dataframe/from_astropy.py
+++ b/src/lsdb/loaders/dataframe/from_astropy.py
@@ -72,7 +72,7 @@ def from_astropy(
         If True, flattens multidimensional columns to 2D arrays in the
         resulting catalog.
     **kwargs
-        Additional arguments to pass to the Dataframe loader.
+        Additional arguments to pass along to LSDB.from_dataframe.
 
     Returns
     -------

--- a/src/lsdb/loaders/dataframe/from_astropy.py
+++ b/src/lsdb/loaders/dataframe/from_astropy.py
@@ -90,9 +90,9 @@ def from_astropy(
     ... }
     >>> table = Table(data)
     >>> catalog = lsdb.from_astropy(table, ra_column="ra", dec_column="dec")
-    >>> catalog.head()
+    >>> catalog.head()  # doctest: +NORMALIZE_WHITESPACE
                            ra   dec  magnitude
-    _healpix_29                               
+    _healpix_29
     1212933045629049957  10.0 -10.0       15.0
     1176808107119886823  20.0 -20.0       16.5
     2510306432296314470  30.0 -30.0       14.2

--- a/src/lsdb/loaders/dataframe/from_astropy.py
+++ b/src/lsdb/loaders/dataframe/from_astropy.py
@@ -89,7 +89,7 @@ def from_astropy(
     ...     "magnitude": [15.0, 16.5, 14.2],
     ... }
     >>> table = Table(data)
-    >>> catalog = lsdb.from_astropy(table, ra_column="ra", dec_column="dec")
+    >>> catalog = lsdb.from_astropy(table)
     >>> catalog.head()
                            ra   dec  magnitude
     _healpix_29                               

--- a/tests/lsdb/loaders/dataframe/test_from_astropy.py
+++ b/tests/lsdb/loaders/dataframe/test_from_astropy.py
@@ -40,3 +40,29 @@ def test_from_astropy_qtable():
     assert "d" in catalog.columns
     assert "RA" in catalog.columns
     assert "DEC" in catalog.columns
+
+
+def test_from_astropy_multidimensional_column():
+    data = {
+        "ra": [10.0, 20.0, 30.0],
+        "dec": [-10.0, -20.0, -30.0],
+        "spectrum": [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]],
+    }
+    table = Table(data)
+    catalog = lsdb.from_astropy(table, ra_column="ra", dec_column="dec")
+    assert catalog is not None
+    assert len(catalog) == 3
+    assert "spectrum" in catalog.columns
+
+
+def test_from_astropy_multidimensional_ragged_column():
+    data = {
+        "ra": [10.0, 20.0, 30.0],
+        "dec": [-10.0, -20.0, -30.0],
+        "lc": [[1.0, 2.0], [3.0], [4.0, 5.0, 6.0]],
+    }
+    table = Table(data)
+    catalog = lsdb.from_astropy(table, ra_column="ra", dec_column="dec")
+    assert catalog is not None
+    assert len(catalog) == 3
+    assert "lc" in catalog.columns

--- a/tests/lsdb/loaders/dataframe/test_from_astropy.py
+++ b/tests/lsdb/loaders/dataframe/test_from_astropy.py
@@ -1,0 +1,42 @@
+import astropy.units as u
+import numpy as np
+from astropy.table import QTable, Table
+
+import lsdb
+
+
+def test_from_astropy_table():
+    data = {
+        "ra": [10.0, 20.0, 30.0],
+        "dec": [-10.0, -20.0, -30.0],
+        "magnitude": [15.0, 16.5, 14.2],
+    }
+    table = Table(data)
+    catalog = lsdb.from_astropy(table, ra_column="ra", dec_column="dec")
+
+    assert catalog is not None
+    assert len(catalog) == 3
+    assert "magnitude" in catalog.columns
+    assert "ra" in catalog.columns
+    assert "dec" in catalog.columns
+
+
+def test_from_astropy_qtable():
+    a = np.array([1, 4, 5], dtype=np.int32)
+    b = [2.0, 5.0, 8.5]
+    c = ["x", "y", "z"]
+    d = [10, 20, 30] * u.m / u.s
+    ra = [2.0, 5.0, 10.0]
+    dec = [-30.0, 35.0, 15.0]
+
+    qt = QTable([a, b, c, d, ra, dec], names=("a", "b", "c", "d", "RA", "DEC"), meta={"name": "test table"})
+    catalog = lsdb.from_astropy(qt)
+
+    assert catalog is not None
+    assert len(catalog) == 3
+    assert "a" in catalog.columns
+    assert "b" in catalog.columns
+    assert "c" in catalog.columns
+    assert "d" in catalog.columns
+    assert "RA" in catalog.columns
+    assert "DEC" in catalog.columns

--- a/tests/lsdb/loaders/dataframe/test_from_astropy.py
+++ b/tests/lsdb/loaders/dataframe/test_from_astropy.py
@@ -66,3 +66,20 @@ def test_from_astropy_multidimensional_ragged_column():
     assert catalog is not None
     assert len(catalog) == 3
     assert "lc" in catalog.columns
+
+
+def test_from_astropy_flatten_tensors():
+    data = {
+        "ra": [10.0, 20.0, 30.0],
+        "dec": [-10.0, -20.0, -30.0],
+        "images": [
+            [[1.0, 2.0], [3.0, 4.0]],
+            [[5.0, 6.0], [7.0, 8.0]],
+            [[9.0, 10.0], [11.0, 12.0]],
+        ],
+    }
+    table = Table(data)
+    catalog = lsdb.from_astropy(table, ra_column="ra", dec_column="dec", flatten_tensors=True)
+    assert catalog is not None
+    assert len(catalog) == 3
+    assert "images" in catalog.columns


### PR DESCRIPTION
Closes #780 

Originally embarrassingly simple, just leveraging the existing astropy->pandas and pandas->LSDB infrastructure. A little bit more involved after thinking about more use-case coverage, for example, astropy does not allow multi-dimensional columns to cast to pandas, but we may have an opportunity with nested-pandas for those, in which case going from astropy->arrow->nested-pandas->LSDB is more appropriate.

Astropy _just_ (Astropy 7.2, Nov 2025) released direct pyarrow conversion support through an external library (narwhals). Because this relies on an external library I think it's better for us to do the conversion ourselves, currently leveraging: https://github.com/astronomy-commons/hats-import/blob/475646b43d0a2c83ed54bdd651bfcdc08efac80b/src/hats_import/catalog/file_readers/fits.py#L9

A note on performance:
Using `table.to_pandas()` is several times faster generally than various approaches that go from astropy table->arrow->pandas/nested-pandas. However, the time spent doing these conversion is much shorter in either case compared to the time spent loading the dataframe into LSDB (at an example data scale, microseconds vs milliseconds), so the efficiency loss seems perfectly fine to gain multidimensional column support. If for some reason the performance is crucial to slim down, then a user could always just do astropy->pandas->LSDB manually.