### PR TITLE
Add Lazy Size Estimation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "dask[complete]>=2025.3.0",
     "deprecated",
     "hats>=0.9.0,<0.10",
+    "human_readable",
     "nested-pandas>=0.6.7,<0.7.0",
     "numpy",
     "pyarrow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "dask[complete]>=2025.3.0",
     "deprecated",
     "hats>=0.9.0,<0.10",
-    "human_readable>=1.0.0",
+    "human_readable>=2.0.0",
     "nested-pandas>=0.6.7,<0.7.0",
     "numpy",
     "pyarrow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "dask[complete]>=2025.3.0",
     "deprecated",
     "hats>=0.9.0,<0.10",
-    "human_readable",
+    "human_readable>=1.0.0",
     "nested-pandas>=0.6.7,<0.7.0",
     "numpy",
     "pyarrow",

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -14,6 +14,7 @@ import hats as hc
 import nested_pandas as npd
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 from astropy.coordinates import SkyCoord
 from astropy.units import Quantity
 from dask.dataframe.core import _repr_data_series
@@ -22,6 +23,7 @@ from deprecated import deprecated  # type: ignore
 from hats.catalog.healpix_dataset.healpix_dataset import HealpixDataset as HCHealpixDataset
 from hats.pixel_math import HealpixPixel
 from hats.pixel_math.healpix_pixel_function import get_pixel_argsort
+from human_readable import file_size
 from mocpy import MOC
 from pandas._typing import Renamer
 from tqdm.dask import TqdmCallback
@@ -89,16 +91,93 @@ class HealpixDataset:
     def __repr__(self):
         return self._ddf.__repr__()
 
+    def _compute_column_size_ratio(self) -> float | None:
+        """Compute the ratio of loaded column sizes to original column sizes based on Arrow schema.
+
+        Uses the Arrow schema data types to estimate the actual memory footprint of columns,
+        always including the index column in the calculation.
+
+        Returns
+        -------
+        float
+            Ratio of loaded columns size to original columns size
+        """
+
+        # Get the original schema if available, otherwise use current schema
+        original_schema = self.hc_structure.original_schema
+        if original_schema is None:
+            return None
+
+        current_schema = get_arrow_schema(self._ddf)
+
+        for field in current_schema:
+            if field.name not in original_schema.names:
+                return None
+
+        # Helper function to estimate size of an Arrow type
+        def estimate_type_size(arrow_type: pa.DataType) -> int | None:
+            """Estimate the size in bytes of an Arrow data type using PyArrow's bit_width when available."""
+            # For fixed-width types, use bit_width
+            try:
+                return arrow_type.bit_width // 8  # Convert bits to bytes
+            except (AttributeError, TypeError, ValueError):
+                return None
+
+        # Compute total size of loaded columns (including index)
+        loaded_size = 0
+        non_fixed_column = False
+
+        for field in current_schema:
+            field_size = estimate_type_size(field.type)
+            if field_size is not None:
+                loaded_size += field_size
+            else:
+                non_fixed_column = True
+
+        original_size_per_row = (
+            self.hc_structure.catalog_info.hats_estsize / self.hc_structure.catalog_info.total_rows
+            if self.hc_structure.catalog_info.hats_estsize and self.hc_structure.catalog_info.total_rows
+            else None
+        )
+
+        if non_fixed_column:
+            total_fixed_size_per_row = sum([estimate_type_size(field.type) or 0 for field in original_schema])
+            loaded_size += original_size_per_row - total_fixed_size_per_row
+
+        return loaded_size / original_size_per_row
+
+    def est_size(self):
+        """Estimate the size of the catalog in KB
+
+        Size estimate is based on the estimated size in the metadata, scaled by the ratio of loaded to
+        original columns and partitions.
+        """
+        if self.hc_structure.catalog_info.hats_estsize is not None:
+            if self.hc_structure.original_partition_info is not None:
+                partition_ratio = len(self.get_healpix_pixels()) / len(
+                    self.hc_structure.original_partition_info
+                )
+                column_ratio = self._compute_column_size_ratio()
+                if column_ratio is not None:
+                    return float(self.hc_structure.catalog_info.hats_estsize) * partition_ratio * column_ratio
+        return None
+
     def _repr_html_(self):
         data = self._repr_data().to_html(max_rows=5, show_dimensions=False, notebook=True)
         loaded_cols = len(self.columns)
         available_cols = len(self.all_columns)
+        est_size = self.est_size()
+        est_size_text = (
+            f"<div>This catalog has an estimated size of {file_size(est_size * 1000)}</div>"
+            if est_size is not None
+            else ""
+        )
         return (
             f"<div><strong>lsdb Catalog {self.name}:</strong></div>"
             f"{data}"
             f"<div>{loaded_cols} out of {available_cols} available columns in the catalog have been loaded "
             f"<strong>lazily</strong>, meaning no data has been read, only the catalog schema</div>"
-        )
+        ) + est_size_text
 
     def __getitem__(self, item):
         """Select a column or columns from the catalog."""
@@ -149,6 +228,16 @@ class HealpixDataset:
 
     def compute(self, progress_bar=True, tqdm_kwargs=None) -> npd.NestedFrame:
         """Compute dask distributed dataframe to pandas dataframe"""
+        est_size = self.est_size()
+        if est_size is not None and est_size > COMPUTE_SIZE_WARNING_THRESHOLD:
+            est_size_text = file_size(est_size * 1000)
+            logging.warning(
+                f"The estimated size of the catalog is {est_size_text}. Computing the catalog "
+                f"will load all data into memory and may cause your system to run out of memory."
+                f"Consider using `write_catalog` to write the catalog to disk, or selecting a subset of the "
+                f"catalog to compute."
+            )
+
         desc = tqdm_kwargs.pop("desc", "Computing Catalog") if tqdm_kwargs else "Computing Catalog"
         with TqdmCallback(desc=desc, disable=not progress_bar, **(tqdm_kwargs or {})):
             res = self._ddf.compute()
@@ -1073,6 +1162,7 @@ class HealpixDataset:
             hc_structure = self.hc_structure.__class__(
                 catalog_info=self.hc_structure.catalog_info,
                 pixels=[pixel],
+                original_partition_info=self.hc_structure.original_partition_info,
             )
             return self.__class__(output_ddf, partition_map, hc_structure)
 

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
     from matplotlib.figure import Figure
 
 
-COMPUTE_SIZE_WARNING_THRESHOLD_KB = 1_000  # 1 GB
+COMPUTE_SIZE_WARNING_THRESHOLD_KB = 1_000_000  # 1 GB
 
 
 # pylint: disable=protected-access,too-many-public-methods,too-many-lines,import-outside-toplevel,cyclic-import

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
     from matplotlib.figure import Figure
 
 
-COMPUTE_SIZE_WARNING_THRESHOLD_KB = 1_000_000  # 1 GB
+COMPUTE_SIZE_WARNING_THRESHOLD_KiB = 1 << 20  # 1 GiB
 
 
 # pylint: disable=protected-access,too-many-public-methods,too-many-lines,import-outside-toplevel,cyclic-import
@@ -130,7 +130,7 @@ class HealpixDataset:
         if any(size is None for size in original_field_sizes):
             snapshot_info = self.hc_structure.snapshot.catalog_info if self.hc_structure.snapshot else None
             original_size_per_row = (
-                snapshot_info.hats_estsize * 1000 / snapshot_info.total_rows
+                snapshot_info.hats_estsize * 1024 / snapshot_info.total_rows
                 if snapshot_info and snapshot_info.hats_estsize and snapshot_info.total_rows
                 else None
             )
@@ -152,13 +152,13 @@ class HealpixDataset:
                 non_fixed_column = True
 
         if non_fixed_column:
-            total_fixed_size_per_row = sum(estimate_type_size(field.type) or 0 for field in original_schema)
+            total_fixed_size_per_row = sum(size for size in original_field_sizes if size is not None)
             loaded_size += original_size_per_row - total_fixed_size_per_row
 
         return loaded_size / original_size_per_row
 
-    def est_size(self):
-        """Estimate the size of the catalog in KB
+    def est_size(self) -> float:
+        """Estimate the size of the catalog in KiB
 
         Size estimate is based on the estimated size in the metadata, scaled by the ratio of loaded to
         original columns and partitions.
@@ -180,7 +180,7 @@ class HealpixDataset:
         available_cols = len(self.all_columns)
         est_size = self.est_size()
         est_size_text = (
-            f"<div>This catalog has an estimated size of {file_size(est_size * 1000)}</div>"
+            f"<div>This catalog has an estimated size of {file_size(est_size * 1024)}</div>"
             if est_size is not None
             else ""
         )
@@ -242,7 +242,7 @@ class HealpixDataset:
         """Compute dask distributed dataframe to pandas dataframe"""
         est_size = self.est_size()
         if est_size is not None and est_size > COMPUTE_SIZE_WARNING_THRESHOLD_KB:
-            est_size_text = file_size(est_size * 1000)
+            est_size_text = file_size(est_size * 1024)
             logging.warning(
                 "The estimated size of the catalog is %s. Computing the catalog "
                 "will load all data into memory and may cause your system to run out of memory."

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -54,6 +54,9 @@ if TYPE_CHECKING:
     from matplotlib.figure import Figure
 
 
+COMPUTE_SIZE_WARNING_THRESHOLD_KB = 1_000  # 1 GB
+
+
 # pylint: disable=protected-access,too-many-public-methods,too-many-lines,import-outside-toplevel,cyclic-import
 class HealpixDataset:
     """LSDB Catalog to perform analysis of sky catalogs and efficient spatial operations."""
@@ -123,6 +126,20 @@ class HealpixDataset:
             except (AttributeError, TypeError, ValueError):
                 return None
 
+        original_field_sizes = [estimate_type_size(field.type) for field in original_schema]
+        if any(size is None for size in original_field_sizes):
+            snapshot_info = self.hc_structure.snapshot.catalog_info if self.hc_structure.snapshot else None
+            original_size_per_row = (
+                snapshot_info.hats_estsize * 1000 / snapshot_info.total_rows
+                if snapshot_info and snapshot_info.hats_estsize and snapshot_info.total_rows
+                else None
+            )
+        else:
+            original_size_per_row = sum(original_field_sizes)
+
+        if original_size_per_row is None:
+            return None
+
         # Compute total size of loaded columns (including index)
         loaded_size = 0
         non_fixed_column = False
@@ -133,12 +150,6 @@ class HealpixDataset:
                 loaded_size += field_size
             else:
                 non_fixed_column = True
-
-        original_size_per_row = (
-            self.hc_structure.catalog_info.hats_estsize / self.hc_structure.catalog_info.total_rows
-            if self.hc_structure.catalog_info.hats_estsize and self.hc_structure.catalog_info.total_rows
-            else None
-        )
 
         if non_fixed_column:
             total_fixed_size_per_row = sum([estimate_type_size(field.type) or 0 for field in original_schema])
@@ -153,10 +164,9 @@ class HealpixDataset:
         original columns and partitions.
         """
         if self.hc_structure.catalog_info.hats_estsize is not None:
-            if self.hc_structure.original_partition_info is not None:
-                partition_ratio = len(self.get_healpix_pixels()) / len(
-                    self.hc_structure.original_partition_info
-                )
+            snapshot = self.hc_structure.snapshot
+            if snapshot is not None and snapshot.partition_info is not None:
+                partition_ratio = len(self.get_healpix_pixels()) / len(snapshot.partition_info)
                 column_ratio = self._compute_column_size_ratio()
                 if column_ratio is not None:
                     return float(self.hc_structure.catalog_info.hats_estsize) * partition_ratio * column_ratio
@@ -229,7 +239,7 @@ class HealpixDataset:
     def compute(self, progress_bar=True, tqdm_kwargs=None) -> npd.NestedFrame:
         """Compute dask distributed dataframe to pandas dataframe"""
         est_size = self.est_size()
-        if est_size is not None and est_size > COMPUTE_SIZE_WARNING_THRESHOLD:
+        if est_size is not None and est_size > COMPUTE_SIZE_WARNING_THRESHOLD_KB:
             est_size_text = file_size(est_size * 1000)
             logging.warning(
                 f"The estimated size of the catalog is {est_size_text}. Computing the catalog "
@@ -1162,7 +1172,7 @@ class HealpixDataset:
             hc_structure = self.hc_structure.__class__(
                 catalog_info=self.hc_structure.catalog_info,
                 pixels=[pixel],
-                original_partition_info=self.hc_structure.original_partition_info,
+                snapshot=self.hc_structure.snapshot,
             )
             return self.__class__(output_ddf, partition_map, hc_structure)
 

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -23,7 +23,7 @@ from deprecated import deprecated  # type: ignore
 from hats.catalog.healpix_dataset.healpix_dataset import HealpixDataset as HCHealpixDataset
 from hats.pixel_math import HealpixPixel
 from hats.pixel_math.healpix_pixel_function import get_pixel_argsort
-from human_readable import file_size
+from human_readable import file_size, int_comma
 from mocpy import MOC
 from pandas._typing import Renamer
 from tqdm.dask import TqdmCallback
@@ -1783,11 +1783,11 @@ class HealpixDataset:
         orig_cat = hc.read_hats(self.hc_structure.catalog_path)
         expected_cat_rows = int(get_row_count(pixel_stats))
         row_pct = expected_cat_rows / int(orig_cat.catalog_info.total_rows) * 100
-        expected_cat_rows = f"{expected_cat_rows:,}"
+        expected_cat_rows = int_comma(expected_cat_rows)
 
         # In-memory and on disk estimates
-        mem_size = _human_file_size(get_mem_size(pixel_stats))
-        disk_size = _human_file_size(get_disk_size(pixel_stats))
+        mem_size = file_size(get_mem_size(pixel_stats), binary=True)
+        disk_size = file_size(get_disk_size(pixel_stats), binary=True)
 
         print(
             f"You selected {len(self.columns)}/{len(self.all_columns)} columns.\n"
@@ -1796,12 +1796,3 @@ class HealpixDataset:
             f"Expect up to {mem_size} in MEMORY.\n"
             f"Expect up to {disk_size} on DISK."
         )
-
-
-def _human_file_size(size_bytes):
-    """Convert bytes to human readable format (binary units only)."""
-    for unit in ["B", "KiB", "MiB", "GiB", "TiB"]:
-        if size_bytes < 1024:
-            return f"{size_bytes:.1f} {unit}"
-        size_bytes /= 1024
-    return f"{size_bytes:.2f} PiB"

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -166,6 +166,8 @@ class HealpixDataset:
         if self.hc_structure.catalog_info.hats_estsize is not None:
             snapshot = self.hc_structure.snapshot
             if snapshot is not None and snapshot.partition_info is not None:
+                if len(snapshot.partition_info) == 0:
+                    return 0.0
                 partition_ratio = len(self.get_healpix_pixels()) / len(snapshot.partition_info)
                 column_ratio = self._compute_column_size_ratio()
                 if column_ratio is not None:

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -241,7 +241,7 @@ class HealpixDataset:
     def compute(self, progress_bar=True, tqdm_kwargs=None) -> npd.NestedFrame:
         """Compute dask distributed dataframe to pandas dataframe"""
         est_size = self.est_size()
-        if est_size is not None and est_size > COMPUTE_SIZE_WARNING_THRESHOLD_KB:
+        if est_size is not None and est_size > COMPUTE_SIZE_WARNING_THRESHOLD_KiB:
             est_size_text = file_size(est_size * 1024)
             logging.warning(
                 "The estimated size of the catalog is %s. Computing the catalog "

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -135,13 +135,13 @@ class HealpixDataset:
                 else None
             )
         else:
-            original_size_per_row = sum(original_field_sizes)
+            original_size_per_row = sum(original_field_sizes)  # type: ignore[arg-type]
 
         if original_size_per_row is None:
             return None
 
         # Compute total size of loaded columns (including index)
-        loaded_size = 0
+        loaded_size = 0.0
         non_fixed_column = False
 
         for field in current_schema:
@@ -152,7 +152,7 @@ class HealpixDataset:
                 non_fixed_column = True
 
         if non_fixed_column:
-            total_fixed_size_per_row = sum([estimate_type_size(field.type) or 0 for field in original_schema])
+            total_fixed_size_per_row = sum(estimate_type_size(field.type) or 0 for field in original_schema)
             loaded_size += original_size_per_row - total_fixed_size_per_row
 
         return loaded_size / original_size_per_row
@@ -244,10 +244,11 @@ class HealpixDataset:
         if est_size is not None and est_size > COMPUTE_SIZE_WARNING_THRESHOLD_KB:
             est_size_text = file_size(est_size * 1000)
             logging.warning(
-                f"The estimated size of the catalog is {est_size_text}. Computing the catalog "
-                f"will load all data into memory and may cause your system to run out of memory."
-                f"Consider using `write_catalog` to write the catalog to disk, or selecting a subset of the "
-                f"catalog to compute."
+                "The estimated size of the catalog is %s. Computing the catalog "
+                "will load all data into memory and may cause your system to run out of memory."
+                "Consider using `write_catalog` to write the catalog to disk, or selecting a subset of the "
+                "catalog to compute.",
+                est_size_text,
             )
 
         desc = tqdm_kwargs.pop("desc", "Computing Catalog") if tqdm_kwargs else "Computing Catalog"

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
     from matplotlib.figure import Figure
 
 
-COMPUTE_SIZE_WARNING_THRESHOLD_KiB = 1 << 20  # 1 GiB
+COMPUTE_SIZE_WARNING_THRESHOLD_KiB = 1 << 20  # pylint: disable=invalid-name
 
 
 # pylint: disable=protected-access,too-many-public-methods,too-many-lines,import-outside-toplevel,cyclic-import
@@ -157,7 +157,7 @@ class HealpixDataset:
 
         return loaded_size / original_size_per_row
 
-    def est_size(self) -> float:
+    def est_size(self) -> float | None:
         """Estimate the size of the catalog in KiB
 
         Size estimate is based on the estimated size in the metadata, scaled by the ratio of loaded to
@@ -242,7 +242,7 @@ class HealpixDataset:
         """Compute dask distributed dataframe to pandas dataframe"""
         est_size = self.est_size()
         if est_size is not None and est_size > COMPUTE_SIZE_WARNING_THRESHOLD_KiB:
-            est_size_text = file_size(est_size * 1024)
+            est_size_text = file_size(int(est_size * 1024))
             logging.warning(
                 "The estimated size of the catalog is %s. Computing the catalog "
                 "will load all data into memory and may cause your system to run out of memory."

--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -256,7 +256,9 @@ class DataframeCatalogLoader:
         self.catalog_info.total_rows = total_rows
         moc = self._generate_moc() if self.should_generate_moc else None
         schema = self.schema if self.schema is not None else get_arrow_schema(ddf)
-        hc_structure = hc.catalog.Catalog(self.catalog_info, pixel_list, moc=moc, schema=schema)
+        hc_structure = hc.catalog.Catalog(
+            self.catalog_info, pixel_list, moc=moc, schema=schema, generate_snapshot=True
+        )
 
         # Recover NestedDtype (https://github.com/astronomy-commons/lsdb/issues/730)
         if len(self.dataframe.nested_columns) > 0:

--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -229,7 +229,7 @@ class DataframeCatalogLoader:
         """
         if kwargs is None:
             kwargs = {}
-        kwargs = kwargs | new_provenance_properties() | {"hats_estsize": self.df_total_memory // 1000}
+        kwargs = kwargs | new_provenance_properties() | {"hats_estsize": self.df_total_memory // 1024}
         if catalog_type and catalog_type not in (CatalogType.OBJECT, CatalogType.SOURCE, CatalogType.MAP):
             raise ValueError(f"Cannot create {catalog_type} type catalog via from_dataframe.")
         return TableProperties(

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -37,6 +37,7 @@ def test_kdtree_crossmatch(small_sky_catalog, small_sky_xmatch_catalog, xmatch_c
     assert xmatched_cat.hc_structure.catalog_info.dec_column in xmatched_cat.columns
     assert xmatched_cat.hc_structure.catalog_info.ra_column == "ra_small_sky"
     assert xmatched_cat.hc_structure.catalog_info.dec_column == "dec_small_sky"
+    assert xmatched_cat.est_size() is None
 
 
 def test_kdtree_crossmatch_nested(small_sky_catalog, small_sky_xmatch_catalog, xmatch_correct):

--- a/tests/lsdb/catalog/test_est_size.py
+++ b/tests/lsdb/catalog/test_est_size.py
@@ -1,0 +1,128 @@
+import logging
+
+import pyarrow as pa
+import pytest
+
+import lsdb
+from lsdb.catalog.dataset.healpix_dataset import COMPUTE_SIZE_WARNING_THRESHOLD_KB
+from lsdb.io.schema import get_arrow_schema
+
+
+def _row_bytes(schema):
+    """Sum the fixed-width byte sizes of all fields in a schema."""
+    return sum(f.type.bit_width // 8 for f in schema)
+
+
+def test_est_size_full_columns_equals_hats_estsize(small_sky_order1_catalog):
+    # All columns loaded: column_ratio = 1, partition_ratio = 1
+    hats_estsize = small_sky_order1_catalog.hc_structure.catalog_info.hats_estsize
+    assert small_sky_order1_catalog.est_size() == pytest.approx(float(hats_estsize))
+
+
+def test_est_size_default_column_subset(small_sky_order1_default_cols_catalog):
+    cat = small_sky_order1_default_cols_catalog
+    hats_estsize = cat.hc_structure.catalog_info.hats_estsize
+    original_schema = cat.hc_structure.original_schema
+    current_schema = get_arrow_schema(cat._ddf)
+    expected = hats_estsize * (_row_bytes(current_schema) / _row_bytes(original_schema))
+    assert cat.est_size() == pytest.approx(expected)
+
+
+def test_est_size_explicit_two_column_subset(small_sky_order1_default_cols_catalog):
+    cat = small_sky_order1_default_cols_catalog[["ra", "dec"]]
+    hats_estsize = cat.hc_structure.catalog_info.hats_estsize
+    original_schema = cat.hc_structure.original_schema
+    current_schema = get_arrow_schema(cat._ddf)
+    expected = hats_estsize * (_row_bytes(current_schema) / _row_bytes(original_schema))
+    assert cat.est_size() == pytest.approx(expected)
+
+
+def test_est_size_scales_with_partition_subset(small_sky_order1_catalog):
+    cat = small_sky_order1_catalog
+    hats_estsize = cat.hc_structure.catalog_info.hats_estsize
+    original_n_partitions = len(cat.hc_structure.snapshot.partition_info)
+    pixel = cat.get_healpix_pixels()[0]
+    subset = cat.search(lsdb.PixelSearch([pixel]))
+    assert len(subset.get_healpix_pixels()) == 1
+    expected = float(hats_estsize) * (1 / original_n_partitions)
+    assert subset.est_size() == pytest.approx(expected)
+
+
+def test_est_size_column_and_partition_ratios_combine(small_sky_order1_default_cols_catalog):
+    cat = small_sky_order1_default_cols_catalog
+    hats_estsize = cat.hc_structure.catalog_info.hats_estsize
+    original_schema = cat.hc_structure.original_schema
+    original_n_partitions = len(cat.hc_structure.snapshot.partition_info)
+    pixel = cat.get_healpix_pixels()[0]
+    subset = cat[["ra", "dec"]].search(lsdb.PixelSearch([pixel]))
+    current_schema = get_arrow_schema(subset._ddf)
+    expected = (
+        hats_estsize
+        * (1 / original_n_partitions)
+        * (_row_bytes(current_schema) / _row_bytes(original_schema))
+    )
+    assert subset.est_size() == pytest.approx(expected)
+
+
+def test_est_size_nested(small_sky_with_nested_sources):
+    cat = small_sky_with_nested_sources[["sources"]]
+    assert cat.est_size() < small_sky_with_nested_sources.est_size()
+    assert cat.est_size() > small_sky_with_nested_sources.est_size() * 0.5
+
+
+def test_compute_warns_when_estimated_size_exceeds_threshold(small_sky_order1_catalog, mocker, caplog):
+    mocker.patch.object(
+        small_sky_order1_catalog, "est_size", return_value=COMPUTE_SIZE_WARNING_THRESHOLD_KB + 1
+    )
+    with caplog.at_level(logging.WARNING):
+        small_sky_order1_catalog.compute(progress_bar=False)
+    assert "estimated size" in caplog.text.lower()
+
+
+def test_compute_does_not_warn_below_threshold(small_sky_order1_catalog, mocker, caplog):
+    mocker.patch.object(
+        small_sky_order1_catalog, "est_size", return_value=COMPUTE_SIZE_WARNING_THRESHOLD_KB - 1
+    )
+    with caplog.at_level(logging.WARNING):
+        small_sky_order1_catalog.compute(progress_bar=False)
+    assert "estimated size" not in caplog.text.lower()
+
+
+def test_repr_html_includes_estimated_size(small_sky_order1_catalog):
+    html = small_sky_order1_catalog._repr_html_()
+    est_size = small_sky_order1_catalog.est_size()
+    assert "estimated size" in html.lower()
+    assert f"{est_size:.1f} KB" in html
+
+
+def test_repr_html_omits_size_without_snapshot(small_sky_order1_catalog):
+    small_sky_order1_catalog.hc_structure.snapshot = None
+    html = small_sky_order1_catalog._repr_html_()
+    assert "estimated size" not in html.lower()
+
+
+def test_est_size_none_without_snapshot(small_sky_order1_catalog):
+    small_sky_order1_catalog.hc_structure.snapshot = None
+    assert small_sky_order1_catalog.est_size() is None
+
+
+def test_est_size_none_without_estsize(small_sky_order1_catalog):
+    small_sky_order1_catalog.hc_structure.catalog_info.hats_estsize = None
+    assert small_sky_order1_catalog.est_size() is None
+
+
+def test_est_size_none_when_column_not_in_original_schema(small_sky_order1_default_cols_catalog, mocker):
+    extra_schema = pa.schema([pa.field("ra", pa.float64()), pa.field("derived_col", pa.int64())])
+    mocker.patch("lsdb.catalog.dataset.healpix_dataset.get_arrow_schema", return_value=extra_schema)
+    assert small_sky_order1_default_cols_catalog.est_size() is None
+
+
+def test_est_size_none_for_variable_width_original_schema_without_total_rows(
+    small_sky_order1_default_cols_catalog,
+):
+    # Set original_schema to a variable-width type so the hats_estsize/total_rows path
+    # is taken, then remove total_rows to force None.
+    string_schema = pa.schema([pa.field("name", pa.string()), pa.field("ra", pa.float64())])
+    small_sky_order1_default_cols_catalog.hc_structure.snapshot.schema = string_schema
+    small_sky_order1_default_cols_catalog.hc_structure.snapshot.catalog_info.total_rows = None
+    assert small_sky_order1_default_cols_catalog.est_size() is None

--- a/tests/lsdb/catalog/test_est_size.py
+++ b/tests/lsdb/catalog/test_est_size.py
@@ -120,9 +120,16 @@ def test_est_size_none_when_column_not_in_original_schema(small_sky_order1_defau
 def test_est_size_none_for_variable_width_original_schema_without_total_rows(
     small_sky_order1_default_cols_catalog,
 ):
-    # Set original_schema to a variable-width type so the hats_estsize/total_rows path
-    # is taken, then remove total_rows to force None.
+    # Replace snapshot with one whose schema has a variable-width field (triggering the
+    # hats_estsize/total_rows path) and whose catalog_info has total_rows=None.
+    from hats.catalog.catalog_snapshot import CatalogSnapshot
+
     string_schema = pa.schema([pa.field("name", pa.string()), pa.field("ra", pa.float64())])
-    small_sky_order1_default_cols_catalog.hc_structure.snapshot.schema = string_schema
-    small_sky_order1_default_cols_catalog.hc_structure.snapshot.catalog_info.total_rows = None
+    original_snapshot = small_sky_order1_default_cols_catalog.hc_structure.snapshot
+    new_catalog_info = original_snapshot.catalog_info.copy_and_update(total_rows=None)
+    small_sky_order1_default_cols_catalog.hc_structure.snapshot = CatalogSnapshot(
+        schema=string_schema,
+        catalog_info=new_catalog_info,
+        partition_info=original_snapshot.partition_info,
+    )
     assert small_sky_order1_default_cols_catalog.est_size() is None

--- a/tests/lsdb/catalog/test_est_size.py
+++ b/tests/lsdb/catalog/test_est_size.py
@@ -2,6 +2,7 @@ import logging
 
 import pyarrow as pa
 import pytest
+from hats.catalog.catalog_snapshot import CatalogSnapshot
 
 import lsdb
 from lsdb.catalog.dataset.healpix_dataset import COMPUTE_SIZE_WARNING_THRESHOLD_KB
@@ -120,9 +121,6 @@ def test_est_size_none_when_column_not_in_original_schema(small_sky_order1_defau
 def test_est_size_none_for_variable_width_original_schema_without_total_rows(
     small_sky_order1_default_cols_catalog,
 ):
-    # Replace snapshot with one whose schema has a variable-width field (triggering the
-    # hats_estsize/total_rows path) and whose catalog_info has total_rows=None.
-    from hats.catalog.catalog_snapshot import CatalogSnapshot
 
     string_schema = pa.schema([pa.field("name", pa.string()), pa.field("ra", pa.float64())])
     original_snapshot = small_sky_order1_default_cols_catalog.hc_structure.snapshot

--- a/tests/lsdb/catalog/test_est_size.py
+++ b/tests/lsdb/catalog/test_est_size.py
@@ -73,7 +73,7 @@ def test_est_size_nested(small_sky_with_nested_sources):
 
 def test_compute_warns_when_estimated_size_exceeds_threshold(small_sky_order1_catalog, mocker, caplog):
     mocker.patch.object(
-        small_sky_order1_catalog, "est_size", return_value=COMPUTE_SIZE_WARNING_THRESHOLD_KB + 1
+        small_sky_order1_catalog, "est_size", return_value=COMPUTE_SIZE_WARNING_THRESHOLD_KiB + 1
     )
     with caplog.at_level(logging.WARNING):
         small_sky_order1_catalog.compute(progress_bar=False)
@@ -82,7 +82,7 @@ def test_compute_warns_when_estimated_size_exceeds_threshold(small_sky_order1_ca
 
 def test_compute_does_not_warn_below_threshold(small_sky_order1_catalog, mocker, caplog):
     mocker.patch.object(
-        small_sky_order1_catalog, "est_size", return_value=COMPUTE_SIZE_WARNING_THRESHOLD_KB - 1
+        small_sky_order1_catalog, "est_size", return_value=COMPUTE_SIZE_WARNING_THRESHOLD_KiB - 1
     )
     with caplog.at_level(logging.WARNING):
         small_sky_order1_catalog.compute(progress_bar=False)
@@ -91,9 +91,9 @@ def test_compute_does_not_warn_below_threshold(small_sky_order1_catalog, mocker,
 
 def test_repr_html_includes_estimated_size(small_sky_order1_catalog):
     html = small_sky_order1_catalog._repr_html_()
-    est_size = small_sky_order1_catalog.est_size()
+    est_size_kb = small_sky_order1_catalog.est_size() * 1024 / 1000
     assert "estimated size" in html.lower()
-    assert f"{est_size:.1f} KB" in html
+    assert f"{est_size_kb:.1f} KB" in html
 
 
 def test_repr_html_omits_size_without_snapshot(small_sky_order1_catalog):

--- a/tests/lsdb/catalog/test_est_size.py
+++ b/tests/lsdb/catalog/test_est_size.py
@@ -5,7 +5,7 @@ import pytest
 from hats.catalog.catalog_snapshot import CatalogSnapshot
 
 import lsdb
-from lsdb.catalog.dataset.healpix_dataset import COMPUTE_SIZE_WARNING_THRESHOLD_KB
+from lsdb.catalog.dataset.healpix_dataset import COMPUTE_SIZE_WARNING_THRESHOLD_KiB
 from lsdb.io.schema import get_arrow_schema
 
 

--- a/tests/lsdb/catalog/test_join.py
+++ b/tests/lsdb/catalog/test_join.py
@@ -54,6 +54,7 @@ def test_small_sky_join_small_sky_order1(small_sky_catalog, small_sky_order1_cat
     helpers.assert_divisions_are_correct(joined)
     helpers.assert_schema_correct(joined)
     assert not joined.hc_structure.on_disk
+    assert joined.est_size() is None
 
 
 def test_small_sky_join_overlapping_suffix(small_sky_catalog, small_sky_order1_catalog, helpers):

--- a/tests/lsdb/loaders/dataframe/test_from_dataframe.py
+++ b/tests/lsdb/loaders/dataframe/test_from_dataframe.py
@@ -68,6 +68,8 @@ def test_from_dataframe(small_sky_order1_df, small_sky_order1_catalog, helpers):
     # The arrow schema was automatically inferred
     helpers.assert_schema_correct(catalog)
     assert isinstance(catalog.compute(), npd.NestedFrame)
+    assert catalog.hc_structure.snapshot is not None
+    assert catalog.hc_structure.original_schema == catalog.hc_structure.schema
 
 
 def test_from_dataframe_catalog_of_invalid_type(small_sky_order1_df, small_sky_order1_catalog):


### PR DESCRIPTION
Adds the `est_size` function to estimate lazy size from hats properties and currently loaded columns and partitions. Displays this with catalog repr and warns user if larger than 1GB during compute.

Closes #1083 