### PR TITLE
WIP: `Catalog.from_flat`

### DIFF
--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -1206,6 +1206,51 @@ class Catalog(HealpixDataset):
             )
         return catalog
 
+    @classmethod
+    def from_flat(
+        cls, catalog, base_columns, nested_columns=None, on: str | None = None, name="nested"
+    ) -> Self:
+        """Creates a new catalog from a flat catalog by nesting specified columns.
+
+        Parameters
+        ----------
+        catalog : Catalog
+            The input flat catalog to nest columns from.
+        base_columns : list-like
+            Any columns that have non-nested values in the input catalog.
+            These will simply be kept as identical columns in the result.
+        nested_columns : list-like or None, default None
+            The columns that should be packed into a nested
+            column. All columns in the list will attempt to be packed into a single nested column
+            with the name provided in `nested_name`. If None, all columns not in `base_columns` are used.
+        on : str or None, default None
+            If specified, the column to group by when nesting. If None, all rows are nested together.
+        name : str, default "nested"
+            The name of the output column the `nested_columns` are packed into.
+
+        Returns
+        -------
+        Self
+            A new catalog with specified columns nested into a new nested column.
+        """
+
+        new_catalog = super().from_flat(
+            catalog,
+            base_columns=base_columns,
+            nested_columns=nested_columns,
+            on=on,
+            name=name,
+        )
+        if hasattr(catalog, "margin") and catalog.margin is not None:
+            new_catalog.margin = cls.from_flat(
+                catalog.margin,
+                base_columns=base_columns,
+                nested_columns=nested_columns,
+                on=on,
+                name=name,
+            )
+        return new_catalog
+
     def map_rows(
         self,
         func,

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -1256,11 +1256,20 @@ class HealpixDataset:
         dataset._check_unloaded_columns(nested_columns)
 
         def from_flat_partition(df, base_columns, nested_columns, on, name):
-            # If we treat it as nested column, we have control over what _healpix_29 value is assigned
+
+            if on is None:
+                packed_nf = npd.NestedFrame.from_flat(
+                    df,
+                    base_columns=base_columns,
+                    nested_columns=nested_columns,
+                    on=on,
+                    name=name,
+                )
+                return packed_nf
             packed_nf = npd.NestedFrame.from_flat(
                 df.reset_index(),
                 base_columns=base_columns,
-                nested_columns=nested_columns + ["_healpix_29"],
+                nested_columns=nested_columns + ["_healpix_29"], # always nest _healpix_29
                 on=on,
                 name=name,
             )


### PR DESCRIPTION
Closes #434 

#434 has helpful commentary on dealing with the healpix index and the margin catalogs. My initial implementation handles the healpix index by selecting the lowest healpix index for each object, but handles the margins independently from the data. The primary concern for this I would think is for multiple observations of the same object with some jitter in ra/dec, causing some observation to fall into the margin for an object that is in the main catalog. So we would ideally like to collect all measurements so as not to duplicate objects between the margin and main catalog.