### PR TITLE
Implement dask collection protocol on HealpixDataset

### DIFF
--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -146,6 +146,27 @@ class HealpixDataset:
             series_df = pd.concat([_repr_data_series(s, index=index) for _, s in meta.items()], axis=1)
         return series_df
 
+    def __dask_graph__(self):
+        return self._ddf.__dask_graph__()
+
+    def __dask_keys__(self):
+        return self._ddf.__dask_keys__()
+
+    def __dask_tokenize__(self):
+        return self._ddf.__dask_tokenize__()
+
+    def __dask_postcompute__(self):
+        return self._ddf.__dask_postcompute__()
+
+    def __dask_postpersist__(self):
+        return self._ddf.__dask_postpersist__()
+
+    @staticmethod
+    def __dask_optimize__(dsk, keys, **kwargs):
+        return dd.DataFrame.__dask_optimize__(dsk, keys, **kwargs)
+
+    __dask_scheduler__ = staticmethod(dd.DataFrame.__dask_scheduler__)
+
     def compute(self) -> npd.NestedFrame:
         """Compute dask distributed dataframe to pandas dataframe"""
         return self._ddf.compute()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import numpy.testing as npt
 import pandas as pd
 import pyarrow as pa
 import pytest
+from dask.distributed import Client
 from hats.io import paths
 from hats.pixel_math import spatial_index_to_healpix
 from hats.pixel_math.spatial_index import (
@@ -55,6 +56,13 @@ XMATCH_CORRECT_3N_2T_NO_MARGIN_FILE = "xmatch_correct_3n_2t_no_margin.csv"
 XMATCH_CORRECT_3N_2T_NEGATIVE_FILE = "xmatch_correct_3n_2t_negative.csv"
 XMATCH_MOCK_FILE = "xmatch_mock.csv"
 TEST_DIR = Path(__file__).parent
+
+
+@pytest.fixture
+def dask_client():
+    client = Client(n_workers=1, threads_per_worker=1)
+    yield client
+    client.close()
 
 
 @pytest.fixture

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 
 import astropy.units as u
+import dask
 import dask.dataframe as dd
 import hats as hc
 import hats.io.file_io
@@ -63,6 +64,13 @@ def test_catalog_html_repr_empty(small_sky_order1_catalog):
 
 def test_catalog_compute_equals_ddf_compute(small_sky_order1_catalog):
     pd.testing.assert_frame_equal(small_sky_order1_catalog.compute(), small_sky_order1_catalog._ddf.compute())
+
+
+def test_catalog_is_dask_collection(small_sky_order1_catalog):
+    assert dask.base.is_dask_collection(small_sky_order1_catalog)
+    (result,) = dask.compute(small_sky_order1_catalog)
+    assert isinstance(result, npd.NestedFrame)
+    pd.testing.assert_frame_equal(result, small_sky_order1_catalog._ddf.compute())
 
 
 def test_catalog_uses_dask_expressions(small_sky_order1_catalog):


### PR DESCRIPTION
Add __dask_graph__, __dask_keys__, __dask_tokenize__, __dask_postcompute__,
__dask_postpersist__, __dask_optimize__, and __dask_scheduler__ methods to
HealpixDataset, delegating to the underlying _ddf NestedFrame.

This allows dask.distributed.Client.compute(catalog) to return a Future
instead of requiring users to access the internal _ddf attribute.

Fixes #1028

https://claude.ai/code/session_013NNQnzZHryYqUC1eAWFC5w