### PR TITLE
Add latest version of lsdb in Getting Started

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -48,11 +48,11 @@ The latest release version of LSDB is available to install with `pip <https://py
 
 .. code-block:: bash
 
-    pip install lsdb
+    pip install "lsdb>=0.7.3"
 
 .. code-block:: bash
 
-    conda install -c conda-forge lsdb
+    conda install -c conda-forge "lsdb>=0.7.3"
 
 LSDB can also be installed from source on `GitHub <https://github.com/astronomy-commons/lsdb>`_. See our
 advanced installation instructions in the :doc:`contribution guide </developer/contributing>`.
@@ -64,7 +64,7 @@ advanced installation instructions in the :doc:`contribution guide </developer/c
 
     .. code-block:: console
 
-        python -m pip install 'lsdb[full]'
+        python -m pip install "lsdb[full]>=0.7.3"
 
 Quickstart
 --------------------------


### PR DESCRIPTION
Partially solves https://github.com/astronomy-commons/lsdb/issues/908. This pull only adds the latest version that is currently avaliable, but we would have to manually refresh for each new version. I did manage to get GitHub Action workflows with ChatGPT that seemed to update the Getting Started notebook which each new release, but I did not feel comfortable pushing that code that I did not fully understand.  