### PR TITLE
Improve validation of meta in `map_rows`

### DIFF
--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -1327,16 +1327,14 @@ class Catalog(HealpixDataset):
         func,
         columns=None,
         *,
+        meta,
         row_container="dict",
         output_names=None,
         infer_nesting=True,
         append_columns=False,
-        meta=None,
         **kwargs,
     ) -> Catalog:
         """Takes a function and applies it to each top-level row of the Catalog.
-
-        docstring copied from nested-pandas
 
         Nested columns are packaged alongside base columns and available for function use, where base columns
         are passed as scalars and nested columns are passed as numpy arrays. The way in which the row data is
@@ -1346,38 +1344,38 @@ class Catalog(HealpixDataset):
         ----------
         func : callable
             Function to apply to each nested dataframe. The first arguments to `func` should be which
-            columns to apply the function to. See the Notes for recommendations
-            on writing func outputs.
+            columns to apply the function to. Make sure `meta` is consistent with the return value of
+            `func`. See the Notes for recommendations on writing func outputs.
         columns : None | str | list of str, default None
             Specifies which columns to pass to the function in the row_container format.
             If None, all columns are passed. If list of str, those columns are passed.
             If str, a single column is passed or if the string is a nested column, then all nested sub-columns
             are passed (e.g. columns="nested" passes all columns of the nested dataframe "nested"). To pass
             individual nested sub-columns, use the hierarchical column name (e.g. columns=["nested.t",...]).
+        meta : dataframe or series-like
+            The dask meta of the output. If `append_columns` is True, the meta should only specify the
+            additional columns output by func. Make sure `meta` is consistent with the return value of `func`.
         row_container : 'dict' or 'args', default 'dict'
             Specifies how the row data will be packaged when passed as an input to the function.
             If 'dict', the function will be called as `func({"col1": value, ...}, **kwargs)`, so func should
             expect a single dictionary input with keys corresponding to column names.
             If 'args', the function will be called as `func(value, ..., **kwargs)`, so func should expect
-            positional arguments corresponding to the columns specified in `args`. (Default value = "dict")
-        output_names : None | str | list of str
+            positional arguments corresponding to the columns specified in `args`.
+        output_names : None | str | list of str, default None
             Specifies the names of the output columns in the resulting NestedFrame. If None, the function
             will return whatever names the user function returns. If specified will override any names
             returned by the user function provided the number of names matches the number of outputs. When not
             specified and the user function returns values without names (e.g. a list or tuple), the output
-            columns will be enumerated (e.g. "0", "1", ...). (Default value = None)
+            columns will be enumerated (e.g. "0", "1", ...).
         infer_nesting : bool, default True
             If True, the function will pack output columns into nested
             structures based on column names adhering to a nested naming
             scheme. E.g. "nested.b" and "nested.c" will be packed into a column
             called "nested" with columns "b" and "c". If False, all outputs
             will be returned as base columns. Note that this will trigger off of names specified in
-            `output_names` in addition to names returned by the user function. (Default value = True)
+            `output_names` in addition to names returned by the user function.
         append_columns : bool, default False
-            if True, the output columns should be appended to those in the original NestedFrame
-        meta : dataframe or series-like, optional, default None
-            The dask meta of the output. If append_columns is True, the meta should specify just the
-            additional columns output by func.
+            if True, the output columns should be appended to those in the original NestedFrame.
         kwargs : keyword arguments, optional
             Keyword arguments to pass to the function.
 
@@ -1388,14 +1386,21 @@ class Catalog(HealpixDataset):
 
         Notes
         -----
-        If concerned about performance, specify `columns` to only include the columns
-        needed for the function, as this will avoid the overhead of packaging
-        all columns for each row.
+        `func` should NOT update positional columns (ra/dec). A warning is issued to alert the user
+        that this will lead to the creation of an LSDB Catalog with an invalid HATS structure.
+        If you wish to update positional coordinates, consider adding them as separate columns.
+        Make sure `meta` is consistent with the return value of `func`.
 
-        By default, `map_rows` will produce a `NestedFrame` with enumerated
-        column names for each returned value of the function. It's recommended
-        to either specify `output_names` or have `func` return a dictionary
-        where each key is an output column of the dataframe returned by
+        If `append_columns` is True, `func` should only return the columns to be appended. Make
+        sure neither `func` nor the provided `meta` contain columns to append to the Catalog that
+        overlap in name with pre-existing columns.
+
+        If concerned about performance, specify `columns` to only include the columns needed for
+        the function, as this will avoid the overhead of packaging all columns for each row.
+
+        By default, `map_rows` will produce a `NestedFrame` with enumerated column names for each
+        returned value of the function. It's recommended to either specify `output_names` or have
+        `func` return a dictionary where each key is an output column of the dataframe returned by
         `map_rows` (as shown above).
 
         Examples

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -809,7 +809,8 @@ class Catalog(HealpixDataset):
             to the `map_partitions` function. If the `include_pixel` parameter is set, the function will
             be called with the `healpix_pixel` as the second positional argument set to the healpix pixel
             of the partition as
-            `func(partition: npd.NestedFrame, healpix_pixel: HealpixPixel, *args, **kwargs)`
+            `func(partition: npd.NestedFrame, healpix_pixel: HealpixPixel, *args, **kwargs)`.
+            See the Notes for recommendations on writing functions.
         *args
             Additional positional arguments to call `func` with.
         meta : pd.DataFrame | pd.Series | Dict | Iterable | Tuple | None, default None
@@ -845,6 +846,17 @@ class Catalog(HealpixDataset):
         Catalog | dd.Series
             A new catalog with each partition replaced with the output of the function applied to the original
             partition. If the function returns a non dataframe output, a dask Series will be returned.
+
+        Notes
+        -----
+        When `meta` is specified, make sure it is consistent with the return value of `func`.
+
+        `func` should NOT update positional columns (ra/dec). If you wish to update coordinates,
+        transform the Catalog into a Dask Dataframe, using `Catalog.to_dask_dataframe()`
+        and apply a similar `map_partitions` call. Then, compute the data into a DataFrame using
+        `Catalog.compute()` and reimport it using `lsdb.from_dataframe()`. If the data is not
+        expected to fit in memory, write it to disk instead, using `dask.DataFrame.to_parquet()`,
+        and reimport with `hats-import`.
 
         Examples
         --------
@@ -1386,10 +1398,18 @@ class Catalog(HealpixDataset):
 
         Notes
         -----
-        `func` should NOT update positional columns (ra/dec). A warning is issued to alert the user
-        that this will lead to the creation of an LSDB Catalog with an invalid HATS structure.
-        If you wish to update positional coordinates, consider adding them as separate columns.
         Make sure `meta` is consistent with the return value of `func`.
+
+        `func` should NOT update positional columns (ra/dec). If you wish to update coordinates,
+        transform the Catalog into a Dask Dataframe, using `Catalog.to_dask_dataframe()`
+        and apply a similar `map_partitions` call. Then, compute the data into a DataFrame using
+        `Catalog.compute()` and reimport it using `lsdb.from_dataframe()`. If the data is not
+        expected to fit in memory, write it to disk instead, using `dask.DataFrame.to_parquet()`,
+        and reimport with `hats-import`.
+
+        To return unmodified values of ra/dec from a `map_rows` call, set `append_columns=True`,
+        and remember to only return the new columns to append. If you wish to only keep a subset
+        of the resulting columns, select them after the `map_rows` call.
 
         If `append_columns` is True, `func` should only return the columns to be appended. Make
         sure neither `func` nor the provided `meta` contain columns to append to the Catalog that

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -809,8 +809,7 @@ class Catalog(HealpixDataset):
             to the `map_partitions` function. If the `include_pixel` parameter is set, the function will
             be called with the `healpix_pixel` as the second positional argument set to the healpix pixel
             of the partition as
-            `func(partition: npd.NestedFrame, healpix_pixel: HealpixPixel, *args, **kwargs)`.
-            See the Notes for recommendations on writing functions.
+            `func(partition: npd.NestedFrame, healpix_pixel: HealpixPixel, *args, **kwargs)`
         *args
             Additional positional arguments to call `func` with.
         meta : pd.DataFrame | pd.Series | Dict | Iterable | Tuple | None, default None
@@ -846,17 +845,6 @@ class Catalog(HealpixDataset):
         Catalog | dd.Series
             A new catalog with each partition replaced with the output of the function applied to the original
             partition. If the function returns a non dataframe output, a dask Series will be returned.
-
-        Notes
-        -----
-        When `meta` is specified, make sure it is consistent with the return value of `func`.
-
-        `func` should NOT update positional columns (ra/dec). If you wish to update coordinates,
-        transform the Catalog into a Dask Dataframe, using `Catalog.to_dask_dataframe()`
-        and apply a similar `map_partitions` call. Then, compute the data into a DataFrame using
-        `Catalog.compute()` and reimport it using `lsdb.from_dataframe()`. If the data is not
-        expected to fit in memory, write it to disk instead, using `dask.DataFrame.to_parquet()`,
-        and reimport with `hats-import`.
 
         Examples
         --------
@@ -1399,17 +1387,6 @@ class Catalog(HealpixDataset):
         Notes
         -----
         Make sure `meta` is consistent with the return value of `func`.
-
-        `func` should NOT update positional columns (ra/dec). If you wish to update coordinates,
-        transform the Catalog into a Dask Dataframe, using `Catalog.to_dask_dataframe()`
-        and apply a similar `map_partitions` call. Then, compute the data into a DataFrame using
-        `Catalog.compute()` and reimport it using `lsdb.from_dataframe()`. If the data is not
-        expected to fit in memory, write it to disk instead, using `dask.DataFrame.to_parquet()`,
-        and reimport with `hats-import`.
-
-        To return unmodified values of ra/dec from a `map_rows` call, set `append_columns=True`,
-        and remember to only return the new columns to append. If you wish to only keep a subset
-        of the resulting columns, select them after the `map_rows` call.
 
         If `append_columns` is True, `func` should only return the columns to be appended. Make
         sure neither `func` nor the provided `meta` contain columns to append to the Catalog that

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -1124,7 +1124,8 @@ class HealpixDataset:
             to the `map_partitions` function. If the `include_pixel` parameter is set, the function will
             be called with the `healpix_pixel` as the second positional argument set to the healpix pixel
             of the partition as
-            `func(partition: npd.NestedFrame, healpix_pixel: HealpixPixel, *args, **kwargs)`
+            `func(partition: npd.NestedFrame, healpix_pixel: HealpixPixel, *args, **kwargs)`.
+            See the Notes for recommendations on writing functions.
         *args
             Additional positional arguments to call `func` with.
         meta : pd.DataFrame | pd.Series | Dict | Iterable | Tuple | None, default None
@@ -1159,6 +1160,17 @@ class HealpixDataset:
         Self or dd.Series
             A new catalog with each partition replaced with the output of the function applied to the original
             partition. If the function returns a non dataframe output, a dask Series will be returned.
+
+        Notes
+        -----
+        When `meta` is specified, make sure it is consistent with the return value of `func`.
+
+        `func` should NOT update positional columns (ra/dec). If you wish to update coordinates,
+        transform the HealpixDataset into a Dask Dataframe, using `HealpixDataset.to_dask_dataframe()`
+        and apply a similar `map_partitions` call. Then, compute the data into a DataFrame using
+        `HealpixDataset.compute()` and reimport it using `lsdb.from_dataframe()`. If the data is not
+        expected to fit in memory, write it to disk instead, using `dask.DataFrame.to_parquet()`,
+        and reimport with `hats-import`.
         """
         if compute_single_partition:
             if partition_index is None:
@@ -1530,10 +1542,18 @@ class HealpixDataset:
 
         Notes
         -----
-        `func` should NOT update positional columns (ra/dec). A warning is issued to alert the user
-        that this will lead to the creation of an LSDB Catalog with an invalid HATS structure.
-        If you wish to update positional coordinates, consider adding them as separate columns.
         Make sure `meta` is consistent with the return value of `func`.
+
+        `func` should NOT update positional columns (ra/dec). If you wish to update coordinates,
+        transform the HealpixDataset into a Dask Dataframe, using `HealpixDataset.to_dask_dataframe()`
+        and apply a similar `map_partitions` call. Then, compute the data into a DataFrame using
+        `HealpixDataset.compute()` and reimport it using `lsdb.from_dataframe()`. If the data is not
+        expected to fit in memory, write it to disk instead, using `dask.DataFrame.to_parquet()`,
+        and reimport with `hats-import`.
+
+        To return unmodified values of ra/dec from a `map_rows` call, set `append_columns=True`,
+        and remember to only return the new columns to append. If you wish to only keep a subset
+        of the resulting columns, select them after the `map_rows` call.
 
         If `append_columns` is True, `func` should only return the columns to be appended. Make
         sure neither `func` nor the provided `meta` contain columns to append to the Catalog that
@@ -1594,33 +1614,28 @@ class HealpixDataset:
         self_meta = self._ddf._meta.copy()
         meta = npd.NestedFrame(make_meta(meta))
 
-        def _make_result_meta():
-            nonlocal self_meta, meta
-            added_nested_subcols = [str(col) for col in meta.columns if "." in str(col)]
-            self_meta = self_meta.assign(**{col: meta[col] for col in added_nested_subcols})
-            meta = meta.drop(columns=added_nested_subcols)
-            return concat_metas([self_meta, meta])
-
-        hc_updates = {}
-
         if append_columns:
             overlapping_columns = set(self_meta.columns) & set(meta.columns)
             if overlapping_columns:
                 raise ValueError(
                     f"`meta` specifies columns to append that already exist: {list(overlapping_columns)}."
                 )
-            meta = _make_result_meta()
+            added_nested_subcols = [str(col) for col in meta.columns if "." in str(col)]
+            self_meta = self_meta.assign(**{col: meta[col] for col in added_nested_subcols})
+            meta = meta.drop(columns=added_nested_subcols)
+            meta = concat_metas([self_meta, meta])
         else:
             radec_columns = {
                 self.hc_structure.catalog_info.ra_column,
                 self.hc_structure.catalog_info.dec_column,
             }
             if radec_columns & set(meta.columns):
-                warnings.warn(
-                    f"`meta` specifies positional columns {list(radec_columns)} that should NOT be modified.",
-                    RuntimeWarning,
+                raise ValueError(
+                    f"`meta` specifies positional columns {list(radec_columns)} that should NOT be modified. "
+                    "To preserve unmodified ra/dec columns set `append_columns=True`, and remember to only"
+                    " return the new columns to append. If you wish to only keep a subset of the resulting "
+                    "columns, select them after the `map_rows` call."
                 )
-                hc_updates = {"ra_column": "", "dec_column": ""}
 
         ndf = self._ddf.map_rows(
             func,
@@ -1632,7 +1647,7 @@ class HealpixDataset:
             meta=meta,
             **kwargs,
         )
-        return self._create_updated_dataset(ddf=ndf, updated_catalog_info_params=hc_updates)
+        return self._create_updated_dataset(ddf=ndf)
 
     # pylint: disable=duplicate-code
     def plot_points(

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -1550,13 +1550,13 @@ class HealpixDataset:
         Examples
         --------
 
-        Writing a function that takes a row as a dictionary:
-
         >>> import numpy as np
         >>> import lsdb
         >>> import pandas as pd
         >>> catalog = lsdb.from_dataframe(pd.DataFrame({"ra":[0, 10], "dec":[5, 15],
         ...                                             "mag":[21, 22], "mag_err":[.1, .2]}))
+
+        Writing a function that takes a row as a dictionary:
 
         >>> def my_sigma(row):
         ...    '''map_rows will return a NestedFrame with two columns'''
@@ -1569,7 +1569,6 @@ class HealpixDataset:
                    _healpix_29  plus_one  minus_one
         0  1372475556631677955      21.1       20.9
         1  1389879706834706546      22.2       21.8
-
 
         Writing the same function using positional arguments:
 

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -1602,6 +1602,8 @@ class HealpixDataset:
             meta = meta.drop(columns=added_nested_subcols)
             return concat_metas([self_meta, meta])
 
+        hc_updates = {}
+
         if append_columns:
             overlapping_columns = set(self_meta.columns) & set(meta.columns)
             if overlapping_columns:
@@ -1619,6 +1621,7 @@ class HealpixDataset:
                     f"`meta` specifies positional columns {list(radec_columns)} that should NOT be modified.",
                     RuntimeWarning,
                 )
+                hc_updates = {"ra_column": "", "dec_column": ""}
 
         ndf = self._ddf.map_rows(
             func,
@@ -1630,7 +1633,7 @@ class HealpixDataset:
             meta=meta,
             **kwargs,
         )
-        return self._create_updated_dataset(ddf=ndf)
+        return self._create_updated_dataset(ddf=ndf, updated_catalog_info_params=hc_updates)
 
     # pylint: disable=duplicate-code
     def plot_points(

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -1124,8 +1124,7 @@ class HealpixDataset:
             to the `map_partitions` function. If the `include_pixel` parameter is set, the function will
             be called with the `healpix_pixel` as the second positional argument set to the healpix pixel
             of the partition as
-            `func(partition: npd.NestedFrame, healpix_pixel: HealpixPixel, *args, **kwargs)`.
-            See the Notes for recommendations on writing functions.
+            `func(partition: npd.NestedFrame, healpix_pixel: HealpixPixel, *args, **kwargs)`
         *args
             Additional positional arguments to call `func` with.
         meta : pd.DataFrame | pd.Series | Dict | Iterable | Tuple | None, default None
@@ -1160,17 +1159,6 @@ class HealpixDataset:
         Self or dd.Series
             A new catalog with each partition replaced with the output of the function applied to the original
             partition. If the function returns a non dataframe output, a dask Series will be returned.
-
-        Notes
-        -----
-        When `meta` is specified, make sure it is consistent with the return value of `func`.
-
-        `func` should NOT update positional columns (ra/dec). If you wish to update coordinates,
-        transform the HealpixDataset into a Dask Dataframe, using `HealpixDataset.to_dask_dataframe()`
-        and apply a similar `map_partitions` call. Then, compute the data into a DataFrame using
-        `HealpixDataset.compute()` and reimport it using `lsdb.from_dataframe()`. If the data is not
-        expected to fit in memory, write it to disk instead, using `dask.DataFrame.to_parquet()`,
-        and reimport with `hats-import`.
         """
         if compute_single_partition:
             if partition_index is None:
@@ -1544,17 +1532,6 @@ class HealpixDataset:
         -----
         Make sure `meta` is consistent with the return value of `func`.
 
-        `func` should NOT update positional columns (ra/dec). If you wish to update coordinates,
-        transform the HealpixDataset into a Dask Dataframe, using `HealpixDataset.to_dask_dataframe()`
-        and apply a similar `map_partitions` call. Then, compute the data into a DataFrame using
-        `HealpixDataset.compute()` and reimport it using `lsdb.from_dataframe()`. If the data is not
-        expected to fit in memory, write it to disk instead, using `dask.DataFrame.to_parquet()`,
-        and reimport with `hats-import`.
-
-        To return unmodified values of ra/dec from a `map_rows` call, set `append_columns=True`,
-        and remember to only return the new columns to append. If you wish to only keep a subset
-        of the resulting columns, select them after the `map_rows` call.
-
         If `append_columns` is True, `func` should only return the columns to be appended. Make
         sure neither `func` nor the provided `meta` contain columns to append to the Catalog that
         overlap in name with pre-existing columns.
@@ -1624,18 +1601,6 @@ class HealpixDataset:
             self_meta = self_meta.assign(**{col: meta[col] for col in added_nested_subcols})
             meta = meta.drop(columns=added_nested_subcols)
             meta = concat_metas([self_meta, meta])
-        else:
-            radec_columns = {
-                self.hc_structure.catalog_info.ra_column,
-                self.hc_structure.catalog_info.dec_column,
-            }
-            if radec_columns & set(meta.columns):
-                raise ValueError(
-                    f"`meta` specifies positional columns {list(radec_columns)} that should NOT be modified. "
-                    "To preserve unmodified ra/dec columns set `append_columns=True`, and remember to only"
-                    " return the new columns to append. If you wish to only keep a subset of the resulting "
-                    "columns, select them after the `map_rows` call."
-                )
 
         ndf = self._ddf.map_rows(
             func,

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -1471,16 +1471,14 @@ class HealpixDataset:
         func,
         columns=None,
         *,
+        meta,
         row_container="dict",
         output_names=None,
         infer_nesting=True,
         append_columns=False,
-        meta=None,
         **kwargs,
     ) -> Self:
         """Takes a function and applies it to each top-level row of the Catalog.
-
-        docstring copied from nested-pandas
 
         Nested columns are packaged alongside base columns and available for function use, where base columns
         are passed as scalars and nested columns are passed as numpy arrays. The way in which the row data is
@@ -1490,14 +1488,17 @@ class HealpixDataset:
         ----------
         func : callable
             Function to apply to each nested dataframe. The first arguments to `func` should be which
-            columns to apply the function to. See the Notes for recommendations
-            on writing func outputs.
+            columns to apply the function to. Make sure `meta` is consistent with the return value of
+            `func`. See the Notes for recommendations on writing func outputs.
         columns : None | str | list of str, default None
             Specifies which columns to pass to the function in the row_container format.
             If None, all columns are passed. If list of str, those columns are passed.
             If str, a single column is passed or if the string is a nested column, then all nested sub-columns
             are passed (e.g. columns="nested" passes all columns of the nested dataframe "nested"). To pass
             individual nested sub-columns, use the hierarchical column name (e.g. columns=["nested.t",...]).
+        meta : dataframe or series-like
+            The dask meta of the output. If `append_columns` is True, the meta should only specify the
+            additional columns output by func. Make sure `meta` is consistent with the return value of `func`.
         row_container : 'dict' or 'args', default 'dict'
             Specifies how the row data will be packaged when passed as an input to the function.
             If 'dict', the function will be called as `func({"col1": value, ...}, **kwargs)`, so func should
@@ -1519,9 +1520,6 @@ class HealpixDataset:
             `output_names` in addition to names returned by the user function.
         append_columns : bool, default False
             if True, the output columns should be appended to those in the original NestedFrame.
-        meta : dataframe or series-like, default None
-            The dask meta of the output. If append_columns is True, the meta should specify just the
-            additional columns output by func.
         kwargs : keyword arguments, optional
             Keyword arguments to pass to the function.
 
@@ -1532,15 +1530,23 @@ class HealpixDataset:
 
         Notes
         -----
-        If concerned about performance, specify `columns` to only include the columns
-        needed for the function, as this will avoid the overhead of packaging
-        all columns for each row.
+        `func` should NOT update positional columns (ra/dec). A warning is issued to alert the user
+        that this will lead to the creation of an LSDB Catalog with an invalid HATS structure.
+        If you wish to update positional coordinates, consider adding them as separate columns.
+        Make sure `meta` is consistent with the return value of `func`.
 
-        By default, `map_rows` will produce a `NestedFrame` with enumerated
-        column names for each returned value of the function. It's recommended
-        to either specify `output_names` or have `func` return a dictionary
-        where each key is an output column of the dataframe returned by
+        If `append_columns` is True, `func` should only return the columns to be appended. Make
+        sure neither `func` nor the provided `meta` contain columns to append to the Catalog that
+        overlap in name with pre-existing columns.
+
+        If concerned about performance, specify `columns` to only include the columns needed for
+        the function, as this will avoid the overhead of packaging all columns for each row.
+
+        By default, `map_rows` will produce a `NestedFrame` with enumerated column names for each
+        returned value of the function. It's recommended to either specify `output_names` or have
+        `func` return a dictionary where each key is an output column of the dataframe returned by
         `map_rows` (as shown above).
+
         Examples
         --------
 
@@ -1584,21 +1590,35 @@ class HealpixDataset:
         """
         self._check_unloaded_columns(columns)
 
-        ra_column = self.hc_structure.catalog_info.ra_column
-        dec_column = self.hc_structure.catalog_info.dec_column
+        if meta is None:
+            raise ValueError("Please specify `meta`.")
+        self_meta = self._ddf._meta.copy()
+        meta = npd.NestedFrame(make_meta(meta))
 
-        def _make_result_meta(self_meta, meta):
+        def _make_result_meta():
+            nonlocal self_meta, meta
             added_nested_subcols = [str(col) for col in meta.columns if "." in str(col)]
             self_meta = self_meta.assign(**{col: meta[col] for col in added_nested_subcols})
             meta = meta.drop(columns=added_nested_subcols)
             return concat_metas([self_meta, meta])
 
         if append_columns:
-            self_meta = self._ddf._meta.copy()
-            meta = npd.NestedFrame(make_meta(meta))
-            if ra_column in meta.columns or dec_column in meta.columns:
-                raise ValueError("ra and dec columns can not be modified using `map_rows`")
-            meta = _make_result_meta(self_meta, meta)
+            overlapping_columns = set(self_meta.columns) & set(meta.columns)
+            if overlapping_columns:
+                raise ValueError(
+                    f"`meta` specifies columns to append that already exist: {list(overlapping_columns)}."
+                )
+            meta = _make_result_meta()
+        else:
+            radec_columns = {
+                self.hc_structure.catalog_info.ra_column,
+                self.hc_structure.catalog_info.dec_column,
+            }
+            if radec_columns & set(meta.columns):
+                warnings.warn(
+                    f"`meta` specifies positional columns {list(radec_columns)} that should NOT be modified.",
+                    RuntimeWarning,
+                )
 
         ndf = self._ddf.map_rows(
             func,
@@ -1610,11 +1630,7 @@ class HealpixDataset:
             meta=meta,
             **kwargs,
         )
-
-        hc_updates = {}
-        if not append_columns:
-            hc_updates = {"ra_column": "", "dec_column": ""}
-        return self._create_updated_dataset(ddf=ndf, updated_catalog_info_params=hc_updates)
+        return self._create_updated_dataset(ddf=ndf)
 
     # pylint: disable=duplicate-code
     def plot_points(

--- a/tests/lsdb/catalog/test_nested.py
+++ b/tests/lsdb/catalog/test_nested.py
@@ -101,29 +101,17 @@ def test_map_rows_meta_required(small_sky_with_nested_sources):
         )
 
 
-def test_map_rows_warns_on_radec_overwrite(small_sky_with_nested_sources):
+def test_map_rows_raises_on_radec_overwrite(small_sky_with_nested_sources):
     def mean_mag(ra, dec, mag):
         return {"ra": ra, "dec": dec, "mean_mag": np.mean(mag)}
 
-    with pytest.warns(RuntimeWarning, match="specifies positional columns"):
-        reduced_cat = small_sky_with_nested_sources.map_rows(
+    with pytest.raises(ValueError, match="specifies positional columns"):
+        small_sky_with_nested_sources.map_rows(
             mean_mag,
             columns=["ra", "dec", "sources.mag"],
             row_container="args",
             meta={"ra": float, "dec": float, "mean_mag": float},
         )
-
-    assert reduced_cat.hc_structure.catalog_info.ra_column == ""
-    assert reduced_cat.hc_structure.catalog_info.dec_column == ""
-
-    reduced_ddf = small_sky_with_nested_sources._ddf.map_rows(
-        mean_mag,
-        columns=["ra", "dec", "sources.mag"],
-        row_container="args",
-        meta={"ra": float, "dec": float, "mean_mag": float},
-    )
-
-    pd.testing.assert_frame_equal(reduced_cat.compute(), reduced_ddf.compute())
 
 
 def test_map_rows_append_columns(small_sky_with_nested_sources):

--- a/tests/lsdb/catalog/test_nested.py
+++ b/tests/lsdb/catalog/test_nested.py
@@ -66,33 +66,42 @@ def test_nest_lists_only_list_columns(small_sky_with_nested_sources):
 
 
 def test_map_rows(small_sky_with_nested_sources):
-    def mean_mag(ra, dec, mag):
-        return {"ra": ra, "dec": dec, "mean_mag": np.mean(mag)}
+    def mean_mag(mag):
+        return {"mean_mag": np.mean(mag)}
 
     reduced_cat = small_sky_with_nested_sources.map_rows(
         mean_mag,
-        columns=["ra", "dec", "sources.mag"],
+        columns=["sources.mag"],
         row_container="args",
-        meta={"ra": float, "dec": float, "mean_mag": float},
+        meta={"mean_mag": float},
     )
-
     assert isinstance(reduced_cat, Catalog)
     assert isinstance(reduced_cat._ddf, nd.NestedFrame)
-
-    assert reduced_cat.hc_structure.catalog_info.ra_column == ""
-    assert reduced_cat.hc_structure.catalog_info.dec_column == ""
 
     reduced_cat_compute = reduced_cat.compute()
     assert isinstance(reduced_cat_compute, npd.NestedFrame)
 
     reduced_ddf = small_sky_with_nested_sources._ddf.map_rows(
         mean_mag,
-        columns=["ra", "dec", "sources.mag"],
+        columns=["sources.mag"],
         row_container="args",
-        meta={"ra": float, "dec": float, "mean_mag": float},
+        meta={"mean_mag": float},
     )
 
     pd.testing.assert_frame_equal(reduced_cat_compute, reduced_ddf.compute())
+
+
+def test_map_rows_warns_on_radec_overwrite(small_sky_with_nested_sources):
+    def mean_mag(ra, dec, mag):
+        return {"ra": ra, "dec": dec, "mean_mag": np.mean(mag)}
+
+    with pytest.warns(RuntimeWarning, match="specifies positional columns"):
+        small_sky_with_nested_sources.map_rows(
+            mean_mag,
+            columns=["ra", "dec", "sources.mag"],
+            row_container="args",
+            meta={"ra": float, "dec": float, "mean_mag": float},
+        )
 
 
 def test_map_rows_append_columns(small_sky_with_nested_sources):
@@ -158,6 +167,20 @@ def test_map_rows_append_columns(small_sky_with_nested_sources):
     pd.testing.assert_series_equal(expected_t_ra, reduced_cat_compute["sources.t_ra"])
 
 
+def test_map_rows_append_columns_raises_error_on_overlap(small_sky_with_nested_sources):
+    def passthrough_mag(obj_id, ra_err, dec_err):
+        return {"id": obj_id % 10, "mean_err": abs(ra_err - dec_err) / 2}
+
+    with pytest.raises(ValueError, match="already exist"):
+        small_sky_with_nested_sources.map_rows(
+            passthrough_mag,
+            columns=["id", "ra_error", "dec_error"],
+            row_container="args",
+            meta={"id": float, "mean_err": float},
+            append_columns=True,
+        )
+
+
 def test_map_rows_no_return_column(small_sky_with_nested_sources):
     def mean_mag(mag):
         return np.mean(mag)
@@ -206,20 +229,6 @@ def test_map_rows_invalid_return_column(small_sky_with_nested_sources):
 
     with pytest.raises(ValueError):
         reduced_cat.compute()
-
-
-def test_map_rows_append_columns_raises_error(small_sky_with_nested_sources):
-    def mean_mag(ra, dec, mag):
-        return {"ra": ra, "dec": dec, "mean_mag": np.mean(mag)}
-
-    with pytest.raises(ValueError):
-        small_sky_with_nested_sources.map_rows(
-            mean_mag,
-            columns=["ra", "dec", "sources.mag"],
-            row_container="args",
-            meta={"ra": float, "dec": float, "mean_mag": float},
-            append_columns=True,
-        ).compute()
 
 
 def test_map_rows_infer_nesting(small_sky_with_nested_sources):

--- a/tests/lsdb/catalog/test_nested.py
+++ b/tests/lsdb/catalog/test_nested.py
@@ -66,14 +66,14 @@ def test_nest_lists_only_list_columns(small_sky_with_nested_sources):
 
 
 def test_map_rows(small_sky_with_nested_sources):
-    def mean_mag(mag):
-        return {"mean_mag": np.mean(mag)}
+    def mean_mag(ra, dec, mag):
+        return {"ra": ra, "dec": dec, "mean_mag": np.mean(mag)}
 
     reduced_cat = small_sky_with_nested_sources.map_rows(
         mean_mag,
-        columns=["sources.mag"],
+        columns=["ra", "dec", "sources.mag"],
         row_container="args",
-        meta={"mean_mag": float},
+        meta={"ra": float, "dec": float, "mean_mag": float},
     )
     assert isinstance(reduced_cat, Catalog)
     assert isinstance(reduced_cat._ddf, nd.NestedFrame)
@@ -86,9 +86,9 @@ def test_map_rows(small_sky_with_nested_sources):
 
     reduced_ddf = small_sky_with_nested_sources._ddf.map_rows(
         mean_mag,
-        columns=["sources.mag"],
+        columns=["ra", "dec", "sources.mag"],
         row_container="args",
-        meta={"mean_mag": float},
+        meta={"ra": float, "dec": float, "mean_mag": float},
     )
 
     pd.testing.assert_frame_equal(reduced_cat_compute, reduced_ddf.compute())
@@ -98,19 +98,6 @@ def test_map_rows_meta_required(small_sky_with_nested_sources):
     with pytest.raises(ValueError, match="specify `meta`"):
         small_sky_with_nested_sources.map_rows(
             lambda mag: {"mean_mag": np.mean(mag)}, columns=["sources.mag"], meta=None
-        )
-
-
-def test_map_rows_raises_on_radec_overwrite(small_sky_with_nested_sources):
-    def mean_mag(ra, dec, mag):
-        return {"ra": ra, "dec": dec, "mean_mag": np.mean(mag)}
-
-    with pytest.raises(ValueError, match="specifies positional columns"):
-        small_sky_with_nested_sources.map_rows(
-            mean_mag,
-            columns=["ra", "dec", "sources.mag"],
-            row_container="args",
-            meta={"ra": float, "dec": float, "mean_mag": float},
         )
 
 

--- a/tests/lsdb/catalog/test_nested.py
+++ b/tests/lsdb/catalog/test_nested.py
@@ -78,6 +78,9 @@ def test_map_rows(small_sky_with_nested_sources):
     assert isinstance(reduced_cat, Catalog)
     assert isinstance(reduced_cat._ddf, nd.NestedFrame)
 
+    assert reduced_cat.hc_structure.catalog_info.ra_column == "ra"
+    assert reduced_cat.hc_structure.catalog_info.dec_column == "dec"
+
     reduced_cat_compute = reduced_cat.compute()
     assert isinstance(reduced_cat_compute, npd.NestedFrame)
 
@@ -91,17 +94,36 @@ def test_map_rows(small_sky_with_nested_sources):
     pd.testing.assert_frame_equal(reduced_cat_compute, reduced_ddf.compute())
 
 
+def test_map_rows_meta_required(small_sky_with_nested_sources):
+    with pytest.raises(ValueError, match="specify `meta`"):
+        small_sky_with_nested_sources.map_rows(
+            lambda mag: {"mean_mag": np.mean(mag)}, columns=["sources.mag"], meta=None
+        )
+
+
 def test_map_rows_warns_on_radec_overwrite(small_sky_with_nested_sources):
     def mean_mag(ra, dec, mag):
         return {"ra": ra, "dec": dec, "mean_mag": np.mean(mag)}
 
     with pytest.warns(RuntimeWarning, match="specifies positional columns"):
-        small_sky_with_nested_sources.map_rows(
+        reduced_cat = small_sky_with_nested_sources.map_rows(
             mean_mag,
             columns=["ra", "dec", "sources.mag"],
             row_container="args",
             meta={"ra": float, "dec": float, "mean_mag": float},
         )
+
+    assert reduced_cat.hc_structure.catalog_info.ra_column == ""
+    assert reduced_cat.hc_structure.catalog_info.dec_column == ""
+
+    reduced_ddf = small_sky_with_nested_sources._ddf.map_rows(
+        mean_mag,
+        columns=["ra", "dec", "sources.mag"],
+        row_container="args",
+        meta={"ra": float, "dec": float, "mean_mag": float},
+    )
+
+    pd.testing.assert_frame_equal(reduced_cat.compute(), reduced_ddf.compute())
 
 
 def test_map_rows_append_columns(small_sky_with_nested_sources):
@@ -168,15 +190,32 @@ def test_map_rows_append_columns(small_sky_with_nested_sources):
 
 
 def test_map_rows_append_columns_raises_error_on_overlap(small_sky_with_nested_sources):
-    def passthrough_mag(obj_id, ra_err, dec_err):
-        return {"id": obj_id % 10, "mean_err": abs(ra_err - dec_err) / 2}
+    def calc_magerr(obj_id, ra_err, dec_err):
+        return {"id": obj_id, "mean_err": abs(ra_err - dec_err) / 2}
 
     with pytest.raises(ValueError, match="already exist"):
         small_sky_with_nested_sources.map_rows(
-            passthrough_mag,
+            calc_magerr,
             columns=["id", "ra_error", "dec_error"],
             row_container="args",
-            meta={"id": float, "mean_err": float},
+            meta={"id": float, "mean_err": float},  # "id" column already exists in the catalog
+            append_columns=True,
+        )
+
+
+def test_map_rows_append_columns_raises_error_with_full_meta(small_sky_with_nested_sources):
+    def calc_magerr(ra_err, dec_err):
+        return {"mean_err": abs(ra_err - dec_err) / 2}
+
+    meta = small_sky_with_nested_sources._ddf._meta.copy()
+    meta["mean_err"] = np.float64(0)
+
+    with pytest.raises(ValueError, match="already exist"):
+        small_sky_with_nested_sources.map_rows(
+            calc_magerr,
+            columns=["ra_error", "dec_error"],
+            row_container="args",
+            meta=meta,  # should not be full meta when `append_columns` is set
             append_columns=True,
         )
 


### PR DESCRIPTION
Improve how we handle the metadata in `map_rows` and the related docstrings:

- Require `meta` to be specified.
- Issue error when trying to append columns that already exist. If the user tries to specify the full meta this is the error that will bubble up. Hopefully it's a lot clearer than what Sam got in issue #1338. 

Closes #1338.