### PR TITLE
docs: add missing resume and create_thumbnail params to write_catalog docstring

### DIFF
--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -1490,10 +1490,15 @@ class Catalog(HealpixDataset):
             If True, saves the catalog and its margin as a collection
         overwrite : bool, default False
             If True existing catalog is overwritten
+        resume : bool, default False
+            If True, resumes a previously interrupted write, skipping partitions
+            already written to disk.
         progress_bar : bool, default True
             If True, shows a progress bar for the export process. Defaults to True.
         tqdm_kwargs : dict, default None
             Additional kwargs to pass to the tqdm progress bar.
+        create_thumbnail : bool, default True
+            If True, generates a sky map thumbnail image for the catalog.
         error_if_empty : bool, default True
             If True, raises an error if the catalog is empty.
         **kwargs

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -1285,6 +1285,9 @@ class HealpixDataset:
             original hats catalogs if they exist.
         overwrite : bool, default False
             If True existing catalog is overwritten
+        resume : bool, default False
+            If True, resumes a previously interrupted write, skipping partitions
+            already written to disk.
         progress_bar : bool, default True
             If True, displays a progress bar during the save operation
         tqdm_kwargs : dict or None, default None


### PR DESCRIPTION
## Summary

Adds the missing `resume` and `create_thumbnail` parameters to the `write_catalog` docstring in both `catalog.py` and `healpix_dataset.py`.

Both parameters were accepted and passed through but not documented, causing confusion for users reading the API docs.

Closes #1286