### PR TITLE
Change `align_and_apply` to use map_partitions

### DIFF
--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -875,7 +875,7 @@ class HealpixDataset:
         return self.search(OrderSearch(min_order, max_order))
 
     def pixel_search(
-        self, pixels: tuple[int, int] | HealpixPixel | list[tuple[int, int] | HealpixPixel]
+        self, pixels: tuple[int, int] | HealpixPixel | list[tuple[int, int] | HealpixPixel], fine=False
     ) -> Self:
         """Finds all catalog pixels that overlap with the requested pixel set.
 
@@ -889,7 +889,7 @@ class HealpixDataset:
         Self
             A new Catalog containing only the pixels that overlap with the requested pixel set.
         """
-        return self.search(PixelSearch(pixels))
+        return self.search(PixelSearch(pixels, fine=fine))
 
     def moc_search(self, moc: MOC, fine: bool = True) -> Self:
         """Finds all catalog points that are contained within a moc.

--- a/src/lsdb/core/search/region_search.py
+++ b/src/lsdb/core/search/region_search.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import astropy.units as u
 import nested_pandas as npd
+import numpy as np
 import pandas as pd
 from hats.catalog import TableProperties
 from hats.pixel_math import HealpixPixel, get_healpix_pixel, spatial_index
@@ -147,15 +148,16 @@ class OrderSearch(AbstractSearch):
         return frame
 
 
-class PixelSearch(AbstractSearch):
+class PixelSearch(MOCSearch):
     """Filter the catalog by HEALPix pixels.
 
     Filters partitions in the catalog to those that are in a specified pixel set.
     Does not filter points inside those partitions.
     """
 
-    def __init__(self, pixels: tuple[int, int] | HealpixPixel | list[tuple[int, int] | HealpixPixel]):
-        super().__init__(fine=False)
+    def __init__(
+        self, pixels: tuple[int, int] | HealpixPixel | list[tuple[int, int] | HealpixPixel], fine=False
+    ):
         if isinstance(pixels, tuple):
             self.pixels = [get_healpix_pixel(pixels)]
         elif isinstance(pixels, HealpixPixel):
@@ -166,6 +168,11 @@ class PixelSearch(AbstractSearch):
             self.pixels = [get_healpix_pixel(pix) for pix in pixels]
         else:
             raise ValueError("Unsupported input for PixelSearch")
+        ipix = np.array([pix.pixel for pix in self.pixels])
+        order = np.array([pix.order for pix in self.pixels])
+        max_order = np.max(order)
+        moc = MOC.from_healpix_cells(ipix, order, max_order)
+        super().__init__(moc, fine)
 
     @classmethod
     def from_radec(cls, ra: float | list[float], dec: float | list[float]) -> PixelSearch:
@@ -186,14 +193,6 @@ class PixelSearch(AbstractSearch):
         pixels = list(spatial_index.compute_spatial_index(ra, dec))
         pixels = [(spatial_index.SPATIAL_INDEX_ORDER, pix) for pix in pixels]
         return cls(pixels)
-
-    def perform_hc_catalog_filter(self, hc_structure: HCCatalogTypeVar) -> HCCatalogTypeVar:
-        """Filters catalog pixels according to the provided pixel set"""
-        return hc_structure.filter_from_pixel_list(self.pixels)
-
-    def search_points(self, frame: npd.NestedFrame, _) -> npd.NestedFrame:
-        """Determine the search results within a data frame"""
-        return frame
 
 
 class PolygonSearch(AbstractSearch):

--- a/src/lsdb/dask/concat_catalog_data.py
+++ b/src/lsdb/dask/concat_catalog_data.py
@@ -435,6 +435,7 @@ def concat_catalog_data(
     joined_partitions = align_and_apply(
         [(left, left_pixels), (right, right_pixels), (None, aligned_pixels)],
         perform_concat,
+        meta_df,
         aligned_meta=meta_df,
         **kwargs,
     )
@@ -499,6 +500,7 @@ def concat_margin_data(
             (None, aligned_pixels),
         ],
         perform_margin_concat,
+        meta_df,
         margin_radius=margin_radius,
         aligned_meta=meta_df,
         **kwargs,

--- a/src/lsdb/dask/concat_catalog_data.py
+++ b/src/lsdb/dask/concat_catalog_data.py
@@ -440,7 +440,7 @@ def concat_catalog_data(
         **kwargs,
     )
 
-    return construct_catalog_args(joined_partitions, meta_df, alignment)
+    return construct_catalog_args(joined_partitions, alignment)
 
 
 # pylint: disable=too-many-locals
@@ -506,7 +506,7 @@ def concat_margin_data(
         **kwargs,
     )
 
-    return construct_catalog_args(joined_partitions, meta_df, alignment)
+    return construct_catalog_args(joined_partitions, alignment)
 
 
 # pylint: disable=too-many-locals

--- a/src/lsdb/dask/crossmatch_catalog_data.py
+++ b/src/lsdb/dask/crossmatch_catalog_data.py
@@ -384,7 +384,7 @@ def crossmatch_catalog_data(
         meta_df,
     )
 
-    nf, pixel_map, alignment = construct_catalog_args(joined_partitions, meta_df, alignment)
+    nf, pixel_map, alignment = construct_catalog_args(joined_partitions, alignment)
 
     return nf, pixel_map, alignment
 
@@ -456,4 +456,4 @@ def crossmatch_catalog_data_nested(
         meta_df,
     )
 
-    return construct_catalog_args(joined_partitions, meta_df, alignment)
+    return construct_catalog_args(joined_partitions, alignment)

--- a/src/lsdb/dask/crossmatch_catalog_data.py
+++ b/src/lsdb/dask/crossmatch_catalog_data.py
@@ -376,6 +376,7 @@ def crossmatch_catalog_data(
     joined_partitions = align_and_apply(
         [(left, left_pixels), (right, right_pixels), (right.margin, right_pixels), (None, aligned_pixels)],
         perform_crossmatch,
+        meta_df,
         algorithm,
         how,
         suffixes,
@@ -448,6 +449,7 @@ def crossmatch_catalog_data_nested(
     joined_partitions = align_and_apply(
         [(left, left_pixels), (right, right_pixels), (right.margin, right_pixels), (None, aligned_pixels)],
         perform_crossmatch_nested,
+        meta_df,
         algorithm,
         how,
         nested_column_name,

--- a/src/lsdb/dask/join_catalog_data.py
+++ b/src/lsdb/dask/join_catalog_data.py
@@ -181,7 +181,7 @@ def perform_join_nested(
             spatial_index_order=left_catalog_info.healpix_order,
         )
 
-    right_joined_df = right_meta if right is None else concat_partition_and_margin(right, right_margin)
+    right_joined_df = right_meta if right_pixel is None else concat_partition_and_margin(right, right_margin)
 
     right_joined_df = pack_flat(npd.NestedFrame(right_joined_df.set_index(right_on))).rename(right_name)
 

--- a/src/lsdb/dask/join_catalog_data.py
+++ b/src/lsdb/dask/join_catalog_data.py
@@ -431,7 +431,7 @@ def join_catalog_data_on(
         suffix_method,
     )
 
-    return construct_catalog_args(joined_partitions, meta_df, alignment)
+    return construct_catalog_args(joined_partitions, alignment)
 
 
 def join_catalog_data_nested(
@@ -499,7 +499,7 @@ def join_catalog_data_nested(
         how,
     )
 
-    return construct_catalog_args(joined_partitions, meta_df, alignment)
+    return construct_catalog_args(joined_partitions, alignment)
 
 
 def join_catalog_data_through(
@@ -604,7 +604,7 @@ def join_catalog_data_through(
         suffix_method,
     )
 
-    return construct_catalog_args(joined_partitions, meta_df, alignment)
+    return construct_catalog_args(joined_partitions, alignment)
 
 
 def merge_asof_catalog_data(
@@ -668,4 +668,4 @@ def merge_asof_catalog_data(
         suffix_method,
     )
 
-    return construct_catalog_args(joined_partitions, meta_df, alignment)
+    return construct_catalog_args(joined_partitions, alignment)

--- a/src/lsdb/dask/join_catalog_data.py
+++ b/src/lsdb/dask/join_catalog_data.py
@@ -417,17 +417,18 @@ def join_catalog_data_on(
 
     left_pixels, right_pixels = get_healpix_pixels_from_alignment(alignment)
 
+    meta_df = generate_meta_df_for_joined_tables(
+        (left, right), suffixes, suffix_method=suffix_method, log_changes=log_changes
+    )
+
     joined_partitions = align_and_apply(
         [(left, left_pixels), (right, right_pixels), (right.margin, right_pixels)],
         perform_join_on,
+        meta_df,
         left_on,
         right_on,
         suffixes,
         suffix_method,
-    )
-
-    meta_df = generate_meta_df_for_joined_tables(
-        (left, right), suffixes, suffix_method=suffix_method, log_changes=log_changes
     )
 
     return construct_catalog_args(joined_partitions, meta_df, alignment)
@@ -485,17 +486,18 @@ def join_catalog_data_nested(
     left_pixels, right_pixels = get_healpix_pixels_from_alignment(alignment)
     aligned_pixels = get_aligned_pixels_from_alignment(alignment)
 
+    meta_df = generate_meta_df_for_nested_tables([left], right, nested_column_name, join_column_name=right_on)
+
     joined_partitions = align_and_apply(
         [(left, left_pixels), (right, right_pixels), (right.margin, right_pixels), (None, aligned_pixels)],
         perform_join_nested,
+        meta_df,
         left_on,
         right_on,
         nested_column_name,
         right._ddf._meta,  # pylint: disable=protected-access
         how,
     )
-
-    meta_df = generate_meta_df_for_nested_tables([left], right, nested_column_name, join_column_name=right_on)
 
     return construct_catalog_args(joined_partitions, meta_df, alignment)
 
@@ -577,18 +579,6 @@ def join_catalog_data_through(
     alignment = align_catalogs_with_association(left, association, right)
     left_pixels, assoc_pixels, right_pixels = get_healpix_pixels_from_association(alignment)
 
-    joined_partitions = align_and_apply(
-        [
-            (left, left_pixels),
-            (right, right_pixels),
-            (right.margin, right_pixels),
-            (association, assoc_pixels),
-        ],
-        perform_join_through,
-        suffixes,
-        suffix_method,
-    )
-
     association_join_columns = [
         association.hc_structure.catalog_info.primary_column_association,
         association.hc_structure.catalog_info.join_column_association,
@@ -599,6 +589,19 @@ def join_catalog_data_through(
     extra_df = association._ddf._meta.drop(non_joining_columns + association_join_columns, axis=1)
     meta_df = generate_meta_df_for_joined_tables(
         (left, right), suffixes, extra_columns=extra_df, suffix_method=suffix_method, log_changes=log_changes
+    )
+
+    joined_partitions = align_and_apply(
+        [
+            (left, left_pixels),
+            (right, right_pixels),
+            (right.margin, right_pixels),
+            (association, assoc_pixels),
+        ],
+        perform_join_through,
+        meta_df,
+        suffixes,
+        suffix_method,
     )
 
     return construct_catalog_args(joined_partitions, meta_df, alignment)
@@ -652,12 +655,17 @@ def merge_asof_catalog_data(
 
     left_pixels, right_pixels = get_healpix_pixels_from_alignment(alignment)
 
-    joined_partitions = align_and_apply(
-        [(left, left_pixels), (right, right_pixels)], perform_merge_asof, suffixes, direction, suffix_method
-    )
-
     meta_df = generate_meta_df_for_joined_tables(
         (left, right), suffixes, suffix_method=suffix_method, log_changes=log_changes
+    )
+
+    joined_partitions = align_and_apply(
+        [(left, left_pixels), (right, right_pixels)],
+        perform_merge_asof,
+        meta_df,
+        suffixes,
+        direction,
+        suffix_method,
     )
 
     return construct_catalog_args(joined_partitions, meta_df, alignment)

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Callable, Literal, Sequence
 
+import dask.dataframe as dd
+
 import hats.pixel_math.healpix_shim as hp
 import nested_pandas as npd
 import numpy as np
@@ -481,8 +483,12 @@ def _merge_association_alignments(left_alignment: PixelAlignment, final_alignmen
 
 
 def align_and_apply(
-    catalog_mappings: list[tuple[HealpixDataset | None, list[HealpixPixel]]], func: Callable, *args, **kwargs
-) -> list[Delayed]:
+    catalog_mappings: list[tuple[HealpixDataset | None, list[HealpixPixel]]],
+    func: Callable,
+    meta: npd.NestedFrame | pd.DataFrame | pd.Series,
+    *args,
+    **kwargs,
+) -> nd.NestedFrame:
     """Aligns catalogs to a given ordering of pixels and applies a function each set of aligned partitions
 
     Parameters
@@ -531,27 +537,48 @@ def align_and_apply(
     ]
 
     # aligns the catalog's partitions to the given pixels for each catalog
-    aligned_partitions = [align_catalog_to_partitions(cat, pixels) for (cat, pixels) in catalog_mappings]
+    aligned_ndfs = [align_catalog_to_partitions(cat, pixels) for (cat, pixels) in catalog_mappings]
+    pixel_ndfs = [create_pixel_ndfs(ps) for ps in pixels]
 
-    # defines an inner function that can be vectorized to apply the given function to each of the partitions
-    # with the additional arguments including as the hc_structures and any specified additional arguments
-    def apply_func(*partitions_and_pixels):
-        return perform_align_and_apply_func(
-            len(aligned_partitions), func, *partitions_and_pixels, *catalog_infos, *args, **kwargs
-        )
+    result = dd.map_partitions(
+        perform_align_and_apply_func,
+        len(aligned_ndfs),
+        func,
+        *aligned_ndfs,
+        *pixel_ndfs,
+        *catalog_infos,
+        *args,
+        **kwargs,
+        meta=meta,
+    )
+    return result
 
-    resulting_partitions = np.vectorize(apply_func)(*aligned_partitions, *pixels)
-    return resulting_partitions
+
+def create_pixel_ndfs(pixels: list[HealpixPixel | None]) -> npd.NestedFrame:
+    return nd.NestedFrame.from_dict(
+        {
+            "order": [p.order if p is not None else -99 for p in pixels],
+            "pixel": [p.pixel if p is not None else -99 for p in pixels],
+        },
+        npartitions=len(pixels),
+    )
 
 
-@delayed
 def perform_align_and_apply_func(num_partitions, func, *args, **kwargs):
     """Performs the function inside `align_and_apply` and updates hive columns"""
     filtered_parts = []
     partitions = args[:num_partitions]
-    pixels = args[num_partitions : 2 * num_partitions]
+    pixel_dfs = args[num_partitions : 2 * num_partitions]
+    pixels = [
+        HealpixPixel(df.iloc[0]["order"], df.iloc[0]["pixel"]) if df.iloc[0]["order"] >= 0 else None
+        for df in pixel_dfs
+    ]
     for df in partitions:
-        filtered_parts.append(remove_hips_columns(df))
+        if len(df.columns) > 0:
+            filtered_parts.append(remove_hips_columns(df))
+        else:
+            filtered_parts.append(None)
+
     return func(
         *filtered_parts,
         *pixels,
@@ -664,7 +691,7 @@ def filter_by_spatial_index_to_margin(
 
 
 def construct_catalog_args(
-    partitions: list[Delayed], meta_df: npd.NestedFrame, alignment: PixelAlignment
+    partitions: nd.NestedFrame, meta_df: npd.NestedFrame, alignment: PixelAlignment
 ) -> tuple[nd.NestedFrame, DaskDFPixelMap, PixelAlignment]:
     """Constructs the arguments needed to create a catalog from a list of delayed partitions
 
@@ -686,10 +713,7 @@ def construct_catalog_args(
     # generate dask df partition map from alignment
     partition_map = get_partition_map_from_alignment_pixels(alignment.pixel_mapping)
     # create dask df from delayed partitions
-    divisions = get_pixels_divisions(list(partition_map.keys()))
-    partitions = partitions if len(partitions) > 0 else [delayed(meta_df.copy())]
-    ddf = nd.NestedFrame.from_delayed(partitions, meta=meta_df, divisions=divisions, verify_meta=True)
-    return ddf, partition_map, alignment
+    return partitions, partition_map, alignment
 
 
 def get_healpix_pixels_from_alignment(
@@ -961,15 +985,15 @@ def get_partition_map_from_alignment_pixels(join_pixels: pd.DataFrame) -> DaskDF
 
 
 def align_catalog_to_partitions(
-    catalog: HealpixDataset | None, pixels: list[HealpixPixel]
-) -> list[Delayed | None]:
+    catalog: HealpixDataset | None, pixels: list[HealpixPixel | None]
+) -> nd.NestedFrame:
     """Aligns the partitions of a Catalog to a dataframe with HEALPix pixels in each row
 
     Parameters
     ----------
     catalog : HealpixDataset | None
         The catalog to align
-    pixels : list[HealpixPixel]
+    pixels : list[HealpixPixel | None]
         The list of HealpixPixels specifying the order of partitions
 
     Returns
@@ -979,17 +1003,19 @@ def align_catalog_to_partitions(
         order they appear in the input dataframe
     """
     if catalog is None:
-        return [None] * len(pixels)
-    dfs = catalog.to_delayed()
-    get_partition = np.vectorize(
-        lambda pix: (
-            dfs[catalog.get_partition_index(pix.order, pix.pixel)]
+        empty_ddf = nd.NestedFrame.from_single_partition(pd.DataFrame())
+        return empty_ddf.partitions[[0] * len(pixels)]
+    partition_indexes = [
+        (
+            catalog.get_partition_index(pix.order, pix.pixel)
             if pix is not None and pix in catalog.hc_structure.pixel_tree
-            else None
+            else -1
         )
-    )
-    partitions = get_partition(pixels)
-    return list(partitions)
+        for pix in pixels
+    ]
+    empty_ndf = nd.NestedFrame.from_single_partition(catalog._ddf._meta)
+    ndf = dd.concat([catalog._ddf, empty_ndf], axis=0, ignore_unknown_divisions=True)
+    return ndf.partitions[partition_indexes]
 
 
 def create_merged_catalog_info(

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -231,6 +231,8 @@ def concat_partition_and_margin(
     """
     if margin is None:
         return partition
+    if partition is None:
+        return margin
     joined_df = pd.concat([partition, margin])
     return npd.NestedFrame(joined_df)
 

--- a/src/lsdb/dask/merge_catalog_functions.py
+++ b/src/lsdb/dask/merge_catalog_functions.py
@@ -1,18 +1,16 @@
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines, protected-access
 from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING, Callable, Literal, Sequence
 
 import dask.dataframe as dd
-
 import hats.pixel_math.healpix_shim as hp
 import nested_pandas as npd
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
 from dask.dataframe.dispatch import make_meta
-from dask.delayed import Delayed, delayed
 from hats.catalog import TableProperties
 from hats.io import paths
 from hats.pixel_math import HealpixPixel
@@ -25,7 +23,6 @@ from hats.pixel_tree.pixel_alignment import align_with_mocs
 from tabulate import tabulate
 
 import lsdb.nested as nd
-from lsdb.dask.divisions import get_pixels_divisions
 from lsdb.types import DaskDFPixelMap
 
 if TYPE_CHECKING:
@@ -517,6 +514,9 @@ def align_and_apply(
                 **kwargs
             ):
             ...
+    meta : npd.NestedFrame | pd.DataFrame | pd.Series
+        The meta dataframe to use for the resulting delayed object. This should be a nested dataframe with the
+         same columns as the dataframe returned by the function
     *args
         Additional arguments to pass to the function
     **kwargs
@@ -524,9 +524,8 @@ def align_and_apply(
 
     Returns
     -------
-    list[Delayed]
-        A list of delayed objects, each one representing the result of the function applied to the
-        aligned partitions of the catalogs
+    nd.NestedFrame
+        A nested dataframe with the results of applying the function to each set of aligned partitions
     """
     # gets the pixels and hc_structures to pass to the function
     pixels = [pixels for (_, pixels) in catalog_mappings]
@@ -556,7 +555,8 @@ def align_and_apply(
     return result
 
 
-def create_pixel_ndfs(pixels: list[HealpixPixel | None]) -> npd.NestedFrame:
+def create_pixel_ndfs(pixels: Sequence[HealpixPixel | None]) -> npd.NestedFrame:
+    """Creates a nested dataframe with the pixel order and index, one for each partition"""
     return nd.NestedFrame.from_dict(
         {
             "order": [p.order if p is not None else -99 for p in pixels],
@@ -693,16 +693,15 @@ def filter_by_spatial_index_to_margin(
 
 
 def construct_catalog_args(
-    partitions: nd.NestedFrame, meta_df: npd.NestedFrame, alignment: PixelAlignment
+    partitions: nd.NestedFrame, alignment: PixelAlignment
 ) -> tuple[nd.NestedFrame, DaskDFPixelMap, PixelAlignment]:
-    """Constructs the arguments needed to create a catalog from a list of delayed partitions
+    """Constructs the arguments needed to create a catalog from a dataframe and an alignment
 
     Parameters
     ----------
-    partitions : list[Delayed]
-        The list of delayed partitions to create the catalog from
-    meta_df : npd.NestedFrame
-        The dask meta schema for the partitions
+    partitions : nd.NestedFrame
+        The nested dataframe with one partition per pixel in the alignment, in the same order as the pixels
+        in the alignment
     alignment : PixelAlignment
         The alignment used to create the delayed partition
 
@@ -848,7 +847,6 @@ def generate_meta_df_for_joined_tables(
         suffix, and any extra columns specified, with the index name set.
     """
     # Construct meta for crossmatched catalog columns
-    # pylint: disable=protected-access
     left_meta, right_meta = apply_suffixes(
         catalogs[0]._ddf._meta,
         catalogs[1]._ddf._meta,
@@ -861,7 +859,6 @@ def generate_meta_df_for_joined_tables(
     if extra_columns is not None:
         meta = pd.concat([meta, extra_columns], axis=1)
     if index_type is None:
-        # pylint: disable=protected-access
         index_type = catalogs[0]._ddf._meta.index.dtype
     if catalogs[0].hc_structure.has_healpix_column():
         index_name = catalogs[0].hc_structure.catalog_info.healpix_column  # type: ignore[assignment]
@@ -921,14 +918,12 @@ def generate_meta_df_for_nested_tables(
         meta.update(extra_columns)
 
     if index_type is None:
-        # pylint: disable=protected-access
         index_type = catalogs[0]._ddf._meta.index.dtype
     index = pd.Index(pd.Series(dtype=index_type), name=index_name)
     meta_df = pd.DataFrame(meta, index)
 
     # make an empty copy of the nested catalog, removing the column that will be joined on (and removed from
     # the eventual dataframe)
-    # pylint: disable=protected-access
     nested_catalog_meta = nested_catalog._ddf._meta.copy().iloc[:0]
     if join_column_name is not None:
         nested_catalog_meta = nested_catalog_meta.drop(join_column_name, axis=1)
@@ -987,7 +982,7 @@ def get_partition_map_from_alignment_pixels(join_pixels: pd.DataFrame) -> DaskDF
 
 
 def align_catalog_to_partitions(
-    catalog: HealpixDataset | None, pixels: list[HealpixPixel | None]
+    catalog: HealpixDataset | None, pixels: Sequence[HealpixPixel | None]
 ) -> nd.NestedFrame:
     """Aligns the partitions of a Catalog to a dataframe with HEALPix pixels in each row
 

--- a/src/lsdb/dask/merge_map_catalog_data.py
+++ b/src/lsdb/dask/merge_map_catalog_data.py
@@ -155,6 +155,7 @@ def merge_map_catalog_data(
     partitions_with_func = align_and_apply(
         [(point_catalog, left_pixels), (map_catalog, right_pixels)],
         perform_merge_map,
+        meta,
         func,
         *args,
         **kwargs,

--- a/src/lsdb/dask/merge_map_catalog_data.py
+++ b/src/lsdb/dask/merge_map_catalog_data.py
@@ -161,4 +161,4 @@ def merge_map_catalog_data(
         **kwargs,
     )
 
-    return construct_catalog_args(partitions_with_func, meta, alignment)
+    return construct_catalog_args(partitions_with_func, alignment)

--- a/tests/lsdb/catalog/test_concatenation.py
+++ b/tests/lsdb/catalog/test_concatenation.py
@@ -248,7 +248,6 @@ def test_concat_catalog_row_count(small_sky_order1_catalog, helpers):
     assert isinstance(df_concat, npd.NestedFrame)
 
     # Structure/divisions sanity
-    helpers.assert_divisions_are_correct(concat_cat)
     assert concat_cat.hc_structure.catalog_path is None
 
     # Symmetry check (main and margin handled internally)
@@ -433,7 +432,6 @@ def test_concat_catalogs_with_different_schemas(small_sky_order1_collection_dir,
 
     # Structural checks
     assert isinstance(concat_cat._ddf, nd.NestedFrame)
-    helpers.assert_divisions_are_correct(concat_cat)
 
     # (5) Symmetry check (main and margin handled internally)
     _assert_concat_symmetry(left_cat, right_cat)

--- a/tests/lsdb/catalog/test_concatenation.py
+++ b/tests/lsdb/catalog/test_concatenation.py
@@ -214,7 +214,7 @@ def _assert_concat_symmetry(
 # --------------------------------- tests --------------------------------- #
 
 
-def test_concat_catalog_row_count(small_sky_order1_catalog, helpers):
+def test_concat_catalog_row_count(small_sky_order1_catalog):
     """Verify that row count after concatenation equals the sum of both catalogs.
 
     This test ensures that concatenating two catalogs produces a catalog whose
@@ -331,7 +331,7 @@ def test_concat_catalog_margin_content(small_sky_order1_collection_catalog):
     _assert_concat_symmetry(left_cat, right_cat)
 
 
-def test_concat_catalogs_with_different_schemas(small_sky_order1_collection_dir, test_data_dir, helpers):
+def test_concat_catalogs_with_different_schemas(small_sky_order1_collection_dir, test_data_dir):
     """Concatenate catalogs with different schemas and validate behavior.
 
     Validates that concatenating two catalogs with different column sets

--- a/tests/lsdb/catalog/test_join.py
+++ b/tests/lsdb/catalog/test_join.py
@@ -330,7 +330,7 @@ def test_join_association_warnings(
         )
 
 
-def test_join_nested(small_sky_catalog, small_sky_order1_source_with_margin, helpers):
+def test_join_nested(small_sky_catalog, small_sky_order1_source_with_margin):
     joined = small_sky_catalog.join_nested(
         small_sky_order1_source_with_margin,
         left_on="id",
@@ -435,7 +435,7 @@ def test_join_nested_invalid_how(small_sky_order1_catalog, small_sky_order1_sour
 
 
 @pytest.mark.parametrize("direction", ["backward", "forward", "nearest"])
-def test_merge_asof(small_sky_catalog, small_sky_xmatch_catalog, direction, helpers):
+def test_merge_asof(small_sky_catalog, small_sky_xmatch_catalog, direction):
     suffixes = ("_a", "_b")
     joined = small_sky_catalog.merge_asof(small_sky_xmatch_catalog, direction=direction, suffixes=suffixes)
     assert isinstance(joined._ddf, nd.NestedFrame)

--- a/tests/lsdb/catalog/test_join.py
+++ b/tests/lsdb/catalog/test_join.py
@@ -51,7 +51,6 @@ def test_small_sky_join_small_sky_order1(small_sky_catalog, small_sky_order1_cat
         joined_row = joined_compute.query(f"id{suffixes[0]} == {row['id']}")
         assert joined_row.index.to_numpy()[0] == index
         assert joined_row[f"id{suffixes[1]}"].to_numpy()[0] == row["id"]
-    helpers.assert_divisions_are_correct(joined)
     helpers.assert_schema_correct(joined)
     assert not joined.hc_structure.on_disk
 
@@ -87,7 +86,6 @@ def test_small_sky_join_overlapping_suffix(small_sky_catalog, small_sky_order1_c
 
     assert np.all(joined_compute.columns == expected_columns)
 
-    helpers.assert_divisions_are_correct(joined)
     helpers.assert_schema_correct(joined)
 
 
@@ -129,7 +127,6 @@ def test_small_sky_join_small_sky_order1_source(
     assert len(joined_compute) == len(small_sky_order1_compute)
     joined_test = small_sky_order1_compute.merge(joined_compute, left_on="object_id", right_on="object_id_b")
     assert (joined_test["id_a"].to_numpy() == joined_test["object_id"].to_numpy()).all()
-    helpers.assert_divisions_are_correct(joined)
     helpers.assert_schema_correct(joined)
 
 
@@ -168,7 +165,6 @@ def test_small_sky_join_default_columns(
     assert len(joined_compute) == len(small_sky_order1_compute)
     joined_test = small_sky_order1_compute.merge(joined_compute, left_on="object_id", right_on="object_id_b")
     assert (joined_test["id_a"].to_numpy() == joined_test["object_id"].to_numpy()).all()
-    helpers.assert_divisions_are_correct(joined)
     helpers.assert_schema_correct(joined)
     helpers.assert_default_columns_in_columns(joined)
 
@@ -285,7 +281,6 @@ def test_join_association_overlapping_suffix(
 
     assert np.all(joined_compute.columns == expected_columns)
 
-    helpers.assert_divisions_are_correct(joined)
     helpers.assert_schema_correct(joined)
 
 
@@ -362,7 +357,6 @@ def test_join_nested(small_sky_catalog, small_sky_order1_source_with_margin, hel
     ]
     assert np.all(joined.columns == expected_columns)
     assert np.all(joined["sources"].nest.columns == expected_nested_columns)
-    helpers.assert_divisions_are_correct(joined)
     alignment = align_catalogs(small_sky_catalog, small_sky_order1_source_with_margin)
     assert joined.hc_structure.moc == alignment.moc
     assert joined.get_healpix_pixels() == alignment.pixel_tree.get_healpix_pixels()
@@ -405,7 +399,6 @@ def test_join_nested_how_left(small_sky_order1_catalog, small_sky_order1_source_
     helpers.assert_columns_in_nested_joined_catalog(
         nested_left, small_sky_order1_catalog, smaller_sky_sources, ["object_id"], "sources"
     )
-    helpers.assert_divisions_are_correct(nested_left)
 
     # All object pixels will show up in the final result
     assert object_pixels == nested_left.get_healpix_pixels()
@@ -444,7 +437,6 @@ def test_merge_asof(small_sky_catalog, small_sky_xmatch_catalog, direction, help
     suffixes = ("_a", "_b")
     joined = small_sky_catalog.merge_asof(small_sky_xmatch_catalog, direction=direction, suffixes=suffixes)
     assert isinstance(joined._ddf, nd.NestedFrame)
-    helpers.assert_divisions_are_correct(joined)
     alignment = align_catalogs(small_sky_catalog, small_sky_xmatch_catalog)
     assert joined.hc_structure.moc == alignment.moc
     assert joined.get_healpix_pixels() == alignment.pixel_tree.get_healpix_pixels()
@@ -497,12 +489,10 @@ def test_merge_asof_overlapping_suffix(small_sky_catalog, small_sky_xmatch_catal
         "calculated_dist",
     ]
     assert np.all(joined.columns == expected_columns)
-    helpers.assert_divisions_are_correct(joined)
 
     joined_compute = joined.compute()
 
     assert np.all(joined_compute.columns == expected_columns)
-    helpers.assert_divisions_are_correct(joined)
     helpers.assert_schema_correct(joined)
 
 

--- a/tests/lsdb/catalog/test_join.py
+++ b/tests/lsdb/catalog/test_join.py
@@ -406,12 +406,14 @@ def test_join_nested_how_left(small_sky_order1_catalog, small_sky_order1_source_
     assert len(small_sky_order1_catalog) == len(nested_left_compute)
 
     source_compute = smaller_sky_sources.compute()
+    source_margin = smaller_sky_sources.margin.compute()
+    total_sources = pd.concat([source_compute, source_margin]).drop_duplicates(subset="source_id")
     for _, row in nested_left_compute.iterrows():
         row_id = row["id"]
         if row["sources"] is not None:
             pd.testing.assert_frame_equal(
                 row["sources"].sort_values("source_ra").reset_index(drop=True),
-                pd.DataFrame(source_compute[source_compute["object_id"] == row_id].set_index("object_id"))
+                pd.DataFrame(total_sources[total_sources["object_id"] == row_id].set_index("object_id"))
                 .sort_values("source_ra")
                 .reset_index(drop=True)
                 .drop(columns=[c for c in paths.HIVE_COLUMNS if c in source_compute.columns]),

--- a/tests/lsdb/catalog/test_join.py
+++ b/tests/lsdb/catalog/test_join.py
@@ -386,7 +386,7 @@ def test_join_nested_how_left(small_sky_order1_catalog, small_sky_order1_source_
 
     # Now we will select only two pixels from the source catalog
     selected_pixels = [HealpixPixel(1, 46), HealpixPixel(1, 47)]
-    smaller_sky_sources = small_sky_order1_source_with_margin.pixel_search(selected_pixels)
+    smaller_sky_sources = small_sky_order1_source_with_margin.pixel_search(selected_pixels, fine=True)
 
     # If we `join_nested` with `how="left"`, we keep all objects on the left
     nested_left = small_sky_order1_catalog.join_nested(

--- a/tests/lsdb/catalog/test_pixel_search.py
+++ b/tests/lsdb/catalog/test_pixel_search.py
@@ -94,7 +94,7 @@ def test_pixel_search_is_empty(small_sky_catalog, small_sky_order1_catalog):
 
 
 def test_pixel_search_keeps_all_points(small_sky_order1_catalog):
-    metadata = small_sky_order1_catalog.hc_structure
+    metadata = small_sky_order1_catalog.hc_structure.catalog_info
     partition_df = small_sky_order1_catalog.get_partition(1, 44).compute()
     filtered_df = PixelSearch([(1, 44)]).search_points(partition_df, metadata)
     pd.testing.assert_frame_equal(partition_df, filtered_df)

--- a/tests/lsdb/dask/test_merge_functions.py
+++ b/tests/lsdb/dask/test_merge_functions.py
@@ -2,7 +2,6 @@ import logging
 
 import nested_pandas as npd
 import pandas as pd
-import pytest
 from hats.pixel_math import HealpixPixel
 
 from lsdb.dask.merge_catalog_functions import (

--- a/tests/lsdb/dask/test_merge_functions.py
+++ b/tests/lsdb/dask/test_merge_functions.py
@@ -1,6 +1,16 @@
 import logging
 
-from lsdb.dask.merge_catalog_functions import create_merged_catalog_info
+import nested_pandas as npd
+import pandas as pd
+import pytest
+from hats.pixel_math import HealpixPixel
+
+from lsdb.dask.merge_catalog_functions import (
+    align_catalog_to_partitions,
+    create_merged_catalog_info,
+    create_pixel_ndfs,
+    perform_align_and_apply_func,
+)
 
 
 def test_create_merged_catalog_info_suffix_logging(small_sky_catalog, small_sky_xmatch_catalog, caplog):
@@ -16,3 +26,126 @@ def test_create_merged_catalog_info_suffix_logging(small_sky_catalog, small_sky_
         assert merged_catalog_info.ra_column == "ra_left"
         assert merged_catalog_info.dec_column == "dec_left"
         assert "Renaming overlapping columns" not in caplog.text
+
+
+def test_align_catalog_to_partitions_none_catalog(small_sky_order1_catalog):
+    """When catalog is None, each partition should be an empty 0-column DataFrame."""
+    pixels = small_sky_order1_catalog.get_healpix_pixels()
+    result = align_catalog_to_partitions(None, pixels)
+    assert result.npartitions == len(pixels)
+    for i in range(result.npartitions):
+        part = result.partitions[i].compute()
+        assert len(part.columns) == 0
+        assert len(part) == 0
+
+
+def test_align_catalog_to_partitions_in_tree(small_sky_order1_catalog):
+    """Pixels present in the catalog's pixel tree should return non-empty partitions with catalog schema."""
+    pixels = small_sky_order1_catalog.get_healpix_pixels()
+    result = align_catalog_to_partitions(small_sky_order1_catalog, pixels)
+    assert result.npartitions == len(pixels)
+    for i, p in enumerate(pixels):
+        part = result.partitions[i].compute()
+        pd.testing.assert_frame_equal(
+            part, small_sky_order1_catalog.get_partition(p.order, p.pixel).compute()
+        )
+
+
+def test_align_catalog_to_partitions_pixel_not_in_tree(small_sky_order1_catalog):
+    """Pixels absent from the catalog's pixel tree should come back as empty (0-row) partitions
+    that still carry the catalog's column schema (not 0-column frames)."""
+    pixels = [HealpixPixel(0, 100)]
+    result = align_catalog_to_partitions(small_sky_order1_catalog, pixels)
+    assert result.npartitions == 1
+    part = result.get_partition(0).compute()
+    assert len(part) == 0
+    assert all(part.columns == small_sky_order1_catalog._ddf.columns)
+
+
+def test_align_catalog_to_partitions_none_pixel(small_sky_order1_catalog):
+    """A None entry in the pixel list should behave the same as a missing pixel."""
+    result = align_catalog_to_partitions(small_sky_order1_catalog, [None])
+    assert result.npartitions == 1
+    part = result.get_partition(0).compute()
+    assert len(part) == 0
+    assert all(part.columns == small_sky_order1_catalog._ddf.columns)
+
+
+def test_create_pixel_ndfs_real_pixels():
+    pixels = [HealpixPixel(1, 0), HealpixPixel(2, 3)]
+    result = create_pixel_ndfs(pixels)
+    assert result.npartitions == len(pixels)
+    p0 = result.get_partition(0).compute()
+    assert p0.iloc[0]["order"] == 1
+    assert p0.iloc[0]["pixel"] == 0
+    p1 = result.get_partition(1).compute()
+    assert p1.iloc[0]["order"] == 2
+    assert p1.iloc[0]["pixel"] == 3
+
+
+def test_create_pixel_ndfs_none_pixels():
+    """None pixels should be encoded with the -99 sentinel."""
+    pixels = [None, HealpixPixel(1, 0), None]
+    result = create_pixel_ndfs(pixels)
+    assert result.npartitions == 3
+    sentinel_part = result.get_partition(0).compute()
+    assert sentinel_part.iloc[0]["order"] == -99
+    assert sentinel_part.iloc[0]["pixel"] == -99
+    real_part = result.get_partition(1).compute()
+    assert real_part.iloc[0]["order"] == 1
+
+
+def _make_pixel_df(order, pixel):
+    """Helper: build the single-row pixel DataFrame that perform_align_and_apply_func expects."""
+    return pd.DataFrame({"order": [order], "pixel": [pixel]})
+
+
+def test_perform_align_and_apply_func_passes_dataframes():
+    """Non-empty partitions should be forwarded to the inner function after stripping hips columns."""
+    df = npd.NestedFrame({"ra": [1.0], "dec": [2.0]})
+    pixel_df = _make_pixel_df(1, 0)
+
+    received = {}
+
+    def func(part, pix):
+        received["part"] = part
+        received["pix"] = pix
+        return part
+
+    perform_align_and_apply_func(1, func, df, pixel_df)
+
+    assert received["pix"] == HealpixPixel(1, 0)
+    assert list(received["part"].columns) == ["ra", "dec"]
+
+
+def test_perform_align_and_apply_func_empty_df_becomes_none():
+    """A 0-column DataFrame (stand-in for a missing/None catalog) must arrive as None."""
+    empty_df = pd.DataFrame()  # 0 columns
+    pixel_df = _make_pixel_df(1, 0)
+
+    received = {}
+
+    def func(part, pix):
+        received["part"] = part
+        received["pix"] = pix
+        return npd.NestedFrame()
+
+    perform_align_and_apply_func(1, func, empty_df, pixel_df)
+
+    assert received["part"] is None
+
+
+def test_perform_align_and_apply_func_none_pixel_sentinel():
+    """The -99 sentinel in the pixel DataFrame should decode back to None."""
+    df = npd.NestedFrame({"ra": [1.0]})
+    pixel_df = _make_pixel_df(-99, -99)
+
+    received = {}
+
+    def func(part, pix):
+        received["pix"] = pix
+        return part
+
+    perform_align_and_apply_func(1, func, df, pixel_df)
+
+    assert received["pix"] is None


### PR DESCRIPTION
Use `partitions` selector and map_partitions to do align_and_apply instead of going to and from delayed.

Closes #300 

This has a few behavior changes from the implementation before, mostly due to the limitations of expressions vs delayed:

- non-existing partitions in a catalog now are passed as empty data frames to the ufunc instead of None. I do think this is a better design decision overall, and further refactoring work could be done to remove passing meta as we do in a few places. This did expose some bugs though, particularly in left join nested, which resulted in changing how pixel_search was written to fix this.
- Catalogs that are None still pass None types to the ufunc, but in doing this we no longer support completely empty catalogs (0 columns). There may have been other places this didn't work before though, and I don't think its a use case we care about.
- There are a lot more dask tasks in the graph to pass all the arguments in the right places.