### PR TITLE
Introduce crossmatch_nested(how: "left" | "inner")

### DIFF
--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -399,6 +399,7 @@ class Catalog(HealpixDataset):
         output_catalog_name: str | None = None,
         require_right_margin: bool = False,
         nested_column_name: str | None = None,
+        how: str = "inner",
     ) -> Catalog:
         # pylint:disable=unused-argument
         """Perform a cross-match between two catalogs, adding the result as a nested column
@@ -507,7 +508,9 @@ class Catalog(HealpixDataset):
         if output_catalog_name is None:
             output_catalog_name = f"{self.name}_x_{other.name}"
 
-        ddf, ddf_map, alignment = crossmatch_catalog_data_nested(self, other, algorithm, nested_column_name)
+        ddf, ddf_map, alignment = crossmatch_catalog_data_nested(
+            self, other, algorithm, nested_column_name, how=how
+        )
         hc_catalog = self.hc_structure.__class__(
             self.hc_structure.catalog_info,
             alignment.pixel_tree,

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -512,7 +512,7 @@ class Catalog(HealpixDataset):
             output_catalog_name = f"{self.name}_x_{other.name}"
 
         ddf, ddf_map, alignment = crossmatch_catalog_data_nested(
-            self, other, algorithm, nested_column_name, how=how
+            self, other, algorithm, how, nested_column_name
         )
         hc_catalog = self.hc_structure.__class__(
             self.hc_structure.catalog_info,

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -476,6 +476,9 @@ class Catalog(HealpixDataset):
         nested_column_name : str, default uses the name of the right catalog
             The name of the nested column that will contain the crossmatched rows
             from the right catalog.
+        how : str
+            How to handle the crossmatch of the two catalogs.
+            One of {'left', 'inner'}; defaults to 'inner'.
 
         Returns
         -------

--- a/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
+++ b/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
@@ -375,7 +375,7 @@ class AbstractCrossmatchAlgorithm(ABC):
             The name of the column where the matches should be stored.
         how : str
             How to handle the crossmatch of the two catalogs.
-            One of {'left', 'inner'}; defaults to 'inner'.
+            One of {'left', 'inner'}.
 
         Returns
         -------

--- a/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
+++ b/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
@@ -113,7 +113,9 @@ class AbstractCrossmatchAlgorithm(ABC):
             suffix_method,
         )
 
-    def crossmatch_nested(self, crossmatch_args: CrossmatchArgs, nested_column_name: str) -> npd.NestedFrame:
+    def crossmatch_nested(
+        self, crossmatch_args: CrossmatchArgs, nested_column_name: str, how: str
+    ) -> npd.NestedFrame:
         """Perform a crossmatch and store results in nested column.
 
         Parameters
@@ -140,6 +142,7 @@ class AbstractCrossmatchAlgorithm(ABC):
             r_inds,
             extra_cols,
             nested_column_name,
+            how,
         )
 
     def perform_crossmatch(
@@ -349,6 +352,7 @@ class AbstractCrossmatchAlgorithm(ABC):
         right_idx: npt.NDArray[np.int64],
         extra_cols: pd.DataFrame,
         nested_column_name: str,
+        how: str,
     ) -> npd.NestedFrame:
         """Creates a df containing the crossmatch result from matching indices and additional columns
 
@@ -382,4 +386,8 @@ class AbstractCrossmatchAlgorithm(ABC):
         self._append_extra_columns(right_join_part, extra_cols)
         out = left_join_part.join_nested(right_join_part, nested_column_name)
         out.set_index(index_name, inplace=True)
-        return npd.NestedFrame(out)
+        out = npd.NestedFrame(out)
+        # Remove non-matches
+        if how == "inner":
+            out = out.dropna(subset=[nested_column_name])
+        return out

--- a/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
+++ b/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
@@ -124,6 +124,9 @@ class AbstractCrossmatchAlgorithm(ABC):
             The partitions and respective pixel information.
         nested_column_name : str
             The name of the column where the matches should be stored.
+        how : str
+            How to handle the crossmatch of the two catalogs.
+            One of {'left', 'inner'}; defaults to 'inner'.
 
         Returns
         -------
@@ -370,6 +373,9 @@ class AbstractCrossmatchAlgorithm(ABC):
             Dataframe containing additional columns from crossmatching
         nested_column_name : str
             The name of the column where the matches should be stored.
+        how : str
+            How to handle the crossmatch of the two catalogs.
+            One of {'left', 'inner'}; defaults to 'inner'.
 
         Returns
         -------
@@ -384,10 +390,6 @@ class AbstractCrossmatchAlgorithm(ABC):
         right_join_part["new_index_col"] = left_idx
         right_join_part = right_join_part.set_index("new_index_col")
         self._append_extra_columns(right_join_part, extra_cols)
-        out = left_join_part.join_nested(right_join_part, nested_column_name)
+        out = left_join_part.join_nested(right_join_part, nested_column_name, how=how)
         out.set_index(index_name, inplace=True)
-        out = npd.NestedFrame(out)
-        # Remove non-matches
-        if how == "inner":
-            out = out.dropna(subset=[nested_column_name])
         return out

--- a/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
+++ b/src/lsdb/core/crossmatch/abstract_crossmatch_algorithm.py
@@ -126,7 +126,7 @@ class AbstractCrossmatchAlgorithm(ABC):
             The name of the column where the matches should be stored.
         how : str
             How to handle the crossmatch of the two catalogs.
-            One of {'left', 'inner'}; defaults to 'inner'.
+            One of {'left', 'inner'}.
 
         Returns
         -------

--- a/src/lsdb/dask/crossmatch_catalog_data.py
+++ b/src/lsdb/dask/crossmatch_catalog_data.py
@@ -410,7 +410,7 @@ def crossmatch_catalog_data_nested(
         in the `Catalog` class.
     how : str
         How to handle the crossmatch of the two catalogs.
-        One of {'left', 'inner'}; defaults to 'inner'.
+        One of {'left', 'inner'}.
     nested_column_name : str
         The name of the nested column that will contain the crossmatched rows
         from the right catalog

--- a/src/lsdb/dask/crossmatch_catalog_data.py
+++ b/src/lsdb/dask/crossmatch_catalog_data.py
@@ -393,9 +393,8 @@ def crossmatch_catalog_data_nested(
     left: Catalog,
     right: Catalog,
     algorithm: AbstractCrossmatchAlgorithm,
-    nested_column_name: str,
-    *,
     how: str,
+    nested_column_name: str,
 ) -> tuple[nd.NestedFrame, DaskDFPixelMap, PixelAlignment]:
     """Crossmatches the data from two catalogs with the result from the right catalog in a nested column
 
@@ -409,12 +408,12 @@ def crossmatch_catalog_data_nested(
         The algorithm to use to perform the crossmatch. Specified by subclassing
         `AbstractCrossmatchAlgorithm`. For more details, see `crossmatch` method
         in the `Catalog` class.
-    nested_column_name : str
-        The name of the nested column that will contain the crossmatched rows
-        from the right catalog
     how : str
         How to handle the crossmatch of the two catalogs.
         One of {'left', 'inner'}; defaults to 'inner'.
+    nested_column_name : str
+        The name of the nested column that will contain the crossmatched rows
+        from the right catalog
 
     Returns
     -------

--- a/src/lsdb/dask/crossmatch_catalog_data.py
+++ b/src/lsdb/dask/crossmatch_catalog_data.py
@@ -201,12 +201,15 @@ def perform_crossmatch_nested(
     left_df,
     right_df,
     right_margin_df,
+    aligned_df,
     left_pix,
     right_pix,
     right_margin_pix,
+    aligned_pixel,
     left_catalog_info,
     right_catalog_info,
     right_margin_catalog_info,
+    aligned_catalog_info,
     algorithm,
     how,
     nested_column_name,
@@ -259,9 +262,12 @@ def perform_crossmatch_nested(
     if left_df is None or len(left_df) == 0:
         return meta_df
 
-    if right_pix is not None and right_pix.order > left_pix.order:
+    if aligned_pixel.order > left_pix.order:
         left_df = filter_by_spatial_index_to_pixel(
-            left_df, right_pix.order, right_pix.pixel, spatial_index_order=left_catalog_info.healpix_order
+            left_df,
+            aligned_pixel.order,
+            aligned_pixel.pixel,
+            spatial_index_order=left_catalog_info.healpix_order,
         )
 
     if right_df is None:
@@ -432,6 +438,7 @@ def crossmatch_catalog_data_nested(
 
     # get lists of HEALPix pixels from alignment to pass to cross-match
     left_pixels, right_pixels = get_healpix_pixels_from_alignment(alignment)
+    aligned_pixels = get_aligned_pixels_from_alignment(alignment)
 
     # generate meta table structure for dask df
     meta_df = generate_meta_df_for_nested_tables(
@@ -440,7 +447,7 @@ def crossmatch_catalog_data_nested(
 
     # perform the crossmatch on each partition pairing using dask delayed for lazy computation
     joined_partitions = align_and_apply(
-        [(left, left_pixels), (right, right_pixels), (right.margin, right_pixels)],
+        [(left, left_pixels), (right, right_pixels), (right.margin, right_pixels), (None, aligned_pixels)],
         perform_crossmatch_nested,
         algorithm,
         how,

--- a/src/lsdb/dask/crossmatch_catalog_data.py
+++ b/src/lsdb/dask/crossmatch_catalog_data.py
@@ -272,11 +272,11 @@ def perform_crossmatch_nested(
         extra_column_names = (
             set(algorithm.extra_columns.columns) if algorithm.extra_columns is not None else set()
         )
-        nested_flat = meta_df[nested_column_name].nest.to_flat().iloc[:0]
+        nested_series = meta_df[nested_column_name]
         right_df = npd.NestedFrame(
             {
-                col: pd.Series(dtype=nested_flat[col].dtype)
-                for col in nested_flat.columns
+                col: pd.Series(dtype=nested_series.nest[col].dtype)
+                for col in nested_series.nest.columns
                 if col not in extra_column_names
             }
         )

--- a/src/lsdb/dask/crossmatch_catalog_data.py
+++ b/src/lsdb/dask/crossmatch_catalog_data.py
@@ -241,6 +241,9 @@ def perform_crossmatch_nested(
         The algorithm to use to perform the crossmatch. Specified by subclassing
         `AbstractCrossmatchAlgorithm`. For more details, see `crossmatch` method
         in the `Catalog` class.
+    how : str
+        How to handle the crossmatch of the two catalogs.
+        One of {'left', 'inner'}; defaults to 'inner'.
     nested_column_name : str
         The name of the nested column in the resulting dataframe storing the
         joined columns in the right catalog. (Default: name of right catalog)
@@ -253,13 +256,30 @@ def perform_crossmatch_nested(
         DataFrame with the results of crossmatching for the pair of partitions.
         The results are stored in a nested column.
     """
-    if right_pix.order > left_pix.order:
+    if left_df is None or len(left_df) == 0:
+        return meta_df
+
+    if right_pix is not None and right_pix.order > left_pix.order:
         left_df = filter_by_spatial_index_to_pixel(
             left_df, right_pix.order, right_pix.pixel, spatial_index_order=left_catalog_info.healpix_order
         )
 
-    if len(left_df) == 0:
-        return meta_df
+    if right_df is None:
+        # When right_df is None (partitions don't spatially overlap), we need to create
+        # an empty DataFrame with the right catalog's columns and correct dtypes.
+        # The right catalog columns are the sub-columns of the nested column in meta_df,
+        # excluding any extra columns added by the algorithm (e.g., _dist_arcsec).
+        extra_column_names = (
+            set(algorithm.extra_columns.columns) if algorithm.extra_columns is not None else set()
+        )
+        nested_flat = meta_df[nested_column_name].nest.to_flat().iloc[:0]
+        right_df = npd.NestedFrame(
+            {
+                col: pd.Series(dtype=nested_flat[col].dtype)
+                for col in nested_flat.columns
+                if col not in extra_column_names
+            }
+        )
 
     right_joined_df = concat_partition_and_margin(right_df, right_margin_df)
 
@@ -268,8 +288,8 @@ def perform_crossmatch_nested(
         right_df=right_joined_df,
         left_order=left_pix.order,
         left_pixel=left_pix.pixel,
-        right_order=right_pix.order,
-        right_pixel=right_pix.pixel,
+        right_order=right_pix.order if right_pix is not None else None,
+        right_pixel=right_pix.pixel if right_pix is not None else None,
         left_catalog_info=left_catalog_info,
         right_catalog_info=right_catalog_info,
         right_margin_catalog_info=right_margin_catalog_info,
@@ -386,6 +406,9 @@ def crossmatch_catalog_data_nested(
     nested_column_name : str
         The name of the nested column that will contain the crossmatched rows
         from the right catalog
+    how : str
+        How to handle the crossmatch of the two catalogs.
+        One of {'left', 'inner'}; defaults to 'inner'.
 
     Returns
     -------

--- a/src/lsdb/dask/crossmatch_catalog_data.py
+++ b/src/lsdb/dask/crossmatch_catalog_data.py
@@ -208,6 +208,7 @@ def perform_crossmatch_nested(
     right_catalog_info,
     right_margin_catalog_info,
     algorithm,
+    how,
     nested_column_name,
     meta_df,
 ):
@@ -273,7 +274,7 @@ def perform_crossmatch_nested(
         right_catalog_info=right_catalog_info,
         right_margin_catalog_info=right_margin_catalog_info,
     )
-    return algorithm.crossmatch_nested(crossmatch_args, nested_column_name)
+    return algorithm.crossmatch_nested(crossmatch_args, nested_column_name, how)
 
 
 # pylint: disable=too-many-locals
@@ -367,6 +368,8 @@ def crossmatch_catalog_data_nested(
     right: Catalog,
     algorithm: AbstractCrossmatchAlgorithm,
     nested_column_name: str,
+    *,
+    how: str,
 ) -> tuple[nd.NestedFrame, DaskDFPixelMap, PixelAlignment]:
     """Crossmatches the data from two catalogs with the result from the right catalog in a nested column
 
@@ -400,7 +403,9 @@ def crossmatch_catalog_data_nested(
         )
 
     # perform alignment on the two catalogs
-    alignment = align_catalogs(left, right, add_right_margin=True)
+    alignment = align_catalogs(
+        left, right, add_right_margin=True, alignment_type=PixelAlignmentType[how.upper()]
+    )
 
     # get lists of HEALPix pixels from alignment to pass to cross-match
     left_pixels, right_pixels = get_healpix_pixels_from_alignment(alignment)
@@ -415,6 +420,7 @@ def crossmatch_catalog_data_nested(
         [(left, left_pixels), (right, right_pixels), (right.margin, right_pixels)],
         perform_crossmatch_nested,
         algorithm,
+        how,
         nested_column_name,
         meta_df,
     )

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -879,3 +879,52 @@ def test_crossmatch_nested_left_join_misaligned_trees():
         row = result[result["id"] == left_id]
         assert len(row) == 1
         assert row["matches"].isna().iloc[0], f"Expected null matches for left id={left_id}"
+
+
+def test_crossmatch_nested_left_join_same_pixel_partial_right_coverage():
+    """Left join where a single left partition has BOTH None and non-None right sub-pixel pairs.
+
+    This tests the alignment scenario where one left pixel contains points in different
+    order-3 sub-regions, but the right catalog only has data in ONE of those sub-regions.
+    The alignment produces two pairs for the same left pixel: (left, right_sub_pix) and
+    (left, None). Without proper aligned_pixel filtering, the None pair would return all
+    left rows unfiltered, causing duplicates with the non-None pair's output.
+    """
+    # All 4 left points fall in the same order-1 left pixel, but in different order-3 sub-pixels
+    left_df = pd.DataFrame({"id": [1, 2, 3, 4], "ra": [0.0, 5.0, 10.0, 15.0], "dec": [0.0, 0.0, 0.0, 0.0]})
+    left_df["id"] = left_df["id"].astype(pd.ArrowDtype(pa.int64()))
+    # Right has only one point in one order-3 sub-pixel of that left pixel
+    right_df = pd.DataFrame({"id": [101], "ra": [0.05], "dec": [0.0]})
+    right_df["id"] = right_df["id"].astype(pd.ArrowDtype(pa.int64()))
+
+    left_catalog = lsdb.from_dataframe(
+        left_df,
+        ra_column="ra",
+        dec_column="dec",
+        lowest_order=1,
+        highest_order=1,
+        margin_order=2,
+        margin_threshold=30,
+    )
+    right_catalog = lsdb.from_dataframe(
+        right_df,
+        ra_column="ra",
+        dec_column="dec",
+        lowest_order=3,
+        highest_order=3,
+        margin_order=4,
+        margin_threshold=30,
+    )
+
+    result = left_catalog.crossmatch_nested(
+        right_catalog,
+        n_neighbors=2,
+        radius_arcsec=100,
+        how="left",
+        nested_column_name="matches",
+    ).compute()
+
+    # Must have exactly as many rows as the left catalog — no duplicates from the None pair
+    assert len(result) == len(left_df)
+    assert not result.index.duplicated().any()
+    assert set(result["id"].to_numpy()) == {1, 2, 3, 4}

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -928,3 +928,45 @@ def test_crossmatch_nested_left_join_same_pixel_partial_right_coverage():
     assert len(result) == len(left_df)
     assert not result.index.duplicated().any()
     assert set(result["id"].to_numpy()) == {1, 2, 3, 4}
+
+
+def test_crossmatch_nested_inner_join_no_nulls_in_nested_column():
+    """Inner join with crossmatch_nested must not have null values in the nested column."""
+    left_df = pd.DataFrame({"id": [1, 2, 3], "ra": [0.0, 0.01, 180.0], "dec": [0.0, 0.01, 0.0]})
+    left_df["id"] = left_df["id"].astype(pd.ArrowDtype(pa.int64()))
+    right_df = pd.DataFrame({"id": [101, 102], "ra": [0.0002, 0.0004], "dec": [0.0, 0.0]})
+    right_df["id"] = right_df["id"].astype(pd.ArrowDtype(pa.int64()))
+
+    left_catalog = lsdb.from_dataframe(
+        left_df,
+        ra_column="ra",
+        dec_column="dec",
+        lowest_order=1,
+        highest_order=1,
+        margin_order=2,
+        margin_threshold=30,
+    )
+    right_catalog = lsdb.from_dataframe(
+        right_df,
+        ra_column="ra",
+        dec_column="dec",
+        lowest_order=3,
+        highest_order=3,
+        margin_order=4,
+        margin_threshold=30,
+    )
+
+    result = left_catalog.crossmatch_nested(
+        right_catalog,
+        n_neighbors=2,
+        radius_arcsec=10,
+        how="inner",
+        nested_column_name="matches",
+    ).compute()
+
+    # Only matched left rows should appear — left id=3 (ra=180) has no match
+    assert len(result) < len(left_df)
+    assert 3 not in result["id"].to_numpy()
+
+    # No null values in the nested column — every row must have at least one match
+    assert not result["matches"].isna().any()

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -814,3 +814,68 @@ def test_crossmatch_alignment_pixel_left_join_filters_and_aligns():
     assert aligned_orders
     assert max(aligned_orders) >= max(right_orders)
     assert min(aligned_orders) > min(left_orders)
+
+
+def test_crossmatch_nested_left_join_misaligned_trees():
+    """Left join with crossmatch_nested on misaligned partition trees and n_neighbors>1.
+
+    The left catalog is at order 1 and right at order 3, so their HEALPix trees don't
+    align: some left partitions have no corresponding right partition (right_pix=None)
+    and vice-versa. All left rows must appear in the result exactly once, unmatched rows
+    must have a null nested column, and matches must satisfy the radius constraint.
+    Using n_neighbors=2 exercises the multiple-neighbors path simultaneously.
+    """
+    left_df = pd.DataFrame({"id": [1, 2, 3], "ra": [0.0, 0.01, 180.0], "dec": [0.0, 0.01, 0.0]})
+    left_df["id"] = left_df["id"].astype(pd.ArrowDtype(pa.int64()))
+    # Two right points close to left point 1 (within radius), one far from any left point
+    right_df = pd.DataFrame({"id": [101, 102, 201], "ra": [0.0002, 0.0004, 90.0], "dec": [0.0, 0.0, 45.0]})
+    right_df["id"] = right_df["id"].astype(pd.ArrowDtype(pa.int64()))
+
+    left_catalog = lsdb.from_dataframe(
+        left_df,
+        ra_column="ra",
+        dec_column="dec",
+        lowest_order=1,
+        highest_order=1,
+        margin_order=2,
+        margin_threshold=30,
+    )
+    right_catalog = lsdb.from_dataframe(
+        right_df,
+        ra_column="ra",
+        dec_column="dec",
+        lowest_order=3,
+        highest_order=3,
+        margin_order=4,
+        margin_threshold=30,
+    )
+
+    result = left_catalog.crossmatch_nested(
+        right_catalog,
+        n_neighbors=2,
+        radius_arcsec=10,
+        how="left",
+        nested_column_name="matches",
+    ).compute()
+
+    # Output length must equal input length
+    assert len(result) == len(left_df)
+
+    # All left rows must be present
+    assert set(result["id"].to_numpy()) == {1, 2, 3}
+
+    # No duplicate left rows
+    assert not result.index.duplicated().any()
+
+    # Left point 1 (id=1) is close to right points 101 and 102 — both should be matched
+    row1 = result[result["id"] == 1]
+    assert len(row1) == 1
+    matches1 = row1["matches"].iloc[0]
+    assert matches1 is not None
+    assert set(matches1["id"].to_numpy()) == {101, 102}
+
+    # Left points 2 and 3 (id=2,3) are far from all right points — should have null nested column
+    for left_id in [2, 3]:
+        row = result[result["id"] == left_id]
+        assert len(row) == 1
+        assert row["matches"].isna().iloc[0], f"Expected null matches for left id={left_id}"


### PR DESCRIPTION
Fixes https://github.com/astronomy-commons/lsdb/issues/785, it is a breaking change, because `crossmatched_nested` results will change from what we have now: no `Nulls` for `how='inner'` (default) and adds non-overlapping pixels for `how='left'`.