### PR TITLE
fix: handle suffix collision in catalog self-crossmatches

### DIFF
--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -43,8 +43,20 @@ from lsdb.types import DaskDFPixelMap
 
 
 def _default_suffixes(left_name: str, right_name: str) -> tuple[str, str]:
-    """Return the default pair of suffixes for left/right catalog names."""
-    return (f"_{left_name}", f"_{right_name}")
+    """Return the default pair of suffixes for left/right catalog names.
+
+    When both names are identical (e.g. a self-crossmatch), ``_l`` and
+    ``_r`` are appended to avoid suffix collisions that would cause
+    ``ValueError: cannot reindex on an axis with duplicate labels``.
+
+    See https://github.com/astronomy-commons/lsdb/issues/1275
+    """
+    left_suffix = f"_{left_name}"
+    right_suffix = f"_{right_name}"
+    if left_suffix == right_suffix:
+        left_suffix = f"_{left_name}_l"
+        right_suffix = f"_{right_name}_r"
+    return (left_suffix, right_suffix)
 
 
 # pylint: disable=protected-access,too-many-public-methods, too-many-lines

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -970,3 +970,29 @@ def test_crossmatch_nested_inner_join_no_nulls_in_nested_column():
 
     # No null values in the nested column — every row must have at least one match
     assert not result["matches"].isna().any()
+
+
+def test_self_crossmatch_default_suffixes(small_sky_catalog):
+    """Self-crossmatch should not fail with default suffixes (issue #1275).
+
+    When a catalog is crossmatched against itself the default suffixes
+    used to be identical, causing a ``ValueError`` due to duplicate
+    column labels.  After the fix, unique ``_l`` / ``_r`` suffixes are
+    generated automatically.
+    """
+    from lsdb.catalog.catalog import _default_suffixes
+
+    name = small_sky_catalog.name
+    left_suffix, right_suffix = _default_suffixes(name, name)
+    assert left_suffix != right_suffix, "Self-crossmatch suffixes must differ"
+    assert left_suffix == f"_{name}_l"
+    assert right_suffix == f"_{name}_r"
+
+
+def test_default_suffixes_different_names():
+    """When catalog names differ the original suffix scheme is preserved."""
+    from lsdb.catalog.catalog import _default_suffixes
+
+    left_suffix, right_suffix = _default_suffixes("cat_a", "cat_b")
+    assert left_suffix == "_cat_a"
+    assert right_suffix == "_cat_b"


### PR DESCRIPTION
## Summary

Fixes #1275 — Catalog self-crossmatches fail with `ValueError: cannot reindex on an axis with duplicate labels` when using default suffixes.

## Problem

When a catalog is crossmatched against itself:
```python
cat = lsdb.generate_catalog(...)
cat.crossmatch(cat).compute()  # ValueError!
```

`_default_suffixes()` generates identical suffixes (both `_<name>`), which causes duplicate column labels and a `ValueError` in pandas.

## Solution

When `_default_suffixes()` detects that both catalog names are the same, it appends `_l` and `_r` to produce unique suffixes:
- Before: `("_small_sky", "_small_sky")` → collision
- After: `("_small_sky_l", "_small_sky_r")` → works

When names differ, the existing behavior is preserved unchanged.

## Changes

- **`src/lsdb/catalog/catalog.py`**: Updated `_default_suffixes()` to detect and resolve suffix collisions
- **`tests/lsdb/catalog/test_crossmatch.py`**: Added tests for both self-crossmatch and normal cases

## Testing

Added two test functions:
- `test_self_crossmatch_default_suffixes` — verifies unique suffixes are generated for self-crossmatch
- `test_default_suffixes_different_names` — verifies existing behavior is preserved for different catalog names