### PR TITLE
Fix missing pylance dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ full = [
     "ipykernel", # Support for Jupyter notebooks
     "ipywidgets", # useful for tqdm in notebooks.
     "lancedb", # Used to write lance datasets in to_lance.py
+    "pylance", # needed for lance testing
     "lsst-sphgeom ; sys_platform == 'darwin' or sys_platform == 'linux'", # To handle spherical sky polygons, not available on Windows
     "matplotlib",
 ]


### PR DESCRIPTION
Needed for a few unit tests, looks to work on the smoke test: https://github.com/astronomy-commons/lsdb/actions/runs/26650179596

Wondering why this ever worked though?