### PR TITLE
Move Margin Catalogs notebook to Catalogs section

### DIFF
--- a/docs/tutorial_toc/toc_analyzing.rst
+++ b/docs/tutorial_toc/toc_analyzing.rst
@@ -7,7 +7,6 @@ An introduction to the most common Catalog operations
     :maxdepth: 1
 
     Setting up a Dask Client </tutorials/dask_client>
-    Margins </tutorials/margins>
     Crossmatching catalogs </tutorials/pre_executed/crossmatching>
     Applying a function (e.g. map_partitions) </tutorials/pre_executed/map_partitions>
     Working with TimeSeries </tutorials/pre_executed/timeseries>

--- a/docs/tutorial_toc/toc_catalogs.rst
+++ b/docs/tutorial_toc/toc_catalogs.rst
@@ -12,4 +12,5 @@ An introduction to LSDB's core feature: ``Catalog``
     Region selection filtering (e.g. search_filter) </tutorials/region_selection>
     Row filtering (e.g. .query) </tutorials/row_filtering>
     Single row selection </tutorials/pre_executed/index_table>
+    Margin Catalogs </tutorials/margins>
     Custom Structured Search </tutorials/pre_executed/custom_search>

--- a/docs/tutorials/margins.ipynb
+++ b/docs/tutorials/margins.ipynb
@@ -323,11 +323,6 @@
     "\n",
     "If you use `lsdb` for published research, please cite following [instructions](https://docs.lsdb.io/en/stable/citation.html)."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Waiting for RTD build so I can see if I like how it looks after all...

Edit: alright, I think this is fine. Not in love with it, but can't think of a better place. Link to RTD render for convenience: https://lsdb--1385.org.readthedocs.build/en/1385/tutorials/margins.html 

Closes #1174 