### PR TITLE
Fix columns in HTTP query params

### DIFF
--- a/src/lsdb/loaders/hats/hats_loading_config.py
+++ b/src/lsdb/loaders/hats/hats_loading_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import copy
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
@@ -89,7 +90,7 @@ class HatsLoadingConfig:
         url_params: dict[str, Any] = {}
 
         if self.columns and len(self.columns) > 0:
-            url_params["columns"] = self.columns
+            url_params["columns"] = copy(self.columns)
 
         if self.filters:
             filters = []

--- a/src/lsdb/loaders/hats/read_hats.py
+++ b/src/lsdb/loaders/hats/read_hats.py
@@ -429,11 +429,15 @@ def _load_dask_df_and_map(catalog: HCHealpixDataset, config) -> tuple[nd.NestedF
     pixels = catalog.get_healpix_pixels()
     ordered_pixels = np.array(pixels)[get_pixel_argsort(pixels)]
     divisions = get_pixels_divisions(ordered_pixels)
-    dask_meta_schema = _load_dask_meta_schema(catalog, config)
-    index_column = dask_meta_schema.index.name
+
+    # Assign query parameters before a potential change of `config.columns`
+    # by _load_dask_meta_schema call.
     query_url_params = None
     if isinstance(file_io.get_upath(catalog.catalog_base_dir).fs, HTTPFileSystem):
         query_url_params = config.make_query_url_params()
+
+    dask_meta_schema = _load_dask_meta_schema(catalog, config)
+    index_column = dask_meta_schema.index.name
     npix_suffix = catalog.catalog_info.npix_suffix
     if len(ordered_pixels) > 0:
         ddf = nd.NestedFrame.from_map(


### PR DESCRIPTION
Fix a couple of bugs affecting the construction of `columns` query params and preventing the `_healpix_29` column from appearing there.