### PR TITLE
add summary file generation to write_catalog

### DIFF
--- a/docs/developer/contributing.rst
+++ b/docs/developer/contributing.rst
@@ -192,6 +192,7 @@ can run against all staged changes with the command:
     Thus, this bypass should only be used when necessary, 
     as resolving issues locally ensures successful CI/CD checks.)
     
+    
 
 Create a branch
 -------------------------------------------------------------------------------

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -1512,6 +1512,10 @@ class Catalog(HealpixDataset):
             per partition, for quick previewing of the catalog's contents.
         error_if_empty : bool, default True
             If True, raises an error if the catalog is empty.
+        create_summary : bool, default True
+            If True, writes ``README.md`` summary file(s) describing the catalog. When
+            ``as_collection`` is True, this generates a summary for the collection, the
+            main catalog, and the margin (if it exists).
         **kwargs
             Arguments to pass to the parquet write operations
 

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -1481,6 +1481,7 @@ class Catalog(HealpixDataset):
         tqdm_kwargs: dict | None = None,
         create_thumbnail: bool = True,
         error_if_empty: bool = True,
+        create_summary: bool = True,
         **kwargs,
     ):
         """Save the catalog to disk in HATS format.
@@ -1537,6 +1538,7 @@ class Catalog(HealpixDataset):
                 tqdm_kwargs=tqdm_kwargs,
                 error_if_empty=error_if_empty,
                 create_thumbnail=create_thumbnail,
+                create_summary=create_summary,
                 **kwargs,
             )
         else:
@@ -1550,5 +1552,6 @@ class Catalog(HealpixDataset):
                 tqdm_kwargs=tqdm_kwargs,
                 create_thumbnail=create_thumbnail,
                 error_if_empty=error_if_empty,
+                create_summary=create_summary,
                 **kwargs,
             )

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -1390,6 +1390,7 @@ class HealpixDataset:
         progress_bar: bool = True,
         tqdm_kwargs: dict | None = None,
         error_if_empty: bool = True,
+        create_summary: bool = True,
         **kwargs,
     ):
         """Save the catalog to disk in HATS format.
@@ -1429,6 +1430,7 @@ class HealpixDataset:
             progress_bar=progress_bar,
             tqdm_kwargs=tqdm_kwargs,
             error_if_empty=error_if_empty,
+            create_summary=create_summary,
             **kwargs,
         )
 

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -1416,6 +1416,8 @@ class HealpixDataset:
             Keyword arguments to pass to tqdm for customizing the progress bar
         error_if_empty : bool, default True
             If True, raises an error if the catalog is empty.
+        create_summary : bool, default True
+            If True, writes a ``README.md`` summary file describing the catalog.
         **kwargs
             Arguments to pass to the parquet write operations
         """

--- a/src/lsdb/catalog/margin_catalog.py
+++ b/src/lsdb/catalog/margin_catalog.py
@@ -61,6 +61,7 @@ class MarginCatalog(HealpixDataset):
         overwrite: bool = False,
         resume: bool = False,
         error_if_empty: bool = False,
+        create_summary: bool = True,
         **kwargs,
     ):
         super().write_catalog(
@@ -70,6 +71,7 @@ class MarginCatalog(HealpixDataset):
             overwrite=overwrite,
             resume=resume,
             error_if_empty=error_if_empty,
+            create_summary=create_summary,
             **kwargs,
         )
 

--- a/src/lsdb/io/to_collection.py
+++ b/src/lsdb/io/to_collection.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import hats as hc
 from hats.catalog.catalog_collection import CollectionProperties
+from hats.io.summary_file import write_catalog_summary_file
 from upath import UPath
 
 from lsdb.io.common import new_provenance_properties
@@ -19,6 +20,7 @@ def to_collection(
     progress_bar: bool = True,
     tqdm_kwargs: dict | None = None,
     error_if_empty: bool = True,
+    create_summary: bool = True,
     **kwargs,
 ):
     """Saves the catalog collection to disk in the HATS format.
@@ -68,6 +70,7 @@ def to_collection(
         progress_bar=progress_bar,
         tqdm_kwargs=tqdm_kwargs,
         error_if_empty=error_if_empty,
+        create_summary=create_summary,
         **kwargs,
     )
 
@@ -84,6 +87,7 @@ def to_collection(
             overwrite=overwrite,
             resume=resume,
             error_if_empty=False,
+            create_summary=create_summary,
             **kwargs,
         )
         properties = properties | {"all_margins": margin_name, "default_margin": margin_name}
@@ -91,3 +95,6 @@ def to_collection(
     properties = properties | new_provenance_properties(base_collection_path)
     collection_info = CollectionProperties(**properties)
     collection_info.to_properties_file(base_collection_path)
+
+    if create_summary:
+        write_catalog_summary_file(base_collection_path, fmt="markdown", huggingface_metadata=False)

--- a/src/lsdb/io/to_collection.py
+++ b/src/lsdb/io/to_collection.py
@@ -49,6 +49,9 @@ def to_collection(
         If progress_bar is True, these kwargs are passed to tqdm when creating the progress bar
     error_if_empty : bool, default True
         If True, raises an error if the catalog is empty
+    create_summary : bool, default True
+        If True, writes ``README.md`` summary files for the collection, the main
+        catalog, and the margin (if it exists).
     **kwargs
         Arguments to pass to the parquet write operations
     """

--- a/src/lsdb/io/to_hats.py
+++ b/src/lsdb/io/to_hats.py
@@ -14,6 +14,7 @@ from hats.catalog import CatalogType, PartitionInfo
 from hats.catalog.healpix_dataset.healpix_dataset import HealpixDataset as HCHealpixDataset
 from hats.io import file_io
 from hats.io.skymap import write_skymap
+from hats.io.summary_file import write_catalog_summary_file
 from hats.pixel_math import HealpixPixel, spatial_index_to_healpix
 from hats.pixel_math.sparse_histogram import HistogramAggregator, SparseHistogram
 from tqdm.dask import TqdmCallback
@@ -237,7 +238,7 @@ def remove_done_files(base_catalog_path: UPath):
     file_io.remove_directory(done_path, ignore_errors=True)
 
 
-# pylint: disable=protected-access,too-many-locals
+# pylint: disable=protected-access,too-many-locals,too-many-arguments
 def to_hats(
     catalog: HealpixDataset,
     *,
@@ -250,6 +251,7 @@ def to_hats(
     progress_bar: bool = True,
     tqdm_kwargs: dict | None = None,
     create_thumbnail: bool = False,
+    create_summary: bool = True,
     skymap_alt_orders: list[int] | None = None,
     npix_suffix: str = ".parquet",
     npix_parquet_name: str | None = None,
@@ -400,6 +402,9 @@ def to_hats(
 
     remove_histogram_files(base_catalog_path)
     remove_done_files(base_catalog_path)
+
+    if create_summary:
+        write_catalog_summary_file(base_catalog_path, fmt="markdown", huggingface_metadata=False)
 
 
 def _read_existing_progress(

--- a/src/lsdb/io/to_hats.py
+++ b/src/lsdb/io/to_hats.py
@@ -294,6 +294,8 @@ def to_hats(
     create_thumbnail : bool, default False
         If True, create a data thumbnail of the catalog for
         previewing purposes. Defaults to False.
+    create_summary : bool, default True
+        If True, writes a ``README.md`` summary file describing the catalog.
     skymap_alt_orders : list[int] or None, default None
         We will write a skymap file at the ``histogram_order``,
         but can also write down-sampled skymaps, for easier previewing of the data.

--- a/tests/lsdb/io/test_to_collection.py
+++ b/tests/lsdb/io/test_to_collection.py
@@ -183,3 +183,29 @@ def test_save_collection_with_empty_margin(small_sky_order1_df, tmp_path):
     assert catalog.margin.hc_structure.catalog_base_dir == base_collection_path / "small_sky_order1_10arcs"
     assert catalog.margin.hc_structure.catalog_info.margin_threshold == 10
     pd.testing.assert_frame_equal(expected_catalog.margin.compute(), catalog.margin.compute())
+
+
+def test_save_collection_creates_summary_by_default(small_sky_order1_collection_catalog, tmp_path):
+    base_collection_path = Path(tmp_path) / "small_sky_order1_collection"
+
+    small_sky_order1_collection_catalog.write_catalog(base_collection_path, catalog_name="small_sky_order1")
+
+    collection_summary = base_collection_path / "README.md"
+    catalog_summary = base_collection_path / "small_sky_order1" / "README.md"
+    margin_summary = base_collection_path / "small_sky_order1_3600arcs" / "README.md"
+
+    for summary_path in (collection_summary, catalog_summary, margin_summary):
+        assert summary_path.exists()
+        assert len(summary_path.read_text()) > 0
+
+
+def test_save_collection_no_summary(small_sky_order1_collection_catalog, tmp_path):
+    base_collection_path = Path(tmp_path) / "small_sky_order1_collection"
+
+    small_sky_order1_collection_catalog.write_catalog(
+        base_collection_path, catalog_name="small_sky_order1", create_summary=False
+    )
+
+    assert not (base_collection_path / "README.md").exists()
+    assert not (base_collection_path / "small_sky_order1" / "README.md").exists()
+    assert not (base_collection_path / "small_sky_order1_3600arcs" / "README.md").exists()

--- a/tests/lsdb/io/test_to_collection.py
+++ b/tests/lsdb/io/test_to_collection.py
@@ -187,13 +187,10 @@ def test_save_collection_with_empty_margin(small_sky_order1_df, tmp_path):
 
 def test_save_collection_creates_summary_by_default(small_sky_order1_collection_catalog, tmp_path):
     base_collection_path = Path(tmp_path) / "small_sky_order1_collection"
-
     small_sky_order1_collection_catalog.write_catalog(base_collection_path, catalog_name="small_sky_order1")
-
     collection_summary = base_collection_path / "README.md"
     catalog_summary = base_collection_path / "small_sky_order1" / "README.md"
     margin_summary = base_collection_path / "small_sky_order1_3600arcs" / "README.md"
-
     for summary_path in (collection_summary, catalog_summary, margin_summary):
         assert summary_path.exists()
         assert len(summary_path.read_text()) > 0
@@ -201,11 +198,9 @@ def test_save_collection_creates_summary_by_default(small_sky_order1_collection_
 
 def test_save_collection_no_summary(small_sky_order1_collection_catalog, tmp_path):
     base_collection_path = Path(tmp_path) / "small_sky_order1_collection"
-
     small_sky_order1_collection_catalog.write_catalog(
         base_collection_path, catalog_name="small_sky_order1", create_summary=False
     )
-
     assert not (base_collection_path / "README.md").exists()
     assert not (base_collection_path / "small_sky_order1" / "README.md").exists()
     assert not (base_collection_path / "small_sky_order1_3600arcs" / "README.md").exists()

--- a/tests/lsdb/io/test_to_hats.py
+++ b/tests/lsdb/io/test_to_hats.py
@@ -581,7 +581,6 @@ def test_resume_and_overwrite_catalog_write(small_sky_order1_catalog, tmp_path):
 def test_save_catalog_creates_summary_by_default(small_sky_order1_catalog, tmp_path):
     base_catalog_path = tmp_path / "small_sky"
     small_sky_order1_catalog.write_catalog(base_catalog_path, as_collection=False)
-
     summary_path = base_catalog_path / "README.md"
     assert summary_path.exists()
     assert len(summary_path.read_text()) > 0
@@ -590,5 +589,4 @@ def test_save_catalog_creates_summary_by_default(small_sky_order1_catalog, tmp_p
 def test_save_catalog_no_summary(small_sky_order1_catalog, tmp_path):
     base_catalog_path = tmp_path / "small_sky"
     small_sky_order1_catalog.write_catalog(base_catalog_path, as_collection=False, create_summary=False)
-
     assert not (base_catalog_path / "README.md").exists()

--- a/tests/lsdb/io/test_to_hats.py
+++ b/tests/lsdb/io/test_to_hats.py
@@ -576,3 +576,19 @@ def test_resume_and_overwrite_catalog_write(small_sky_order1_catalog, tmp_path):
 
     with pytest.raises(ValueError, match="overwrite and resume cannot both be True"):
         small_sky_order1_catalog.write_catalog(base_catalog_path, resume=True, overwrite=True)
+
+
+def test_save_catalog_creates_summary_by_default(small_sky_order1_catalog, tmp_path):
+    base_catalog_path = tmp_path / "small_sky"
+    small_sky_order1_catalog.write_catalog(base_catalog_path, as_collection=False)
+
+    summary_path = base_catalog_path / "README.md"
+    assert summary_path.exists()
+    assert len(summary_path.read_text()) > 0
+
+
+def test_save_catalog_no_summary(small_sky_order1_catalog, tmp_path):
+    base_catalog_path = tmp_path / "small_sky"
+    small_sky_order1_catalog.write_catalog(base_catalog_path, as_collection=False, create_summary=False)
+
+    assert not (base_catalog_path / "README.md").exists()


### PR DESCRIPTION
Add summary generation to write_catalog. There is now single control argument "create_summary" whose default value is always true and creates a markdown that is saved to disk.

When the as_collection argument is true (default value), it generates the collection, margin, and catalog margin markdown summary files. When it's false, HealpixDataset generates a catalog markdown summary.

If the user writes MarginCatalog.write_catalog(path, create_summary=True), a margin catalog summary file is generated.