### PR TITLE
Improve dataframe coordinate column errors

### DIFF
--- a/src/lsdb/core/crossmatch/crossmatch.py
+++ b/src/lsdb/core/crossmatch/crossmatch.py
@@ -20,7 +20,18 @@ def _validate_and_convert_to_catalog(
         data_args["catalog_name"] = suffix if suffix else default_suffix
 
     # Convert the DataFrame to a Catalog.
-    data = from_dataframe(data, **data_args)
+    try:
+        data = from_dataframe(data, **data_args)
+    except ValueError as error:
+        for coordinate in ("ra", "dec"):
+            if str(error) == f"No column found for {coordinate}":
+                column_arg = f"{coordinate}_column"
+                raise ValueError(
+                    f"{error}. Specify the column with "
+                    f"{default_suffix}_args={{'{column_arg}': '<column_name>'}}, "
+                    f"or use {column_arg}=... when both inputs share the same column name."
+                ) from error
+        raise
     return data
 
 

--- a/src/lsdb/core/crossmatch/crossmatch.py
+++ b/src/lsdb/core/crossmatch/crossmatch.py
@@ -20,19 +20,7 @@ def _validate_and_convert_to_catalog(
         data_args["catalog_name"] = suffix if suffix else default_suffix
 
     # Convert the DataFrame to a Catalog.
-    try:
-        data = from_dataframe(data, **data_args)
-    except ValueError as error:
-        for coordinate in ("ra", "dec"):
-            if str(error) == f"No column found for {coordinate}":
-                column_arg = f"{coordinate}_column"
-                raise ValueError(
-                    f"{error}. Specify the column with "
-                    f"{default_suffix}_args={{'{column_arg}': '<column_name>'}}, "
-                    f"or use {column_arg}=... when both inputs share the same column name."
-                ) from error
-        raise
-    return data
+    return from_dataframe(data, **data_args)
 
 
 # pylint: disable=too-many-arguments

--- a/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
+++ b/src/lsdb/loaders/dataframe/dataframe_catalog_loader.py
@@ -92,6 +92,7 @@ class DataframeCatalogLoader:
             Arguments to pass to the creation of the catalog info.
         """
         self.dataframe = npd.NestedFrame(dataframe)
+        self.catalog_name = kwargs.get("catalog_name", "from_lsdb_dataframe")
         self.lowest_order = lowest_order
         self.highest_order = highest_order
         self.drop_empty_siblings = drop_empty_siblings
@@ -148,7 +149,10 @@ class DataframeCatalogLoader:
         ]
         n_matches = len(matches)
         if n_matches == 0:
-            raise ValueError(f"No column found for {search_term}")
+            raise ValueError(
+                f"No column found for {search_term} in catalog '{self.catalog_name}'. "
+                f"Specify {search_term}_column='<column_name>'."
+            )
         if n_matches > 1:
             raise ValueError(f"Found {n_matches} possible columns for {search_term}")
         return matches[0]

--- a/tests/lsdb/core/test_crossmatch_function.py
+++ b/tests/lsdb/core/test_crossmatch_function.py
@@ -151,12 +151,18 @@ def test_ra_dec_columns_crossmatch(small_sky_catalog, small_sky_xmatch_catalog, 
     right_dataframe_abnormal_dec_col = right_dataframe.rename(columns={"dec": "abnormal_dec_col_name"})
 
     # Crossmatch method attempts to use default column names and fails
-    with pytest.raises(ValueError, match="No column found for ra"):
+    with pytest.raises(
+        ValueError,
+        match=r"No column found for ra.*right_args=\{'ra_column': '<column_name>'\}",
+    ):
         lsdb.crossmatch(
             left_dataframe,
             right_dataframe_abnormal_ra_col,
         )
-    with pytest.raises(ValueError, match="No column found for dec"):
+    with pytest.raises(
+        ValueError,
+        match=r"No column found for dec.*right_args=\{'dec_column': '<column_name>'\}",
+    ):
         lsdb.crossmatch(
             left_dataframe,
             right_dataframe_abnormal_dec_col,

--- a/tests/lsdb/core/test_crossmatch_function.py
+++ b/tests/lsdb/core/test_crossmatch_function.py
@@ -153,7 +153,7 @@ def test_ra_dec_columns_crossmatch(small_sky_catalog, small_sky_xmatch_catalog, 
     # Crossmatch method attempts to use default column names and fails
     with pytest.raises(
         ValueError,
-        match=r"No column found for ra.*right_args=\{'ra_column': '<column_name>'\}",
+        match=r"No column found for ra in catalog 'right'.*Specify ra_column='<column_name>'",
     ):
         lsdb.crossmatch(
             left_dataframe,
@@ -161,7 +161,7 @@ def test_ra_dec_columns_crossmatch(small_sky_catalog, small_sky_xmatch_catalog, 
         )
     with pytest.raises(
         ValueError,
-        match=r"No column found for dec.*right_args=\{'dec_column': '<column_name>'\}",
+        match=r"No column found for dec in catalog 'right'.*Specify dec_column='<column_name>'",
     ):
         lsdb.crossmatch(
             left_dataframe,

--- a/tests/lsdb/loaders/dataframe/test_from_dataframe.py
+++ b/tests/lsdb/loaders/dataframe/test_from_dataframe.py
@@ -477,6 +477,11 @@ def test_from_dataframe_finds_radec_columns(small_sky_order1_df):
     df_no_radec = small_sky_order1_df.drop(columns=["ra", "dec"])
     with pytest.raises(ValueError, match="No column found"):
         lsdb.from_dataframe(df_no_radec, margin_threshold=None)
+    with pytest.raises(
+        ValueError,
+        match=r"No column found for ra in catalog 'sample_catalog'.*Specify ra_column='<column_name>'",
+    ):
+        lsdb.from_dataframe(df_no_radec, catalog_name="sample_catalog", margin_threshold=None)
     # If multiple matches are found it's ambiguous, and an error is raised
     small_sky_order1_df["RA"] = small_sky_order1_df["ra"].copy()
     with pytest.raises(ValueError, match="possible columns"):


### PR DESCRIPTION
Follow-up to #1435 after the review request in https://github.com/astronomy-commons/lsdb/pull/1435#discussion_r3460806814.

This moves the missing RA/Dec column error into the general `from_dataframe` path and includes the catalog name in the message, so the same validation applies outside crossmatch while crossmatch still reports whether the `left` or `right` input needs explicit coordinate columns.

Validation:
- `python -m pytest tests\lsdb\loaders\dataframe\test_from_dataframe.py::test_from_dataframe_finds_radec_columns tests\lsdb\core\test_crossmatch_function.py::test_ra_dec_columns_crossmatch -q`
- `python -m py_compile src\lsdb\loaders\dataframe\dataframe_catalog_loader.py src\lsdb\core\crossmatch\crossmatch.py`
- `python -m black --check src\lsdb\loaders\dataframe\dataframe_catalog_loader.py src\lsdb\core\crossmatch\crossmatch.py tests\lsdb\loaders\dataframe\test_from_dataframe.py tests\lsdb\core\test_crossmatch_function.py`
- `git diff --check`
