### PR TITLE
Fix landing page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,11 +47,11 @@ Using this Guide
 
        The detailed API documentation
 
-      .. grid-item-card:: Contact Us / Getting Help
-       :link: contact
-       :link-type: doc
+   .. grid-item-card:: Contact Us / Getting Help
+      :link: contact
+      :link-type: doc
 
-       Reach out for more help
+      Reach out for more help
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
One of my previous pull has modified the landing page for documentation. This reverts to original state. 

Previous state:
<img width="1794" height="1004" alt="image_2026-01-20_165631268" src="https://github.com/user-attachments/assets/134d2026-d8b3-43cb-bab0-e782ec9b0d0b" />

After state:
<img width="876" height="352" alt="Screenshot 2026-01-20 at 4 57 37 PM" src="https://github.com/user-attachments/assets/8e33051a-4a10-4d57-b495-542f0cf89d57" />

