### PR TITLE
Improve crossmatch coordinate column errors

### DIFF
--- a/src/lsdb/core/crossmatch/crossmatch.py
+++ b/src/lsdb/core/crossmatch/crossmatch.py
@@ -20,7 +20,18 @@ def _validate_and_convert_to_catalog(
         data_args["catalog_name"] = suffix if suffix else default_suffix
 
     # Convert the DataFrame to a Catalog.
-    data = from_dataframe(data, **data_args)
+    try:
+        data = from_dataframe(data, **data_args)
+    except ValueError as error:
+        for coordinate in ("ra", "dec"):
+            if str(error) == f"No column found for {coordinate}":
+                column_arg = f"{coordinate}_column"
+                raise ValueError(
+                    f"{error}. Specify the column with "
+                    f"{default_suffix}_args={{'{column_arg}': '<column_name>'}}, "
+                    f"or use {column_arg}=... when both inputs share the same column name."
+                ) from error
+        raise
     return data
 
 

--- a/tests/lsdb/core/test_crossmatch_function.py
+++ b/tests/lsdb/core/test_crossmatch_function.py
@@ -125,12 +125,18 @@ def test_ra_dec_columns_crossmatch(small_sky_catalog, small_sky_xmatch_catalog, 
     right_dataframe_abnormal_dec_col = right_dataframe.rename(columns={"dec": "abnormal_dec_col_name"})
 
     # Crossmatch method attempts to use default column names and fails
-    with pytest.raises(ValueError, match="No column found for ra"):
+    with pytest.raises(
+        ValueError,
+        match=r"No column found for ra.*right_args=\{'ra_column': '<column_name>'\}",
+    ):
         lsdb.crossmatch(
             left_dataframe,
             right_dataframe_abnormal_ra_col,
         )
-    with pytest.raises(ValueError, match="No column found for dec"):
+    with pytest.raises(
+        ValueError,
+        match=r"No column found for dec.*right_args=\{'dec_column': '<column_name>'\}",
+    ):
         lsdb.crossmatch(
             left_dataframe,
             right_dataframe_abnormal_dec_col,


### PR DESCRIPTION
Fixes #1393.

When a DataFrame crossmatch cannot infer its RA or Dec column, the error now shows the input-specific override (`left_args` or `right_args`) and the top-level alternative for catalogs that share a column name. Other `from_dataframe` validation errors remain unchanged.

The existing crossmatch regression test now verifies the RA and Dec suggestions.

Validation:
- `python -m pytest tests/lsdb/core/test_crossmatch_function.py -q` (9 passed)
- Black and isort checks on both changed files
- Pylint 10.00/10 on both changed files
- Mypy on both changed files
- Direct `lsdb.crossmatch` reproduction confirmed the new `right_args={'ra_column': '<column_name>'}` hint
