### PR TITLE
Update link to server.data.lsdb.io

### DIFF
--- a/docs/data-access/server-lsdb.rst
+++ b/docs/data-access/server-lsdb.rst
@@ -1,4 +1,4 @@
-[Under Construction] server.lsdb.io Experimental Service
+[Under Construction] server.data.lsdb.io Experimental Service
 ========================================================================================
 
 The LSDB server service provides server-side filtering access to public HATS catalogs.
@@ -6,7 +6,7 @@ The LSDB server service provides server-side filtering access to public HATS cat
 Link
 ----------------------------------------------------------------------------------------
 
-- Server endpoint: https://server.lsdb.io
+- Server endpoint: https://server.data.lsdb.io
 
 
 


### PR DESCRIPTION
Corrects the server endpoint URL in the server-lsdb.io docs page from https://server.lsdb.io to the correct address https://server.data.lsdb.io. The page title was updated to match as well.