### PR TITLE
Fix self-crossmatch failing due to identical default suffixes

### DIFF
--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -44,6 +44,8 @@ from lsdb.types import DaskDFPixelMap
 
 def _default_suffixes(left_name: str, right_name: str) -> tuple[str, str]:
     """Return the default pair of suffixes for left/right catalog names."""
+    if left_name == right_name:
+        return ("_l", "_r")
     return (f"_{left_name}", f"_{right_name}")
 
 

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -45,7 +45,7 @@ from lsdb.types import DaskDFPixelMap
 def _default_suffixes(left_name: str, right_name: str) -> tuple[str, str]:
     """Return the default pair of suffixes for left/right catalog names."""
     if left_name == right_name:
-        return ("_l", "_r")
+        return ("", "_right")
     return (f"_{left_name}", f"_{right_name}")
 
 

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -976,6 +976,6 @@ def test_crossmatch_nested_inner_join_no_nulls_in_nested_column():
 def test_self_crossmatch_default_suffixes(small_sky_catalog):
     result = small_sky_catalog.crossmatch(small_sky_catalog).compute()
     for col in small_sky_catalog.columns:
-        assert f"{col}_l" in result.columns
-        assert f"{col}_r" in result.columns
+        assert f"{col}" in result.columns
+        assert f"{col}_right" in result.columns
     assert len(set(result.columns)) == len(result.columns)

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -971,3 +971,11 @@ def test_crossmatch_nested_inner_join_no_nulls_in_nested_column():
 
     # No null values in the nested column — every row must have at least one match
     assert not result["matches"].isna().any()
+
+
+def test_self_crossmatch_default_suffixes(small_sky_catalog):
+    result = small_sky_catalog.crossmatch(small_sky_catalog).compute()
+    for col in small_sky_catalog.columns:
+        assert f"{col}_l" in result.columns
+        assert f"{col}_r" in result.columns
+    assert len(set(result.columns)) == len(result.columns)


### PR DESCRIPTION
Fixed self-crossmatch failing due to identical default suffixes and by adding ("", "_right")  to identical columns. 

fixes #1275