### PR TITLE
Bump hats to 0.8.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     # dask diagnostics is required to spin up the dashboard for profiling.
     "dask[complete]>=2025.3.0",
     "deprecated",
-    "hats>=0.8,<0.9",
+    "hats>=0.8.2,<0.9",
     "nested-pandas>=0.6.7,<0.7.0",
     "numpy",
     "pyarrow",


### PR DESCRIPTION
Hats 0.8.2 has an important fix for cone search, let's pin on it

Just for the record, we also have some incopatibility between hats 0.8.1 and lsdb 0.8.2, reproducible example with those versions pinned:

```python
import lsdb

df = lsdb.open_catalog(
    'https://data.lsdb.io/hats/ztf_dr20/zubercal',
    search_filter=lsdb.ConeSearch(ra=1.0, dec=1.0, radius_arcsec=30.0)
).compute()
```

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
File ~/.virtualenvs/hats0.8.1-lsdb0.8.2/lib/python3.14/site-packages/lsdb/loaders/hats/read_hats.py:122, in open_catalog(path, search_filter, columns, margin_cache, error_empty_filter, filters, path_generator, **kwargs)
    120 if not isinstance(hc_catalog, (hc.catalog.CatalogCollection, hc.catalog.Catalog)):
    121     raise TypeError("To load auxiliary datasets please use `lsdb.read_hats()`")
--> 122 return _read_dataset(
    123     hc_catalog,
    124     search_filter=search_filter,
    125     columns=columns,
    126     margin_cache=margin_cache,
    127     error_empty_filter=error_empty_filter,
    128     filters=filters,
    129     path_generator=path_generator,
    130     **kwargs,
    131 )

File ~/.virtualenvs/hats0.8.1-lsdb0.8.2/lib/python3.14/site-packages/lsdb/loaders/hats/read_hats.py:217, in _read_dataset(hc_catalog, search_filter, columns, margin_cache, error_empty_filter, filters, path_generator, **kwargs)
    215 if isinstance(hc_catalog, hc.catalog.CatalogCollection):
    216     config.margin_cache = _get_collection_margin(hc_catalog, margin_cache)
--> 217     catalog = _load_catalog(hc_catalog.main_catalog, config)
    218     catalog.hc_collection = hc_catalog  # type: ignore[attr-defined]
    219 else:

File ~/.virtualenvs/hats0.8.1-lsdb0.8.2/lib/python3.14/site-packages/lsdb/loaders/hats/read_hats.py:256, in _load_catalog(hc_catalog, config)
    253 catalog_type = hc_catalog.catalog_info.catalog_type
    255 if catalog_type in (CatalogType.OBJECT, CatalogType.SOURCE):
--> 256     catalog = _load_object_catalog(hc_catalog, config)
    257 elif catalog_type == CatalogType.MARGIN:
    258     catalog = _load_margin_catalog(hc_catalog, config)

File ~/.virtualenvs/hats0.8.1-lsdb0.8.2/lib/python3.14/site-packages/lsdb/loaders/hats/read_hats.py:352, in _load_object_catalog(hc_catalog, config)
    350     catalog = catalog.search(config.search_filter)
    351 if config.margin_cache is not None:
--> 352     margin_hc_catalog = hc.read_hats(config.margin_cache, single_catalog=True, read_moc=False)
    353     margin = _load_margin_catalog(margin_hc_catalog, config)
    354     _validate_margin_catalog(margin, catalog)

TypeError: read_hats() got an unexpected keyword argument 'single_catalog'
```