### PR TITLE
Delayed Streaming Implementation

### DIFF
--- a/src/lsdb/streams/catalog_streams.py
+++ b/src/lsdb/streams/catalog_streams.py
@@ -9,6 +9,13 @@ from dask.distributed import Client, Future
 from lsdb import Catalog
 
 
+def _concat_results(results):
+    """Concatenate a list of DataFrames into a single DataFrame."""
+    if len(results) == 1:
+        return results[0]
+    return pd.concat(results)
+
+
 class _FakeFuture:
     """Duck-typed `Future` interface for a pre-computed value.
 
@@ -95,6 +102,11 @@ class CatalogStream:
         else:
             self.rng = np.random.default_rng((1 << 32, self.seed))
 
+        # Pre-extract delayed partitions with one-time graph optimization.
+        # This avoids repeated graph construction, optimization, and catalog
+        # search/reload overhead on every iteration.
+        self._delayed_partitions = catalog.to_delayed(optimize_graph=True)
+
     def get_next_partitions(
         self, partitions_left: np.ndarray, rng: np.random.Generator  # pylint: disable=unused-argument
     ) -> tuple[np.ndarray, np.ndarray]:
@@ -107,12 +119,12 @@ class CatalogStream:
 
     def submit_next_partitions(self, partitions: np.ndarray) -> Future | _FakeFuture:
         """Submit the next set of partitions for computation."""
-        sliced_catalog = self.catalog.partitions[partitions]
-        futurable = sliced_catalog._ddf  # pylint: disable=protected-access
+        selected = [self._delayed_partitions[i] for i in partitions]
 
         if self.client is None:
-            return _FakeFuture(dask.compute(futurable)[0])
-        return self.client.compute(futurable)
+            return _FakeFuture(_concat_results(list(dask.compute(*selected))))
+        futures = self.client.compute(selected)
+        return self.client.submit(_concat_results, futures)
 
     def __iter__(self) -> "CatalogIterator":
         """Return an iterator for this iterable."""

--- a/src/lsdb/streams/catalog_streams.py
+++ b/src/lsdb/streams/catalog_streams.py
@@ -9,13 +9,6 @@ from dask.distributed import Client, Future
 from lsdb import Catalog
 
 
-def _concat_results(results):
-    """Concatenate a list of DataFrames into a single DataFrame."""
-    if len(results) == 1:
-        return results[0]
-    return pd.concat(results)
-
-
 class _FakeFuture:
     """Duck-typed `Future` interface for a pre-computed value.
 
@@ -121,10 +114,15 @@ class CatalogStream:
         """Submit the next set of partitions for computation."""
         selected = [self._delayed_partitions[i] for i in partitions]
 
+        if len(selected) == 1:
+            if self.client is None:
+                return _FakeFuture(selected[0].compute())
+            return self.client.compute(selected[0])
+
+        combined = dask.delayed(pd.concat)(selected)
         if self.client is None:
-            return _FakeFuture(_concat_results(list(dask.compute(*selected))))
-        futures = self.client.compute(selected)
-        return self.client.submit(_concat_results, futures)
+            return _FakeFuture(combined.compute())
+        return self.client.compute(combined)
 
     def __iter__(self) -> "CatalogIterator":
         """Return an iterator for this iterable."""

--- a/src/lsdb/streams/catalog_streams.py
+++ b/src/lsdb/streams/catalog_streams.py
@@ -89,6 +89,8 @@ class CatalogStream:
             raise ValueError(f"The provided catalog input type {type(catalog)} is not a lsdb.Catalog object.")
 
         self.client = client
+        self.partitions_per_chunk = min(partitions_per_chunk, self.catalog.npartitions)
+        self.shuffle = shuffle
         self.seed = seed
 
         if self.seed is None:

--- a/src/lsdb/streams/catalog_streams.py
+++ b/src/lsdb/streams/catalog_streams.py
@@ -99,6 +99,10 @@ class CatalogStream:
         # This avoids repeated graph construction, optimization, and catalog
         # search/reload overhead on every iteration.
         self._delayed_partitions = catalog.to_delayed(optimize_graph=True)
+        #import sys
+        #print(sys.getsizeof(self._delayed_partitions))
+        #print(len(self._delayed_partitions))
+        #print(self._delayed_partitions[0])
 
     def get_next_partitions(
         self, partitions_left: np.ndarray, rng: np.random.Generator  # pylint: disable=unused-argument

--- a/src/lsdb/streams/catalog_streams.py
+++ b/src/lsdb/streams/catalog_streams.py
@@ -44,8 +44,9 @@ class CatalogStream:
         `client.compute()`.
     partitions_per_chunk : int
         Number of partitions to yield. It will be clipped to the total number
-        of partitions. Be mindful when setting this value larger than 1, as
-        holding multiple partitions in memory at once will increase memory usage.
+        of partitions. By default, one partition will be yielded at a time,
+        however, if using a distributed client, it's recommended to set this to
+        at least 2x the number of workers to allow proper parallelism.
     shuffle : bool
         Whether to shuffle the partition order before streaming. If False, the
         partitions will be streamed in their original order. True by default.
@@ -88,8 +89,6 @@ class CatalogStream:
             raise ValueError(f"The provided catalog input type {type(catalog)} is not a lsdb.Catalog object.")
 
         self.client = client
-        self.partitions_per_chunk = min(partitions_per_chunk, self.catalog.npartitions)
-        self.shuffle = shuffle
         self.seed = seed
 
         if self.seed is None:

--- a/src/lsdb/streams/catalog_streams.py
+++ b/src/lsdb/streams/catalog_streams.py
@@ -4,7 +4,9 @@ from typing import Optional
 import dask
 import numpy as np
 import pandas as pd
+from dask.delayed import Delayed
 from dask.distributed import Client, Future
+from dask.optimization import cull
 
 from lsdb import Catalog
 
@@ -98,11 +100,17 @@ class CatalogStream:
         # Pre-extract delayed partitions with one-time graph optimization.
         # This avoids repeated graph construction, optimization, and catalog
         # search/reload overhead on every iteration.
-        self._delayed_partitions = catalog.to_delayed(optimize_graph=True)
-        #import sys
-        #print(sys.getsizeof(self._delayed_partitions))
-        #print(len(self._delayed_partitions))
-        #print(self._delayed_partitions[0])
+        #
+        # Crucially, to_delayed() returns Delayed objects that all share the
+        # same full graph. We cull each to its own subgraph so that
+        # client.compute() only sends the minimal per-partition graph to the
+        # scheduler, avoiding O(N^2) graph transmission overhead.
+        raw_delayed = catalog.to_delayed(optimize_graph=True)
+        shared_graph = dict(raw_delayed[0].__dask_graph__())
+        self._delayed_partitions = []
+        for d in raw_delayed:
+            culled_graph, _ = cull(shared_graph, list(d.__dask_keys__()))
+            self._delayed_partitions.append(Delayed(d.key, culled_graph))
 
     def get_next_partitions(
         self, partitions_left: np.ndarray, rng: np.random.Generator  # pylint: disable=unused-argument


### PR DESCRIPTION
Made in collaboration with Claude

Improves streaming performance by performing up front graph optimization and task culling, switching to delayed objects. Generally I see that partitions_per_chunk ~2x-4x the number of client workers is best, so I liked it as a default, but it's not clear to me that we have access to a client that was defined elsewhere without directly including it in the CatalogStream setup call, so opted to leave it as a recommendation in the docs.