### PR TITLE
Allow writing catalog with pixel directories

### DIFF
--- a/src/lsdb/io/to_hats.py
+++ b/src/lsdb/io/to_hats.py
@@ -67,7 +67,11 @@ def perform_write(
     if len(df) == 0:
         return 0, SparseHistogram([], [], histogram_order)
     pixel_path = hc.io.paths.new_pixel_catalog_file(
-        base_catalog_dir, hp_pixel, npix_suffix=npix_suffix, npix_parquet_name=npix_parquet_name
+        base_catalog_dir,
+        hp_pixel,
+        create_dirs=True,
+        npix_suffix=npix_suffix,
+        npix_parquet_name=npix_parquet_name,
     )
     df.to_parquet(pixel_path.path, filesystem=pixel_path.fs, **kwargs)
     histogram = calculate_histogram(df, histogram_order)

--- a/src/lsdb/io/to_hats.py
+++ b/src/lsdb/io/to_hats.py
@@ -32,6 +32,8 @@ def perform_write(
     hp_pixel: HealpixPixel,
     base_catalog_dir: UPath,
     histogram_order: int,
+    npix_suffix: str = ".parquet",
+    npix_parquet_name: str | None = None,
     **kwargs,
 ) -> tuple[int, SparseHistogram]:
     """Writes a pandas dataframe to a single parquet file and returns the total count
@@ -47,6 +49,12 @@ def perform_write(
         Location of the base catalog directory to write to
     histogram_order : int
         Order of the count histogram
+    npix_suffix : str, default '.parquet'
+        Extension for the parquet file (or `/` if a directory)
+    npix_parquet_name : str | None, default None
+        Name of the pixel parquet file to be used when npix_suffix=/.
+        By default, it will be named after the pixel with a .parquet
+        extension (e.g. 'Npix=10.parquet').
     **kwargs
         Other kwargs to pass to pq.write_table method
 
@@ -58,9 +66,9 @@ def perform_write(
     """
     if len(df) == 0:
         return 0, SparseHistogram([], [], histogram_order)
-    pixel_dir = hc.io.pixel_directory(base_catalog_dir, hp_pixel.order, hp_pixel.pixel)
-    hc.io.file_io.make_directory(pixel_dir, exist_ok=True)
-    pixel_path = hc.io.paths.pixel_catalog_file(base_catalog_dir, hp_pixel)
+    pixel_path = hc.io.paths.new_pixel_catalog_file(
+        base_catalog_dir, hp_pixel, npix_suffix=npix_suffix, npix_parquet_name=npix_parquet_name
+    )
     df.to_parquet(pixel_path.path, filesystem=pixel_path.fs, **kwargs)
     histogram = calculate_histogram(df, histogram_order)
     write_histogram(histogram, base_catalog_dir, hp_pixel)
@@ -235,6 +243,8 @@ def to_hats(
     tqdm_kwargs=None,
     create_thumbnail: bool = False,
     skymap_alt_orders: list[int] | None = None,
+    npix_suffix: str = ".parquet",
+    npix_parquet_name: str | None = None,
     addl_hats_properties: dict | None = None,
     error_if_empty: bool = True,
     **kwargs,
@@ -277,6 +287,12 @@ def to_hats(
     skymap_alt_orders : list[int] or None, default None
         We will write a skymap file at the ``histogram_order``,
         but can also write down-sampled skymaps, for easier previewing of the data.
+    npix_suffix : str, default '.parquet'
+        Extension for the parquet file (or `/` if a directory)
+    npix_parquet_name : str | None, default None
+        Name of the pixel parquet file to be used when npix_suffix=/.
+        By default, it will be named after the pixel with a .parquet
+        extension (e.g. 'Npix=10.parquet').
     addl_hats_properties : dict or None, default None
         key-value pairs of additional properties to write in the
         ``hats.properties`` file.
@@ -324,6 +340,8 @@ def to_hats(
             base_catalog_dir_fp=base_catalog_path,
             histogram_order=histogram_order,
             existing_pixels=existing_pixels,
+            npix_suffix=npix_suffix,
+            npix_parquet_name=npix_parquet_name,
             **kwargs,
         )
         pixels = existing_pixels + new_pixels
@@ -367,6 +385,7 @@ def to_hats(
         total_rows=int(np.sum(counts)),
         default_columns=default_columns,
         hats_max_rows=hats_max_rows,
+        hats_npix_suffix=npix_suffix,
         **addl_hats_properties,
     )
     new_hc_structure.catalog_info.to_properties_file(base_catalog_path)
@@ -464,6 +483,8 @@ def write_partitions(
     base_catalog_dir_fp: str | Path | UPath,
     histogram_order: int,
     existing_pixels: list[HealpixPixel] | None = None,
+    npix_suffix: str = ".parquet",
+    npix_parquet_name: str | None = None,
     **kwargs,
 ) -> tuple[list[HealpixPixel], list[int], list[SparseHistogram]]:
     """Saves catalog partitions as parquet to disk and computes the sparse
@@ -478,6 +499,14 @@ def write_partitions(
         Path to the base directory of the catalog
     histogram_order : int
         The order of the count histogram to generate
+    existing_pixels : list[HealpixPixel] | None, default None
+        The pixels that already exist and should be skipped.
+    npix_suffix : str, default '.parquet'
+        Extension for the parquet file (or `/` if a directory)
+    npix_parquet_name : str | None, default None
+        Name of the pixel parquet file to be used when npix_suffix=/.
+        By default, it will be named after the pixel with a .parquet
+        extension (e.g. 'Npix=10.parquet').
     **kwargs
         Arguments to pass to the parquet write operations
 
@@ -501,6 +530,8 @@ def write_partitions(
                 pixel,
                 base_catalog_dir_fp,
                 histogram_order,
+                npix_suffix,
+                npix_parquet_name,
                 **kwargs,
             )
         )

--- a/tests/lsdb/io/test_to_hats.py
+++ b/tests/lsdb/io/test_to_hats.py
@@ -173,6 +173,28 @@ def test_save_catalog_empty_default_columns(small_sky_order1_default_cols_catalo
     helpers.assert_default_columns_in_columns(expected_catalog)
 
 
+def test_save_catalog_with_npix_suffix(small_sky_order1_collection_catalog, tmp_path):
+    small_sky_order1_collection_catalog.write_catalog(
+        tmp_path / "small_sky_collection",
+        npix_suffix="/",
+        npix_parquet_name="data.pq",
+    )
+
+    collection_path = tmp_path / "small_sky_collection"
+    catalog = lsdb.read_hats(collection_path)
+
+    pixel_path = "dataset/Norder=1/Dir=0/Npix=44/data.pq"
+    assert catalog.hc_structure.catalog_info.npix_suffix == "/"
+    assert (collection_path / "small_sky_order1" / pixel_path).exists()
+    assert catalog.margin.hc_structure.catalog_info.npix_suffix == "/"
+    assert (collection_path / "small_sky_order1_3600arcs" / pixel_path).exists()
+
+    expected_cat = small_sky_order1_collection_catalog.compute()
+    pd.testing.assert_frame_equal(expected_cat, catalog.compute())
+    expected_margin = small_sky_order1_collection_catalog.margin.compute()
+    pd.testing.assert_frame_equal(expected_margin, catalog.margin.compute())
+
+
 def test_save_catalog_invalid_default_columns(small_sky_order1_default_cols_catalog, tmp_path):
     new_catalog_name = "small_sky_order1"
     base_catalog_path = Path(tmp_path) / new_catalog_name


### PR DESCRIPTION
Allow writing catalogs with pixel directories. This mimics a behavior already present in `hats-import`. Closes #1066.