### PR TITLE
Update to use latest hats snapshot changes

### DIFF
--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -291,7 +291,7 @@ class HealpixDataset:
             pixels=hc_structure.pixel_tree,
             catalog_path=hc_structure.catalog_path,
             schema=hc_structure.schema if updated_schema is None else updated_schema,
-            original_schema=hc_structure.original_schema,
+            snapshot=hc_structure.snapshot,
             moc=hc_structure.moc,
         )
 

--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -256,7 +256,9 @@ class DataframeCatalogLoader:
         self.catalog_info.total_rows = total_rows
         moc = self._generate_moc() if self.should_generate_moc else None
         schema = self.schema if self.schema is not None else get_arrow_schema(ddf)
-        hc_structure = hc.catalog.Catalog(self.catalog_info, pixel_list, moc=moc, schema=schema)
+        hc_structure = hc.catalog.Catalog(
+            self.catalog_info, pixel_list, moc=moc, schema=schema, generate_snapshot=True
+        )
 
         # Recover NestedDtype (https://github.com/astronomy-commons/lsdb/issues/730)
         if len(self.dataframe.nested_columns) > 0:

--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -229,7 +229,7 @@ class DataframeCatalogLoader:
         """
         if kwargs is None:
             kwargs = {}
-        kwargs = kwargs | new_provenance_properties(hats_estsize=self.df_total_memory)
+        kwargs = kwargs | new_provenance_properties() | {"hats_estsize": self.df_total_memory // 1000}
         if catalog_type and catalog_type not in (CatalogType.OBJECT, CatalogType.SOURCE, CatalogType.MAP):
             raise ValueError(f"Cannot create {catalog_type} type catalog via from_dataframe.")
         return TableProperties(
@@ -256,9 +256,7 @@ class DataframeCatalogLoader:
         self.catalog_info.total_rows = total_rows
         moc = self._generate_moc() if self.should_generate_moc else None
         schema = self.schema if self.schema is not None else get_arrow_schema(ddf)
-        hc_structure = hc.catalog.Catalog(
-            self.catalog_info, pixel_list, moc=moc, schema=schema, generate_snapshot=True
-        )
+        hc_structure = hc.catalog.Catalog(self.catalog_info, pixel_list, moc=moc, schema=schema)
 
         # Recover NestedDtype (https://github.com/astronomy-commons/lsdb/issues/730)
         if len(self.dataframe.nested_columns) > 0:

--- a/src/lsdb/loaders/dataframe/margin_catalog_generator.py
+++ b/src/lsdb/loaders/dataframe/margin_catalog_generator.py
@@ -115,7 +115,7 @@ class MarginCatalogGenerator:
         catalog_info = self._create_catalog_info(**self.catalog_info_kwargs, total_rows=total_rows)
         margin_pixels = list(ddf_pixel_map.keys())
         margin_structure = hc.catalog.MarginCatalog(
-            catalog_info, margin_pixels, schema=self.hc_structure.schema
+            catalog_info, margin_pixels, schema=self.hc_structure.schema, generate_snapshot=True
         )
         return MarginCatalog(ddf, ddf_pixel_map, margin_structure)
 

--- a/tests/lsdb/loaders/dataframe/test_from_dataframe.py
+++ b/tests/lsdb/loaders/dataframe/test_from_dataframe.py
@@ -210,9 +210,11 @@ def test_from_dataframe_large_input(small_sky_order1_catalog, helpers):
     expected_dict = {
         k: v
         for k, v in original_catalog_info.explicit_dict().items()
-        if k not in ["skymap_order", "moc_sky_fraction"]
+        if k not in ["skymap_order", "moc_sky_fraction", "hats_estsize"]
     }
-    assert catalog.hc_structure.catalog_info.explicit_dict() == expected_dict
+    test_dict = catalog.hc_structure.catalog_info.explicit_dict()
+    test_dict.pop("hats_estsize", None)
+    assert test_dict == expected_dict
     assert catalog.hc_structure.catalog_info.__pydantic_extra__["obs_regime"] == "Optical"
     assert catalog.hc_structure.catalog_info.__pydantic_extra__["hats_builder"].startswith("lsdb")
     # Index is set to spatial index


### PR DESCRIPTION
Introduced in astronomy-commons/hats#658 that the original_schema has been replaced with snapshot. There was also a change adding hats_estsize as an explicit hats property, which revealed a bug with how estsize is calculated in from_dataframe