### PR TITLE
Add missed parameters to write_catalog's docstring

### DIFF
--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -1504,7 +1504,7 @@ class Catalog(HealpixDataset):
         tqdm_kwargs : dict, default None
             Additional kwargs to pass to the tqdm progress bar.
         create_thumbnail : bool, default True
-            If True, creates a thumbnail image of the catalog's sky coverage.
+            If True, creates a data thumbnail of the catalog for previewing purposes.
         error_if_empty : bool, default True
             If True, raises an error if the catalog is empty.
         **kwargs

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -1496,10 +1496,15 @@ class Catalog(HealpixDataset):
             If True, saves the catalog and its margin as a collection
         overwrite : bool, default False
             If True existing catalog is overwritten
+        resume : bool, default False
+            If True, resumes a previous write operation, skipping partitions that were
+            already written to disk.
         progress_bar : bool, default True
             If True, shows a progress bar for the export process. Defaults to True.
         tqdm_kwargs : dict, default None
             Additional kwargs to pass to the tqdm progress bar.
+        create_thumbnail : bool, default True
+            If True, creates a thumbnail image of the catalog's sky coverage.
         error_if_empty : bool, default True
             If True, raises an error if the catalog is empty.
         **kwargs

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -1504,7 +1504,8 @@ class Catalog(HealpixDataset):
         tqdm_kwargs : dict, default None
             Additional kwargs to pass to the tqdm progress bar.
         create_thumbnail : bool, default True
-            If True, creates a data thumbnail of the catalog for previewing purposes.
+            If True, creates a ``data_thumbnail.parquet`` file containing one row
+            per partition, for quick previewing of the catalog's contents.
         error_if_empty : bool, default True
             If True, raises an error if the catalog is empty.
         **kwargs

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -1285,6 +1285,9 @@ class HealpixDataset:
             original hats catalogs if they exist.
         overwrite : bool, default False
             If True existing catalog is overwritten
+        resume : bool, default False
+            If True, resumes a previous write operation, skipping partitions that were
+            already written to disk.
         progress_bar : bool, default True
             If True, displays a progress bar during the save operation
         tqdm_kwargs : dict or None, default None


### PR DESCRIPTION
Adds `resume` and `create_thumbnail` arguments to the `write_catalog``s method docstring, for both Catalog and Dataset. Closes #1286, closes #1295

<!--

## Summary
This PR adds documentation for two new parameters to the `write_catalog` method: `resume` and `create_thumbnail`. These parameters enable more flexible catalog writing operations with support for resuming interrupted writes and controlling thumbnail generation.

## Key Changes
- Added `resume` parameter documentation to `write_catalog` in both `catalog.py` and `healpix_dataset.py`
  - Allows resuming previous write operations by skipping already-written partitions
  - Useful for recovering from interrupted exports without reprocessing completed work
- Added `create_thumbnail` parameter documentation to `write_catalog` in `catalog.py`
  - Controls generation of `data_thumbnail.parquet` file for quick catalog previewing
  - Defaults to `True` to maintain existing behavior

## Notable Details
- Documentation updates are consistent across the catalog and dataset implementations
- Both new parameters follow existing parameter documentation conventions
- The `resume` parameter is positioned logically after `overwrite` in the parameter list
- The `create_thumbnail` parameter is positioned before `error_if_empty` for logical grouping

https://claude.ai/code/session_01SsFCNmZwVPRtw9f6HpPMAe
-->