### PR TITLE
Simplify learning objectives

### DIFF
--- a/docs/developer/tutorial_template.ipynb
+++ b/docs/developer/tutorial_template.ipynb
@@ -13,13 +13,8 @@
    "id": "6089e920",
    "metadata": {},
    "source": [
-    "## Learning objectives\n",
-    "\n",
-    "By the end of this tutorial, you will:\n",
-    "- [List of things you can learn here]\n",
-    "\n",
-    "You should already have an understanding of:\n",
-    "- [Suggested pre-reading, if applicable]"
+    "In this tutorial we will:\n",
+    "- [List of things you can learn here]"
    ]
   },
   {


### PR DESCRIPTION
This pull simplifies learning objectives section in the template. During the break I went over our tutorials and made the starting part consistent over tutorials, using this simplified version. This change should ensure that future templates keep this format. 