### PR TITLE
Use same partitioning strategy for lsdb and hats-import.

### DIFF
--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -318,6 +318,7 @@ class DataframeCatalogLoader:
             threshold=(self.partition_rows if self.partition_rows is not None else self.partition_bytes),
             drop_empty_siblings=self.drop_empty_siblings,
             mem_size_histogram=mem_size_histogram,
+            use_lower_order=True,
         )
         pixel_list = list({HealpixPixel(tup[0], tup[1]) for tup in alignment if not tup is None})
         return list(np.array(pixel_list)[get_pixel_argsort(pixel_list)])


### PR DESCRIPTION
Introduced this regression with https://github.com/astronomy-commons/hats-import/pull/673

Causes assert failure in docs build.