### PR TITLE
Add tutorial repo links

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -17,3 +17,18 @@ functionality.
    tutorial_toc/toc_science
    tutorial_toc/toc_debugging
 
+Workshop & Event Materials
+----------------------------------------------------------------------------------------
+
+We run hands-on LSDB tutorials at hackathons, workshops, and conferences. The
+materials from these events live in standalone GitHub repositories that you can clone and
+work through on your own:
+
+* `AstroAI 2026 LSDB Tutorial <https://github.com/lincc-frameworks/astroai2026-tutorial-lsdb>`_
+* `LSST-DA Regional Meeting at JHU 2025 — "From Transients to Cosmology" <https://github.com/lincc-frameworks/LSST-DA-meeting-JHU>`_
+* `DESC Dark Matter Workshop 2025 — Stellar Streams in LSST <https://github.com/lincc-frameworks/DESC_Stellar_Streams_2025>`_
+* `Rubin Community Workshop 2025 Hackathon <https://github.com/lincc-frameworks/RCW_Hackathon_2025_LSDB>`_
+* `AGN Science Collaboration Meeting 2025 Hackathon <https://github.com/lincc-frameworks/AGN_SC_2025_LSDB>`_
+* `ADASS 2024 — LSDB and HATS Tutorial, Valletta <https://github.com/lincc-frameworks/ADASS_2024_LSDB_HATS>`_
+* `LINCC Catalyst / DSFP Hack Day 2024 <https://github.com/lincc-frameworks/catalyst-dsfp-hack-day-2024>`_
+


### PR DESCRIPTION
I believe it would be nice to have all the tutorial links on the web page, even if some of the materials are out of date.