### PR TITLE
Forward suffix_method/log_changes from lsdb.crossmatch() to Catalog.crossmatch() (#1470)

### DIFF
--- a/src/lsdb/core/crossmatch/crossmatch.py
+++ b/src/lsdb/core/crossmatch/crossmatch.py
@@ -28,6 +28,7 @@ def _validate_and_convert_to_catalog(
 def crossmatch(
     left: Catalog | npd.NestedFrame | pd.DataFrame,
     right: Catalog | npd.NestedFrame | pd.DataFrame,
+    *,
     ra_column: str | None = None,
     dec_column: str | None = None,
     n_neighbors: int | None = None,
@@ -40,6 +41,8 @@ def crossmatch(
     suffixes: tuple[str, str] | None = None,
     left_args: dict | None = None,
     right_args: dict | None = None,
+    suffix_method: str | None = None,
+    log_changes: bool = True,
 ) -> Catalog:
     """Perform a cross-match between two frames, two catalogs,
     a catalog and a frame, or a frame and a catalog.
@@ -83,6 +86,16 @@ def crossmatch(
         Keyword arguments to pass to from_dataframe for the left catalog.
     right_args : dict or None, default None
         Keyword arguments to pass to from_dataframe for the right catalog.
+    suffix_method : str or None, default "all_columns"
+        Method to use to add suffixes to columns. Options are:
+
+        - "overlapping_columns": only add suffixes to columns that are present in both catalogs
+        - "all_columns": add suffixes to all columns from both catalogs
+
+        .. warning:: This default will change to "overlapping_columns" in a future release.
+    log_changes : bool, default True
+        If True, logs an info message for each column that is being renamed.
+        This only applies when suffix_method is 'overlapping_columns'.
 
     Returns
     -------
@@ -126,4 +139,6 @@ def crossmatch(
         require_right_margin=require_right_margin,
         how=how,
         suffixes=suffixes,
+        suffix_method=suffix_method,
+        log_changes=log_changes,
     )

--- a/tests/lsdb/core/test_crossmatch_function.py
+++ b/tests/lsdb/core/test_crossmatch_function.py
@@ -1,3 +1,5 @@
+import warnings
+
 import nested_pandas as npd
 import numpy as np
 import pytest
@@ -77,6 +79,30 @@ def test_invalid_margin_args_crossmatch(small_sky_catalog, small_sky_xmatch_cata
             require_right_margin=True,
             right_args={"margin_threshold": None},
         )
+
+
+def test_crossmatch_forwards_suffix_method_and_log_changes(
+    small_sky_catalog, small_sky_xmatch_catalog, xmatch_correct
+):
+    """The top-level function must forward suffix_method / log_changes to Catalog.crossmatch().
+
+    Regression test for #1470: these params were absent from the function signature and the
+    delegating call, so a function-form caller could not reach them. A missing forward would
+    leave the method's suffix_method at None and trip the FutureWarning; supplying it here must
+    suppress the warning and produce a correct result.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        result = lsdb.crossmatch(
+            small_sky_catalog,
+            small_sky_xmatch_catalog,
+            radius_arcsec=0.01 * 3600,
+            suffix_method="all_columns",
+            log_changes=False,
+        ).compute()
+
+    assert isinstance(result, npd.NestedFrame)
+    assert len(result) == len(xmatch_correct)
 
 
 def test_crossmatch_healpix_indexes(small_sky_healpix13_dir, small_sky_xmatch_catalog, xmatch_correct):


### PR DESCRIPTION
Fixes #1470 — `suffix_method` / `log_changes` were reachable from `Catalog.crossmatch()` but not from the top-level `lsdb.crossmatch()`.

The new params are appended after `left_args`/`right_args` rather than placed next to `suffixes`: the function accepts positional args (the method is keyword-only), so inserting mid-signature would rebind a positional `left_args`/`right_args`.