### PR TITLE
Implement catalog view

### DIFF
--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -280,6 +280,7 @@ class HealpixDataset:
         if len(cols) == 0:
             return pd.DataFrame([[]] * len(index), columns=cols, index=index)
         show_statistics = (
+            # In-memory catalogs have no loading config
             self.loading_config is not None
             and self.loading_config.show_statistics
             and self._operation.pixel_stats_preserved
@@ -295,12 +296,15 @@ class HealpixDataset:
             non_nested_cols = [c for c in cols if c not in self.nested_columns]
             if len(non_nested_cols) == 0:
                 return None
-            return self.per_partition_statistics(
-                use_default_columns=False,
-                exclude_hats_columns=True,
-                include_columns=non_nested_cols,
-                include_stats=["min_value", "max_value"],
-            )
+            # Only reached when pixel stats are preserved.
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", message=".*modified catalog.*")
+                return self.per_partition_statistics(
+                    use_default_columns=False,
+                    exclude_hats_columns=True,
+                    include_columns=non_nested_cols,
+                    include_stats=["min_value", "max_value"],
+                )
         except Exception:  # pylint: disable=broad-exception-caught
             logging.debug("Could not read partition statistics for catalog %s", self.name, exc_info=True)
             return None

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -227,7 +227,20 @@ class HealpixDataset:
         return None
 
     def __repr__(self):
-        data = self._repr_data().to_string(max_rows=5, show_dimensions=False)
+        return self._format_text_repr(self._repr_data())
+
+    def _repr_html_(self):
+        return self._format_html_repr(self._repr_data())
+
+    def _repr_mimebundle_(self, **kwargs):  # pylint: disable=unused-argument
+        """Return both the text and HTML representations for notebook display."""
+        data = self._repr_data()
+        text = self._format_text_repr(data)
+        html = self._format_html_repr(data)
+        return {"text/plain": text, "text/html": html}
+
+    def _format_text_repr(self, data):
+        body = data.to_string(max_rows=5, show_dimensions=False)
         loaded_cols = len(self.columns)
         available_cols = len(self.all_columns)
         est_size = self.est_size()
@@ -238,13 +251,13 @@ class HealpixDataset:
         )
         return (
             f"lsdb Catalog {self.name}:\n"
-            f"{data}\n"
+            f"{body}\n"
             f"{loaded_cols} out of {available_cols} available columns in the catalog have been "
             f"loaded lazily, meaning no data has been read, only the catalog schema"
         ) + est_size_text
 
-    def _repr_html_(self):
-        data = self._repr_data().to_html(max_rows=5, show_dimensions=False, notebook=True)
+    def _format_html_repr(self, data):
+        body = data.to_html(max_rows=5, show_dimensions=False, notebook=True)
         loaded_cols = len(self.columns)
         available_cols = len(self.all_columns)
         est_size = self.est_size()
@@ -255,7 +268,7 @@ class HealpixDataset:
         )
         return (
             f"<div><strong>lsdb Catalog {self.name}:</strong></div>"
-            f"{data}"
+            f"{body}"
             f"<div>{loaded_cols} out of {available_cols} available columns in the catalog have been loaded "
             f"<strong>lazily</strong>, meaning no data has been read, only the catalog schema</div>"
         ) + est_size_text

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -18,7 +18,6 @@ from astropy.coordinates import SkyCoord
 from astropy.units import Quantity
 from dask import threaded
 from dask.base import get_scheduler
-from dask.dataframe.core import _repr_data_series
 from dask.delayed import Delayed
 from deprecated import deprecated  # type: ignore
 from hats.catalog.healpix_dataset.healpix_dataset import HealpixDataset as HCHealpixDataset
@@ -33,7 +32,7 @@ from typing_extensions import Self
 from upath import UPath
 
 from lsdb import io
-from lsdb.catalog.dataset.repr import _repr_data_min_max
+from lsdb.catalog.dataset.repr import CatalogRepr
 from lsdb.core.plotting.plot_points import plot_points
 from lsdb.core.search.abstract_search import AbstractSearch
 from lsdb.core.search.region_search import (
@@ -227,87 +226,13 @@ class HealpixDataset:
         return None
 
     def __repr__(self):
-        return self._format_text_repr(self._repr_data())
+        return CatalogRepr(self).text()
 
     def _repr_html_(self):
-        return self._format_html_repr(self._repr_data())
+        return CatalogRepr(self).html()
 
     def _repr_mimebundle_(self, **kwargs):  # pylint: disable=unused-argument
-        """Return both the text and HTML representations for notebook display."""
-        data = self._repr_data()
-        text = self._format_text_repr(data)
-        html = self._format_html_repr(data)
-        return {"text/plain": text, "text/html": html}
-
-    def _format_text_repr(self, data):
-        body = data.to_string(max_rows=5, show_dimensions=False)
-        loaded_cols = len(self.columns)
-        available_cols = len(self.all_columns)
-        est_size = self.est_size()
-        est_size_text = (
-            f"\nThis catalog has an estimated size of {file_size(est_size * 1024)}"
-            if est_size is not None
-            else ""
-        )
-        return (
-            f"lsdb Catalog {self.name}:\n"
-            f"{body}\n"
-            f"{loaded_cols} out of {available_cols} available columns in the catalog have been "
-            f"loaded lazily, meaning no data has been read, only the catalog schema"
-        ) + est_size_text
-
-    def _format_html_repr(self, data):
-        body = data.to_html(max_rows=5, show_dimensions=False, notebook=True)
-        loaded_cols = len(self.columns)
-        available_cols = len(self.all_columns)
-        est_size = self.est_size()
-        est_size_text = (
-            f"<div>This catalog has an estimated size of {file_size(est_size * 1024)}</div>"
-            if est_size is not None
-            else ""
-        )
-        return (
-            f"<div><strong>lsdb Catalog {self.name}:</strong></div>"
-            f"{body}"
-            f"<div>{loaded_cols} out of {available_cols} available columns in the catalog have been loaded "
-            f"<strong>lazily</strong>, meaning no data has been read, only the catalog schema</div>"
-        ) + est_size_text
-
-    def _repr_data(self):
-        meta = self.meta
-        index = self._repr_divisions
-        cols = meta.columns
-        if len(cols) == 0:
-            return pd.DataFrame([[]] * len(index), columns=cols, index=index)
-        show_statistics = (
-            # In-memory catalogs have no loading config
-            self.loading_config is not None
-            and self.loading_config.show_statistics
-            and self._operation.pixel_stats_preserved
-        )
-        pixel_stats = self._get_repr_pixel_stats(cols) if show_statistics else None
-        if pixel_stats is None:
-            return pd.concat([_repr_data_series(s, index=index) for _, s in meta.items()], axis=1)
-        return _repr_data_min_max(meta, index, pixel_stats)
-
-    def _get_repr_pixel_stats(self, cols) -> pd.DataFrame | None:
-        """Fetch per-pixel min/max stats for display"""
-        try:
-            non_nested_cols = [c for c in cols if c not in self.nested_columns]
-            if len(non_nested_cols) == 0:
-                return None
-            # Only reached when pixel stats are preserved.
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", message=".*modified catalog.*")
-                return self.per_partition_statistics(
-                    use_default_columns=False,
-                    exclude_hats_columns=True,
-                    include_columns=non_nested_cols,
-                    include_stats=["min_value", "max_value"],
-                )
-        except Exception:  # pylint: disable=broad-exception-caught
-            logging.debug("Could not read partition statistics for catalog %s", self.name, exc_info=True)
-            return None
+        return CatalogRepr(self).mimebundle()
 
     def _create_modified_hc_structure(
         self, hc_structure=None, updated_schema=None, updated_pixels=None, **kwargs
@@ -638,17 +563,6 @@ class HealpixDataset:
             msg = f"Columns {confusing_columns} are in the catalog but were not loaded."
         raise ValueError(msg)
 
-    @property
-    def _repr_divisions(self):
-        pixels = self.get_ordered_healpix_pixels()
-        name = f"npartitions={len(pixels)}"
-        # Dask will raise an exception, preventing display,
-        # if the index does not have at least one element.
-        if len(pixels) == 0:
-            pixels = ["Empty Catalog"]
-        divisions = pd.Index(pixels, name=name)
-        return divisions
-
     def get_healpix_pixels(self) -> list[HealpixPixel]:
         """Get all HEALPix pixels that are contained in the catalog
 
@@ -678,6 +592,7 @@ class HealpixDataset:
         exclude_columns: list[str] | None = None,
         include_columns: list[str] | None = None,
         include_pixels: list[HealpixPixel] | None = None,
+        warn_on_modified_catalog: bool = True,
     ) -> pd.DataFrame:
         """Read footer statistics in parquet metadata, and report on global min/max values.
 
@@ -696,6 +611,9 @@ class HealpixDataset:
         include_pixels : list[HealpixPixel] or None, default None
             If specified, only return statistics for the pixels indicated. Defaults to none,
             and returns all pixels.
+        warn_on_modified_catalog : bool
+            if True, this method will warn if the catalog has been modified from its original on-disk
+            state. Defaults to True.
 
         Returns
         -------
@@ -710,6 +628,7 @@ class HealpixDataset:
             exclude_columns=exclude_columns,
             include_columns=include_columns,
             include_pixels=include_pixels,
+            warn_on_modified_catalog=warn_on_modified_catalog,
         )
 
     @deprecated(
@@ -727,6 +646,7 @@ class HealpixDataset:
         include_stats: list[str] | None = None,
         multi_index=False,
         include_pixels: list[HealpixPixel] | None = None,
+        warn_on_modified_catalog: bool = True,
     ):  # pragma: no cover
         """Read footer statistics in parquet metadata, and report on
         min/max values for for each data partition."""
@@ -738,6 +658,7 @@ class HealpixDataset:
             include_stats=include_stats,
             multi_index=multi_index,
             include_pixels=include_pixels,
+            warn_on_modified_catalog=warn_on_modified_catalog,
         )
 
     def per_partition_statistics(
@@ -752,6 +673,7 @@ class HealpixDataset:
         multi_index: bool = False,
         per_row_group: bool = False,
         include_pixels: list[HealpixPixel] | None = None,
+        warn_on_modified_catalog: bool = True,
     ) -> pd.DataFrame:
         """Read footer statistics in parquet metadata, and report on
         min/max values for each data partition.
@@ -784,6 +706,9 @@ class HealpixDataset:
         include_pixels : list[HealpixPixel] or None, default None
             If specified, only return statistics for the pixels indicated. Defaults to none,
             and returns all pixels.
+        warn_on_modified_catalog : bool
+            if True, this method will warn if the catalog has been modified from its original on-disk
+            state. Defaults to True.
 
         Returns
         -------
@@ -802,6 +727,7 @@ class HealpixDataset:
             multi_index=multi_index,
             per_row_group=per_row_group,
             include_pixels=include_pixels,
+            warn_on_modified_catalog=warn_on_modified_catalog,
         )
 
     def get_partition(self, order: int, pixel: int) -> Self:

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -97,26 +97,6 @@ class HealpixDataset:
         self.loading_config = loading_config
 
     @property
-    def _show_statistics(self) -> bool:
-        """Whether the catalog repr should display the per-column statistics table"""
-        return self.loading_config is not None and self.loading_config.show_statistics
-
-    def __repr__(self):
-        data = self._repr_data().to_string(max_rows=5, show_dimensions=False)
-        loaded_cols = len(self.columns)
-        available_cols = len(self.all_columns)
-        lines = [
-            f"lsdb Catalog {self.name}:",
-            data,
-            f"{loaded_cols} out of {available_cols} available columns in the catalog have been "
-            f"loaded lazily, meaning no data has been read, only the catalog schema",
-        ]
-        est_size = self.est_size()
-        if est_size is not None:
-            lines.append(f"This catalog has an estimated size of {file_size(est_size * 1024)}")
-        return "\n".join(lines)
-
-    @property
     def name(self):
         """The name of the catalog"""
         return self.hc_structure.catalog_name
@@ -246,6 +226,23 @@ class HealpixDataset:
                     return float(self.hc_structure.catalog_info.hats_estsize) * partition_ratio * column_ratio
         return None
 
+    def __repr__(self):
+        data = self._repr_data().to_string(max_rows=5, show_dimensions=False)
+        loaded_cols = len(self.columns)
+        available_cols = len(self.all_columns)
+        est_size = self.est_size()
+        est_size_text = (
+            f"\nThis catalog has an estimated size of {file_size(est_size * 1024)}"
+            if est_size is not None
+            else ""
+        )
+        return (
+            f"lsdb Catalog {self.name}:\n"
+            f"{data}\n"
+            f"{loaded_cols} out of {available_cols} available columns in the catalog have been "
+            f"loaded lazily, meaning no data has been read, only the catalog schema"
+        ) + est_size_text
+
     def _repr_html_(self):
         data = self._repr_data().to_html(max_rows=5, show_dimensions=False, notebook=True)
         loaded_cols = len(self.columns)
@@ -262,6 +259,38 @@ class HealpixDataset:
             f"<div>{loaded_cols} out of {available_cols} available columns in the catalog have been loaded "
             f"<strong>lazily</strong>, meaning no data has been read, only the catalog schema</div>"
         ) + est_size_text
+
+    def _repr_data(self):
+        meta = self.meta
+        index = self._repr_divisions
+        cols = meta.columns
+        if len(cols) == 0:
+            return pd.DataFrame([[]] * len(index), columns=cols, index=index)
+        show_statistics = (
+            self.loading_config is not None
+            and self.loading_config.show_statistics
+            and self._operation.pixel_stats_preserved
+        )
+        pixel_stats = self._get_repr_pixel_stats(cols) if show_statistics else None
+        if pixel_stats is None:
+            return pd.concat([_repr_data_series(s, index=index) for _, s in meta.items()], axis=1)
+        return _repr_data_min_max(meta, index, pixel_stats)
+
+    def _get_repr_pixel_stats(self, cols) -> pd.DataFrame | None:
+        """Fetch per-pixel min/max stats for display"""
+        try:
+            non_nested_cols = [c for c in cols if c not in self.nested_columns]
+            if len(non_nested_cols) == 0:
+                return None
+            return self.per_partition_statistics(
+                use_default_columns=False,
+                exclude_hats_columns=True,
+                include_columns=non_nested_cols,
+                include_stats=["min_value", "max_value"],
+            )
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.debug("Could not read partition statistics for catalog %s", self.name, exc_info=True)
+            return None
 
     def _create_modified_hc_structure(
         self, hc_structure=None, updated_schema=None, updated_pixels=None, **kwargs
@@ -504,34 +533,6 @@ class HealpixDataset:
             The list of nested columns in the catalog.
         """
         return self.meta.nested_columns
-
-    def _repr_data(self):
-        meta = self.meta
-        index = self._repr_divisions
-        cols = meta.columns
-        if len(cols) == 0:
-            return pd.DataFrame([[]] * len(index), columns=cols, index=index)
-        pixel_stats = self._get_repr_pixel_stats(cols) if self._show_statistics else None
-        if pixel_stats is None:
-            return pd.concat([_repr_data_series(s, index=index) for _, s in meta.items()], axis=1)
-        return _repr_data_min_max(meta, index, pixel_stats)
-
-    def _get_repr_pixel_stats(self, cols) -> pd.DataFrame | None:
-        """Fetch per-pixel min/max stats for display"""
-        try:
-            if not self.hc_structure.unmodified:
-                return None
-            non_nested_cols = [c for c in cols if c not in self.nested_columns]
-            if len(non_nested_cols) == 0:
-                return None
-            return self.per_partition_statistics(
-                use_default_columns=False,
-                exclude_hats_columns=True,
-                include_columns=non_nested_cols,
-                include_stats=["min_value", "max_value"],
-            )
-        except Exception:  # pylint: disable=broad-exception-caught
-            return None
 
     def compute(self, progress_bar=True, tqdm_kwargs=None) -> npd.NestedFrame:
         """Compute dask distributed dataframe to pandas dataframe.
@@ -1305,6 +1306,7 @@ class HealpixDataset:
             new_loading_config.filters = self.loading_config.filters
             new_loading_config.kwargs = self.loading_config.kwargs
             new_loading_config.path_generator = self.loading_config.path_generator
+            new_loading_config.show_statistics = self.loading_config.show_statistics
 
         return _load_catalog(hc_structure, new_loading_config)
 

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -33,6 +33,7 @@ from typing_extensions import Self
 from upath import UPath
 
 from lsdb import io
+from lsdb.catalog.dataset.repr import _repr_data_min_max
 from lsdb.core.plotting.plot_points import plot_points
 from lsdb.core.search.abstract_search import AbstractSearch
 from lsdb.core.search.region_search import (
@@ -495,10 +496,29 @@ class HealpixDataset:
         index = self._repr_divisions
         cols = meta.columns
         if len(cols) == 0:
-            series_df = pd.DataFrame([[]] * len(index), columns=cols, index=index)
-        else:
-            series_df = pd.concat([_repr_data_series(s, index=index) for _, s in meta.items()], axis=1)
-        return series_df
+            return pd.DataFrame([[]] * len(index), columns=cols, index=index)
+        pixel_stats = self._get_repr_pixel_stats(cols)
+        if pixel_stats is None:
+            return pd.concat([_repr_data_series(s, index=index) for _, s in meta.items()], axis=1)
+        return _repr_data_min_max(meta, index, pixel_stats)
+
+    def _get_repr_pixel_stats(self, cols) -> pd.DataFrame | None:
+        """Fetch per-pixel min/max stats for display"""
+        try:
+            if not self.hc_structure.unmodified:
+                return None
+            non_nested_cols = [c for c in cols if c not in self.nested_columns]
+            if len(non_nested_cols) == 0:
+                return None
+            # TODO: Read from less expensive metadata summary.
+            return self.per_pixel_statistics(
+                use_default_columns=False,
+                exclude_hats_columns=True,
+                include_columns=non_nested_cols,
+                include_stats=["min_value", "max_value"],
+            )
+        except Exception:  # pylint: disable=broad-exception-caught
+            return None
 
     def compute(self, progress_bar=True, tqdm_kwargs=None) -> npd.NestedFrame:
         """Compute dask distributed dataframe to pandas dataframe.
@@ -703,7 +723,7 @@ class HealpixDataset:
         include_pixels: list[HealpixPixel] | None = None,
     ) -> pd.DataFrame:
         """Read footer statistics in parquet metadata, and report on
-        min/max values for for each data partition.
+        min/max values for each data partition.
 
         Parameters
         ----------

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -96,11 +96,25 @@ class HealpixDataset:
         self.hc_structure = hc_structure
         self.loading_config = loading_config
 
+    @property
+    def _show_statistics(self) -> bool:
+        """Whether the catalog repr should display the per-column statistics table"""
+        return self.loading_config is not None and self.loading_config.show_statistics
+
     def __repr__(self):
-        # TODO: This changes to just be the operation name, not the lazy df view.
-        # Should we add a df like repr?
-        return self._operation.__repr__()
-        # return self._repr_data()
+        data = self._repr_data().to_string(max_rows=5, show_dimensions=False)
+        loaded_cols = len(self.columns)
+        available_cols = len(self.all_columns)
+        lines = [
+            f"lsdb Catalog {self.name}:",
+            data,
+            f"{loaded_cols} out of {available_cols} available columns in the catalog have been "
+            f"loaded lazily, meaning no data has been read, only the catalog schema",
+        ]
+        est_size = self.est_size()
+        if est_size is not None:
+            lines.append(f"This catalog has an estimated size of {file_size(est_size * 1024)}")
+        return "\n".join(lines)
 
     @property
     def name(self):
@@ -497,7 +511,7 @@ class HealpixDataset:
         cols = meta.columns
         if len(cols) == 0:
             return pd.DataFrame([[]] * len(index), columns=cols, index=index)
-        pixel_stats = self._get_repr_pixel_stats(cols)
+        pixel_stats = self._get_repr_pixel_stats(cols) if self._show_statistics else None
         if pixel_stats is None:
             return pd.concat([_repr_data_series(s, index=index) for _, s in meta.items()], axis=1)
         return _repr_data_min_max(meta, index, pixel_stats)

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -510,8 +510,7 @@ class HealpixDataset:
             non_nested_cols = [c for c in cols if c not in self.nested_columns]
             if len(non_nested_cols) == 0:
                 return None
-            # TODO: Read from less expensive metadata summary.
-            return self.per_pixel_statistics(
+            return self.per_partition_statistics(
                 use_default_columns=False,
                 exclude_hats_columns=True,
                 include_columns=non_nested_cols,

--- a/src/lsdb/catalog/dataset/repr.py
+++ b/src/lsdb/catalog/dataset/repr.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pandas as pd
+
+_MAX_STR_WIDTH = 10
+
+
+def _repr_data_min_max(meta, index, pixel_stats) -> pd.DataFrame:
+    """Build repr DataFrame with a dtype header row and per-pixel min..max for every pixel."""
+    dtype_index = pd.Index([index.name] + list(index), name=None)
+    stats_by_pixel = {pixel: pixel_stats.loc[pixel] for pixel in pixel_stats.index}
+    series_list = []
+    for col_name, s in meta.items():
+        min_col = f"{col_name}: min_value"
+        max_col = f"{col_name}: max_value"
+        has_stats = min_col in pixel_stats.columns and max_col in pixel_stats.columns
+        pixel_values = (
+            _make_pixel_range(index, stats_by_pixel, min_col, max_col, s.dtype)
+            if has_stats
+            else ["..."] * len(index)
+        )
+        values = [str(s.dtype)] + pixel_values
+        series_list.append(pd.Series(values, index=dtype_index, name=col_name))
+    return pd.concat(series_list, axis=1)
+
+
+def _make_pixel_range(index, stats_by_pixel, min_col, max_col, dtype) -> list[str]:
+    """Make a 'min..max' string for each pixel in the index."""
+    formatter = _get_formatter(dtype)
+    values = []
+    for pixel in index:
+        row = stats_by_pixel.get(pixel)
+        if row is None or row[min_col] is None or row[max_col] is None:
+            values.append("...")
+            continue
+        min_str, max_str = formatter(row[min_col]), formatter(row[max_col])
+        values.append(min_str if min_str == max_str else f"{min_str}..{max_str}")
+    return values
+
+
+def _get_formatter(dtype):
+    """Return a scalar formatting function for the given dtype, resolved once per column."""
+    if pd.api.types.is_bool_dtype(dtype):
+        return lambda v: str(bool(v))
+    if pd.api.types.is_integer_dtype(dtype):
+        return lambda v: f"{int(v):.4g}" if abs(int(v)) >= 1_000_000 else str(int(v))
+    if pd.api.types.is_float_dtype(dtype):
+        return lambda v: f"{float(v):.4g}"
+
+    def fmt_str(v):
+        s = str(v)
+        return s if len(s) <= _MAX_STR_WIDTH else s[: _MAX_STR_WIDTH - 1] + "…"
+
+    return fmt_str

--- a/src/lsdb/catalog/dataset/repr.py
+++ b/src/lsdb/catalog/dataset/repr.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import pandas as pd
+from human_readable import int_comma
 
-_MAX_STR_WIDTH = 20
+_MAX_CELL_WIDTH = 10
 
 
 def _repr_data_min_max(meta, index, pixel_stats) -> pd.DataFrame:
-    """Build repr DataFrame with a dtype header row and per-pixel min..max for every pixel."""
+    """Build repr DataFrame with a dtype header row and per-pixel min..max for every pixel"""
     dtype_index = pd.Index([index.name] + list(index), name=None)
     stats_by_pixel = {pixel: pixel_stats.loc[pixel] for pixel in pixel_stats.index}
     series_list = []
@@ -25,7 +26,7 @@ def _repr_data_min_max(meta, index, pixel_stats) -> pd.DataFrame:
 
 
 def _make_pixel_range(index, stats_by_pixel, min_col, max_col, dtype) -> list[str]:
-    """Make a 'min..max' string for each pixel in the index."""
+    """Make a 'min..max' string for each pixel in the index"""
     formatter = _get_formatter(dtype)
     values = []
     for pixel in index:
@@ -39,16 +40,23 @@ def _make_pixel_range(index, stats_by_pixel, min_col, max_col, dtype) -> list[st
 
 
 def _get_formatter(dtype):
-    """Return a scalar formatting function for the given dtype, resolved once per column."""
+    """Return a function to format a given scalar of dtype"""
     if pd.api.types.is_bool_dtype(dtype):
         return lambda v: str(bool(v))
-    if pd.api.types.is_integer_dtype(dtype):
-        return lambda v: f"{int(v):.4g}" if abs(int(v)) >= 1_000_000 else str(int(v))
+
     if pd.api.types.is_float_dtype(dtype):
         return lambda v: f"{float(v):.4g}"
 
+    if pd.api.types.is_integer_dtype(dtype):
+
+        def fmt_int(v):
+            s = int_comma(int(v))
+            return s if len(s) <= _MAX_CELL_WIDTH else f"{int(v):.4g}"
+
+        return fmt_int
+
     def fmt_str(v):
         s = str(v)
-        return s if len(s) <= _MAX_STR_WIDTH else s[: _MAX_STR_WIDTH - 1] + "»"
+        return s if len(s) <= _MAX_CELL_WIDTH else s[: _MAX_CELL_WIDTH - 1] + "»"
 
     return fmt_str

--- a/src/lsdb/catalog/dataset/repr.py
+++ b/src/lsdb/catalog/dataset/repr.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-_MAX_STR_WIDTH = 10
+_MAX_STR_WIDTH = 20
 
 
 def _repr_data_min_max(meta, index, pixel_stats) -> pd.DataFrame:
@@ -49,6 +49,6 @@ def _get_formatter(dtype):
 
     def fmt_str(v):
         s = str(v)
-        return s if len(s) <= _MAX_STR_WIDTH else s[: _MAX_STR_WIDTH - 1] + "…"
+        return s if len(s) <= _MAX_STR_WIDTH else s[: _MAX_STR_WIDTH - 1] + "»"
 
     return fmt_str

--- a/src/lsdb/catalog/dataset/repr.py
+++ b/src/lsdb/catalog/dataset/repr.py
@@ -1,13 +1,138 @@
 from __future__ import annotations
 
-import pandas as pd
-from human_readable import int_comma
+import logging
+from typing import TYPE_CHECKING
 
-_MAX_CELL_WIDTH = 10
+import pandas as pd
+from dask.dataframe.core import _repr_data_series
+from hats.pixel_math import HealpixPixel
+from human_readable import file_size, int_comma
+
+if TYPE_CHECKING:
+    from lsdb.catalog.dataset.healpix_dataset import HealpixDataset
+
+
+_MAX_STR_WIDTH = 10
+_REPR_MAX_ROWS = 5
+
+
+class CatalogRepr:
+    """Renders the text and HTML representations of a Catalog"""
+
+    def __init__(self, catalog: HealpixDataset):
+        self.catalog = catalog
+
+    def text(self) -> str:
+        """Returns the text representation of a catalog"""
+        return self._render_text(*self._data())
+
+    def html(self) -> str:
+        """Returns the HTML representation of a catalog"""
+        return self._render_html(*self._data())
+
+    def mimebundle(self) -> dict[str, str]:
+        """Return both the text and HTML representations for notebook display.
+
+        IPython calls this in preference to ``__repr__``/``_repr_html_`` and
+        picks the richest format the frontend supports (``text/html`` in a
+        notebook, ``text/plain`` in a terminal).
+
+        If this method is not defined, both ``__repr__`` and ``_repr_html_``
+        are invoked, leading to double-rendering. See:
+        - https://ipython.readthedocs.io/en/stable/config/integrating.html
+        - https://github.com/ipython/ipython/issues/9771
+        - https://github.com/ibis-project/ibis/pull/10002
+        """
+        data, has_statistics = self._data()
+        return {
+            "text/plain": self._render_text(data, has_statistics),
+            "text/html": self._render_html(data, has_statistics),
+        }
+
+    def _render_text(self, data: pd.DataFrame, has_statistics: bool) -> str:
+        body = data.to_string(max_rows=_REPR_MAX_ROWS, show_dimensions=False)
+        footer = "\n".join(self._footer_lines(has_statistics))
+        return f"lsdb Catalog {self.catalog.name}:\n{body}\n{footer}"
+
+    def _render_html(self, data: pd.DataFrame, has_statistics: bool) -> str:
+        body = data.to_html(max_rows=_REPR_MAX_ROWS, show_dimensions=False, notebook=True)
+        footer = "".join(f"<div>{line}</div>" for line in self._footer_lines(has_statistics))
+        return f"<div><strong>lsdb Catalog {self.catalog.name}:</strong></div>{body}{footer}"
+
+    def _footer_lines(self, has_statistics: bool) -> list[str]:
+        loaded_cols = len(self.catalog.columns)
+        available_cols = len(self.catalog.all_columns)
+        lines = [
+            f"{loaded_cols} out of {available_cols} available columns in the catalog have been "
+            f"loaded lazily, meaning no data has been read, only the catalog schema"
+        ]
+        est_size = self.catalog.est_size()
+        if est_size is not None:
+            lines.append(f"This catalog has an estimated size of {file_size(int(est_size * 1024))}")
+        if has_statistics:
+            lines.append("Statistics for each column are defined by {min}..{max} ranges")
+        return lines
+
+    def _data(self) -> tuple[pd.DataFrame, bool]:
+        """Build the repr DataFrame and report whether it renders per-column statistics."""
+        meta = self.catalog.meta
+        index = self._divisions
+        cols = meta.columns
+        if len(cols) == 0:
+            return pd.DataFrame([[]] * len(index), columns=cols, index=index), False
+        pixel_stats = self._pixel_stats(cols, index) if self._show_statistics else None
+        if pixel_stats is None:
+            placeholder = pd.concat([_repr_data_series(s, index=index) for _, s in meta.items()], axis=1)
+            return placeholder, False
+        return _repr_data_min_max(meta, index, pixel_stats), True
+
+    def _pixel_stats(self, cols, index) -> pd.DataFrame | None:
+        """Fetch per-pixel min/max stats for the pixels visible in the repr"""
+        try:
+            non_nested_cols = [c for c in cols if c not in self.catalog.nested_columns]
+            if len(non_nested_cols) == 0:
+                return None
+            pixels = [p for p in index if isinstance(p, HealpixPixel)]
+            return self.catalog.per_partition_statistics(
+                use_default_columns=False,
+                exclude_hats_columns=True,
+                include_columns=non_nested_cols,
+                include_stats=["min_value", "max_value"],
+                include_pixels=pixels,
+                warn_on_modified_catalog=False,
+            )
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.debug(
+                "Could not read partition statistics for catalog %s", self.catalog.name, exc_info=True
+            )
+            return None
+
+    # pylint: disable=protected-access
+    @property
+    def _show_statistics(self) -> bool:
+        """Whether the user asked for statistics and the current view still preserves them."""
+        return (
+            self.catalog.loading_config is not None
+            and self.catalog.loading_config.show_statistics
+            and self.catalog._operation.pixel_stats_preserved
+            and len(self.catalog.get_healpix_pixels()) > 0
+        )
+
+    @property
+    def _divisions(self) -> pd.Index:
+        pixels = self.catalog.get_ordered_healpix_pixels()
+        name = f"npartitions={len(pixels)}"
+        labels: list[HealpixPixel | str] = list(pixels)
+        if len(pixels) == 0:
+            labels = ["Empty Catalog"]
+        elif len(pixels) > _REPR_MAX_ROWS - 1:
+            # First pixel and last two pixels, with ellipsis in between
+            labels = [pixels[0], "...", *pixels[-2:]]
+        return pd.Index(labels, name=name)
 
 
 def _repr_data_min_max(meta, index, pixel_stats) -> pd.DataFrame:
-    """Build repr DataFrame with a dtype header row and per-pixel min..max for every pixel"""
+    """Build repr DataFrame with a dtype header row and per-pixel '{min}..{max}' for every pixel"""
     dtype_index = pd.Index([index.name] + list(index), name=None)
     stats_by_pixel = {pixel: pixel_stats.loc[pixel] for pixel in pixel_stats.index}
     series_list = []
@@ -26,7 +151,7 @@ def _repr_data_min_max(meta, index, pixel_stats) -> pd.DataFrame:
 
 
 def _make_pixel_range(index, stats_by_pixel, min_col, max_col, dtype) -> list[str]:
-    """Make a 'min..max' string for each pixel in the index"""
+    """Make a '{min}..{max}' string for each pixel in the index"""
     formatter = _get_formatter(dtype)
     values = []
     for pixel in index:
@@ -51,12 +176,12 @@ def _get_formatter(dtype):
 
         def fmt_int(v):
             s = int_comma(int(v))
-            return s if len(s) <= _MAX_CELL_WIDTH else f"{int(v):.4g}"
+            return s if len(s) <= _MAX_STR_WIDTH else f"{int(v):.4g}"
 
         return fmt_int
 
     def fmt_str(v):
         s = str(v)
-        return s if len(s) <= _MAX_CELL_WIDTH else s[: _MAX_CELL_WIDTH - 1] + "»"
+        return s if len(s) <= _MAX_STR_WIDTH else s[: _MAX_STR_WIDTH - 1] + "»"
 
     return fmt_str

--- a/src/lsdb/catalog/dataset/repr.py
+++ b/src/lsdb/catalog/dataset/repr.py
@@ -30,7 +30,7 @@ def _make_pixel_range(index, stats_by_pixel, min_col, max_col, dtype) -> list[st
     values = []
     for pixel in index:
         row = stats_by_pixel.get(pixel)
-        if row is None or row[min_col] is None or row[max_col] is None:
+        if row is None or pd.isna(row[min_col]) or pd.isna(row[max_col]):
             values.append("...")
             continue
         min_str, max_str = formatter(row[min_col]), formatter(row[max_col])

--- a/src/lsdb/loaders/dataframe/margin_catalog_generator.py
+++ b/src/lsdb/loaders/dataframe/margin_catalog_generator.py
@@ -13,7 +13,7 @@ from hats.pixel_math import HealpixPixel, get_margin
 from hats.pixel_math.healpix_pixel_function import get_pixel_argsort
 from hats.pixel_math.spatial_index import SPATIAL_INDEX_COLUMN
 
-from lsdb import Catalog
+from lsdb.catalog import Catalog
 from lsdb.catalog.margin_catalog import MarginCatalog
 from lsdb.io.common import new_provenance_properties
 from lsdb.loaders.dataframe.from_dataframe_utils import (

--- a/src/lsdb/loaders/hats/hats_loading_config.py
+++ b/src/lsdb/loaders/hats/hats_loading_config.py
@@ -42,6 +42,9 @@ class HatsLoadingConfig:
     kwargs: dict = field(default_factory=dict)
     """Extra kwargs for the pandas parquet file reader"""
 
+    show_statistics: bool = False
+    """Whether to show the per-column statistics table in the catalog repr. Defaults to False."""
+
     def __post_init__(self):
         # Check for commonly misspelled or mistaken keys
         for nonused_kwarg in ["margin", "maargin", "margins", "cache", "margincache"]:

--- a/src/lsdb/loaders/hats/hats_loading_config.py
+++ b/src/lsdb/loaders/hats/hats_loading_config.py
@@ -46,6 +46,10 @@ class HatsLoadingConfig:
     """Whether to show the per-column statistics table in the catalog repr. Defaults to False."""
 
     def __post_init__(self):
+        # Whether the user explicitly passed row `filters`, as opposed to the spatial
+        # pruning filters later derived from a search MOC. User filters will often
+        # invalidate the on-disk statistics, the MOC-derived filters do not.
+        self.user_provided_filters = self.filters is not None
         # Check for commonly misspelled or mistaken keys
         for nonused_kwarg in ["margin", "maargin", "margins", "cache", "margincache"]:
             if nonused_kwarg in self.kwargs:

--- a/src/lsdb/loaders/hats/hats_loading_config.py
+++ b/src/lsdb/loaders/hats/hats_loading_config.py
@@ -46,16 +46,14 @@ class HatsLoadingConfig:
     """Whether to show the per-column statistics table in the catalog repr. Defaults to False."""
 
     def __post_init__(self):
-        # Whether the user explicitly passed row `filters`, as opposed to the spatial
-        # pruning filters later derived from a search MOC. User filters will often
-        # invalidate the on-disk statistics, the MOC-derived filters do not.
-        self.user_provided_filters = self.filters is not None
         # Check for commonly misspelled or mistaken keys
         for nonused_kwarg in ["margin", "maargin", "margins", "cache", "margincache"]:
             if nonused_kwarg in self.kwargs:
                 raise ValueError(
                     f"Invalid keyword argument '{nonused_kwarg}' found. Did you mean 'margin_cache'?"
                 )
+        # Whether the user passed row `filters`.
+        self.user_provided_filters = self.filters is not None
 
     def set_columns_from_catalog_info(self, catalog_info):
         """Set the appropriate columns to load, based on the user-provided `columns` argument

--- a/src/lsdb/loaders/hats/read_hats.py
+++ b/src/lsdb/loaders/hats/read_hats.py
@@ -275,13 +275,17 @@ def _load_catalog(hc_catalog: hc.catalog.Dataset, config: HatsLoadingConfig) -> 
     ):
         raise ValueError("The selected sky region has no coverage")
 
-    catalog.hc_structure = _update_hc_structure(catalog)
+    updated_info: dict = {}
+    if config.filters is not None:
+        updated_info["total_rows"] = None
+
+    catalog.hc_structure = _update_hc_structure(catalog, **updated_info)
     if isinstance(catalog, Catalog) and catalog.margin is not None:
-        catalog.margin.hc_structure = _update_hc_structure(catalog.margin)
+        catalog.margin.hc_structure = _update_hc_structure(catalog.margin, **updated_info)
     return catalog
 
 
-def _update_hc_structure(catalog: HealpixDataset):
+def _update_hc_structure(catalog: HealpixDataset, **updated_info):
     """Create the modified schema of the catalog after all the processing on the `read_hats` call"""
     # pylint: disable=protected-access
     default_columns = None
@@ -295,10 +299,6 @@ def _update_hc_structure(catalog: HealpixDataset):
             for col in catalog.hc_structure.catalog_info.default_columns
             if col in exploded_columns(catalog.meta)
         ]
-
-    updated_info: dict = {}
-    if catalog.loading_config is not None and catalog.loading_config.filters:
-        updated_info["total_rows"] = None
 
     return catalog._create_modified_hc_structure(
         updated_schema=get_arrow_schema(catalog.meta),

--- a/src/lsdb/loaders/hats/read_hats.py
+++ b/src/lsdb/loaders/hats/read_hats.py
@@ -37,6 +37,7 @@ def open_catalog(
     error_empty_filter: bool = True,
     filters: list[tuple[str]] | None = None,
     path_generator: Callable[[UPath, HealpixPixel, dict | None, str], UPath] = hc.io.pixel_catalog_file,
+    show_statistics: bool = False,
     **kwargs,
 ) -> Catalog:
     """Open a catalog from a HATS path.
@@ -107,6 +108,8 @@ def open_catalog(
 
         The catalog metadata files need to live where the HATS standard expects them.
         Defaults to `hats.io.pixel_catalog_file`.
+    show_statistics : bool, default False
+        If True, the catalog's repr displays a per-column statistics table (min/max values).
     **kwargs
         Arguments to pass to the pandas parquet file reader
 
@@ -126,6 +129,7 @@ def open_catalog(
         error_empty_filter=error_empty_filter,
         filters=filters,
         path_generator=path_generator,
+        show_statistics=show_statistics,
         **kwargs,
     )
 
@@ -199,6 +203,7 @@ def _read_dataset(
     error_empty_filter: bool = True,
     filters: list[tuple[str]] | None = None,
     path_generator: Callable[[UPath, HealpixPixel, dict | None, str], UPath] = hc.io.pixel_catalog_file,
+    show_statistics: bool = False,
     **kwargs,
 ):
     """Internal method to read any HATS collection/dataset"""
@@ -209,6 +214,7 @@ def _read_dataset(
         margin_cache=margin_cache,
         filters=filters,
         path_generator=path_generator,
+        show_statistics=show_statistics,
         kwargs=kwargs,
     )
     if isinstance(hc_catalog, hc.catalog.CatalogCollection):

--- a/src/lsdb/loaders/hats/read_hats.py
+++ b/src/lsdb/loaders/hats/read_hats.py
@@ -295,9 +295,15 @@ def _update_hc_structure(catalog: HealpixDataset):
             for col in catalog.hc_structure.catalog_info.default_columns
             if col in exploded_columns(catalog.meta)
         ]
+
+    updated_info: dict = {}
+    if catalog.loading_config is not None and catalog.loading_config.filters:
+        updated_info["total_rows"] = None
+
     return catalog._create_modified_hc_structure(
         updated_schema=get_arrow_schema(catalog.meta),
         default_columns=default_columns,
+        **updated_info,
     )
 
 
@@ -456,6 +462,7 @@ def _load_operation(catalog: HCHealpixDataset, config) -> Operation:
         index_column=index_column,
         meta=dask_meta_schema,
         is_dir=(npix_suffix == "/"),
+        preserves_pixel_stats=not config.user_provided_filters,
         **config.kwargs,
     )
     return op

--- a/src/lsdb/operations/lsdb_ops.py
+++ b/src/lsdb/operations/lsdb_ops.py
@@ -43,12 +43,23 @@ def _verified(func, meta):
 class FromHealpixMap(Operation):
     """An Operation that constructs a HealpixGraph from a function that maps HealpixPixels to DataFrames."""
 
-    def __init__(self, func, pixels, *args, meta=None, map_kwargs=None, verify_meta=True, **kwargs):
+    def __init__(
+        self,
+        func,
+        pixels,
+        *args,
+        meta=None,
+        map_kwargs=None,
+        verify_meta=True,
+        preserves_pixel_stats=True,
+        **kwargs,
+    ):
         self.func = func
         self.pixels = pixels
         self.args = args
         self._meta = meta
         self.verify_meta = verify_meta
+        self.preserves_pixel_stats = preserves_pixel_stats
         if map_kwargs is not None:
             for k in map_kwargs:
                 if k in kwargs:
@@ -347,6 +358,8 @@ def perform_select_columns(df, columns):
 class SelectColumns(MapPartitions):
     """An Operation that selects a subset of columns from each partition of a HealpixGraph."""
 
+    preserves_pixel_stats = True
+
     @staticmethod
     def class_func(df, item):
         """Select the specified columns from the DataFrame."""
@@ -360,6 +373,8 @@ class SelectColumns(MapPartitions):
 
 class SelectPixels(Operation):
     """An Operation that selects a subset of HealpixPixels from a HealpixGraph."""
+
+    preserves_pixel_stats = True
 
     def __init__(self, base: Operation, pixels: Sequence[HealpixPixel]):
         self.base = base

--- a/src/lsdb/operations/operation.py
+++ b/src/lsdb/operations/operation.py
@@ -24,6 +24,7 @@ class Operation(ABC):
     """Abstract base class defining an operation."""
 
     allow_column_projection_passthrough = False
+    preserves_pixel_stats = False
 
     @property
     @abstractmethod
@@ -72,3 +73,8 @@ class Operation(ABC):
     def __repr__(self):  # pragma: no cover
         """String representation of the operation."""
         return self.name
+
+    @property
+    def pixel_stats_preserved(self) -> bool:
+        """Whether this operation and all its dependencies preserve the on-disk statistics."""
+        return self.preserves_pixel_stats and all(dep.pixel_stats_preserved for dep in self.dependencies)

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -39,30 +39,6 @@ def test_catalog_pixels_equals_hc_catalog_pixels(small_sky_order1_catalog, small
     assert small_sky_order1_catalog.get_healpix_pixels() == small_sky_order1_hats_catalog.get_healpix_pixels()
 
 
-# def test_catalog_repr_equals_ddf_repr(small_sky_order1_catalog):
-#    # TODO: Failing as repr is just the operation name
-# Switching to data_repr, which will not be the same as ddf but is reasonable
-#    assert repr(small_sky_order1_catalog) == repr(small_sky_order1_catalog.to_dask_dataframe())
-
-
-def test_catalog_html_repr(small_sky_order1_catalog):
-    full_html = small_sky_order1_catalog._repr_html_()
-    assert small_sky_order1_catalog.name in full_html
-    assert str(small_sky_order1_catalog.get_ordered_healpix_pixels()[0]) in full_html
-    assert str(small_sky_order1_catalog.get_ordered_healpix_pixels()[-1]) in full_html
-    assert "available columns in the catalog have been loaded <strong>lazily</strong>" in full_html
-
-
-def test_catalog_html_repr_empty(small_sky_order1_catalog):
-    pixel_search = lsdb.PixelSearch.from_radec(80.0, 33.0)
-    cat = small_sky_order1_catalog.search(pixel_search)
-    full_html = cat._repr_html_()
-    assert cat.name in full_html
-    assert "Empty Catalog" in full_html
-    assert "npartitions=0" in full_html
-    assert "available columns in the catalog have been loaded <strong>lazily</strong>" in full_html
-
-
 def test_catalog_compute_equals_ddf_compute(small_sky_order1_catalog):
     pd.testing.assert_frame_equal(
         small_sky_order1_catalog.compute(), small_sky_order1_catalog.to_dask_dataframe().compute()

--- a/tests/lsdb/catalog/test_repr.py
+++ b/tests/lsdb/catalog/test_repr.py
@@ -41,6 +41,15 @@ def test_catalog_html_repr_empty(small_sky_order1_catalog):
     assert "estimated size of 0.0 Bytes" in full_html
 
 
+def test_repr_mimebundle(small_sky_order1_dir):
+    # Notebook display requests both text/plain and text/html.
+    catalog = lsdb.open_catalog(small_sky_order1_dir, show_statistics=True)
+    bundle = catalog._repr_mimebundle_()
+    assert set(bundle) == {"text/plain", "text/html"}
+    assert bundle["text/plain"] == repr(catalog)
+    assert bundle["text/html"] == catalog._repr_html_()
+
+
 def _assert_statistics(catalog, *, shown):
     """Assert whether the statistics table is rendered in both repr forms.
 
@@ -52,7 +61,7 @@ def _assert_statistics(catalog, *, shown):
 
 
 def test_repr_statistics(small_sky_order1_dir):
-    # By default the repr does not show statistics.
+    # By default, the repr does not show statistics.
     catalog = lsdb.open_catalog(small_sky_order1_dir)
     assert catalog._operation.preserves_pixel_stats
     _assert_statistics(catalog, shown=False)
@@ -141,6 +150,15 @@ def test_repr_when_statistics_unavailable(small_sky_order1_dir, monkeypatch):
 
     monkeypatch.setattr(catalog, "per_partition_statistics", _not_found)
     _assert_statistics(catalog, shown=False)
+
+
+def test_repr_data_with_no_columns(small_sky_order1_dir):
+    catalog = lsdb.open_catalog(small_sky_order1_dir)[[]]
+    assert not list(catalog.columns)
+    data = catalog._repr_data()
+    assert not list(data.columns)
+    assert len(data.index) == catalog.npartitions
+    assert repr(catalog).startswith(f"lsdb Catalog {catalog.name}:")
 
 
 def test_shows_statistics_except_for_nested_columns(small_sky_with_nested_sources_dir):

--- a/tests/lsdb/catalog/test_repr.py
+++ b/tests/lsdb/catalog/test_repr.py
@@ -1,18 +1,22 @@
-import warnings
-
 import pytest
 
 import lsdb
+from lsdb.catalog.dataset.repr import CatalogRepr
 
 
 def _assert_statistics(catalog, *, shown):
-    """Assert whether the statistics table is rendered in both repr forms.
+    """Assert whether the statistics table is rendered.
 
-    When shown, the "min..max" table replaces the "..." placeholders; when hidden, the
-    plain "..." placeholder table is rendered.
+    By default, the view shows a placeholder table with "..." for each column.
+    When statistics are available and the user has requested them, the view
+    shows a table with the '{min}..{max}' ranges for each column, plus a footer
+    legend explaining the notation.
     """
-    assert ("..." not in repr(catalog)) == shown
-    assert ("..." not in catalog._repr_html_()) == shown
+    text, html = repr(catalog), catalog._repr_html_()
+    assert ("..." not in text) == shown
+    assert ("..." not in html) == shown
+    assert ("{min}..{max} ranges" in text) == shown
+    assert ("{min}..{max} ranges" in html) == shown
 
 
 @pytest.mark.parametrize("repr_method", ["__repr__", "_repr_html_"])
@@ -23,10 +27,11 @@ def test_catalog_repr(small_sky_order1_catalog, repr_method):
     assert str(small_sky_order1_catalog.get_ordered_healpix_pixels()[-1]) in text
     assert "available columns in the catalog have been loaded" in text
     assert "estimated size of" in text
+    assert "{min}..{max} ranges" not in text
 
 
 @pytest.mark.parametrize("repr_method", ["__repr__", "_repr_html_"])
-def test_catalog_text_repr_empty(small_sky_order1_catalog, repr_method):
+def test_catalog_repr_empty(small_sky_order1_catalog, repr_method):
     pixel_search = lsdb.PixelSearch.from_radec(80.0, 33.0)
     cat = small_sky_order1_catalog.search(pixel_search)
     text = getattr(cat, repr_method)()
@@ -34,7 +39,8 @@ def test_catalog_text_repr_empty(small_sky_order1_catalog, repr_method):
     assert "Empty Catalog" in text
     assert "npartitions=0" in text
     assert "available columns in the catalog have been loaded" in text
-    assert "estimated size of 0.0 Bytes" in text
+    assert "estimated size of 0 Bytes" in text
+    assert "{min}..{max} ranges" not in text
 
 
 def test_repr_mimebundle(small_sky_order1_dir):
@@ -88,21 +94,6 @@ def test_shows_statistics_with_coarse_search(small_sky_order1_dir):
     _assert_statistics(catalog, shown=True)
 
 
-def test_repr_does_not_warn_about_modified_catalog(small_sky_order1_dir):
-    catalog = lsdb.open_catalog(small_sky_order1_dir, show_statistics=True)
-    catalog = catalog.cone_search(0, -80, 20 * 3600, fine=False)
-    # A coarse search modifies the hats catalog, setting `total_rows` to None.
-    assert catalog.hc_structure.catalog_info.total_rows is None
-    # However, the pixel statistics are still preserved.
-    assert catalog._operation.preserves_pixel_stats
-    # The representation should show the statistics, and not raise a
-    # "Results may be inaccurate" warning to the user.
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        _assert_statistics(catalog, shown=True)
-    assert len(caught) == 0
-
-
 def test_hides_statistics_with_fine_search(small_sky_order1_dir):
     # A fine search filters rows within partitions, so the statistics are not preserved.
     catalog = lsdb.open_catalog(
@@ -142,6 +133,15 @@ def test_hides_statistics_for_in_memory_catalog():
     _assert_statistics(catalog, shown=False)
 
 
+def test_hides_statistics_for_empty_catalog(small_sky_order1_dir):
+    catalog = lsdb.open_catalog(small_sky_order1_dir, show_statistics=True)
+    empty = catalog.search(lsdb.PixelSearch.from_radec(80.0, 33.0))
+    assert len(empty.get_healpix_pixels()) == 0
+    assert not CatalogRepr(empty)._show_statistics
+    assert "{min}..{max} ranges" not in repr(empty)
+    assert "{min}..{max} ranges" not in empty._repr_html_()
+
+
 def test_repr_when_statistics_unavailable(small_sky_order1_dir, monkeypatch):
     # If the statistics cannot be loaded, the repr will fall back to the "..." placeholder table.
     catalog = lsdb.open_catalog(small_sky_order1_dir, show_statistics=True)
@@ -156,24 +156,28 @@ def test_repr_when_statistics_unavailable(small_sky_order1_dir, monkeypatch):
 def test_repr_data_with_no_columns(small_sky_order1_dir):
     catalog = lsdb.open_catalog(small_sky_order1_dir)[[]]
     assert not list(catalog.columns)
-    data = catalog._repr_data()
+    data, has_statistics = CatalogRepr(catalog)._data()
+    assert not has_statistics
     assert not list(data.columns)
-    assert len(data.index) == catalog.npartitions
+    assert len(data.index) == len(catalog.get_healpix_pixels())
     assert repr(catalog).startswith(f"lsdb Catalog {catalog.name}:")
 
 
 def test_shows_statistics_except_for_nested_columns(small_sky_with_nested_sources_dir):
     # Nested columns have no per-column on-disk statistics, so they render the "..."
-    # placeholder while every non-nested column shows its min..max range.
+    # placeholder while every non-nested column shows its '{min}..{max}' range.
     catalog = lsdb.open_catalog(small_sky_with_nested_sources_dir, show_statistics=True)
     assert catalog._operation.preserves_pixel_stats
     assert catalog.nested_columns == ["sources"]
 
-    # The dtype/type header is the first row; the remaining rows hold the per-pixel values.
-    pixel_rows = catalog._repr_data().iloc[1:]
+    # The dtype header is the first row; the remaining rows hold the per-pixel values.
+    catalog_repr = CatalogRepr(catalog)
+    data, has_statistics = catalog_repr._data()
+    assert has_statistics
+    pixel_rows = data.iloc[1:]
     assert (pixel_rows["sources"] == "...").all()
     for col in [c for c in pixel_rows.columns if c not in catalog.nested_columns]:
         assert not (pixel_rows[col] == "...").any()
 
-    # A stats request for only nested columns has nothing to read.
-    assert catalog._get_repr_pixel_stats(catalog.nested_columns) is None
+    # A catalog of only nested columns has no statistics.
+    assert catalog_repr._pixel_stats(catalog.nested_columns, []) is None

--- a/tests/lsdb/catalog/test_repr.py
+++ b/tests/lsdb/catalog/test_repr.py
@@ -1,3 +1,5 @@
+import warnings
+
 import lsdb
 
 
@@ -100,6 +102,21 @@ def test_shows_statistics_with_coarse_search(small_sky_order1_dir):
     catalog = catalog.cone_search(0, -80, 20 * 3600, fine=False)
     assert catalog._operation.preserves_pixel_stats
     _assert_statistics(catalog, shown=True)
+
+
+def test_repr_does_not_warn_about_modified_catalog(small_sky_order1_dir):
+    catalog = lsdb.open_catalog(small_sky_order1_dir, show_statistics=True)
+    catalog = catalog.cone_search(0, -80, 20 * 3600, fine=False)
+    # A coarse search modifies the hats catalog, setting `total_rows` to None.
+    assert catalog.hc_structure.catalog_info.total_rows is None
+    # However, the pixel statistics are still preserved.
+    assert catalog._operation.preserves_pixel_stats
+    # The representation should show the statistics, and not raise a
+    # "Results may be inaccurate" warning to the user.
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _assert_statistics(catalog, shown=True)
+    assert not any("modified catalog" in str(w.message) for w in caught)
 
 
 def test_hides_statistics_with_fine_search(small_sky_order1_dir):

--- a/tests/lsdb/catalog/test_repr.py
+++ b/tests/lsdb/catalog/test_repr.py
@@ -1,55 +1,8 @@
 import warnings
 
+import pytest
+
 import lsdb
-
-
-def test_catalog_text_repr(small_sky_order1_catalog):
-    text = repr(small_sky_order1_catalog)
-    assert small_sky_order1_catalog.name in text
-    assert str(small_sky_order1_catalog.get_ordered_healpix_pixels()[0]) in text
-    assert str(small_sky_order1_catalog.get_ordered_healpix_pixels()[-1]) in text
-    assert "available columns in the catalog have been loaded lazily" in text
-    assert "estimated size of" in text
-
-
-def test_catalog_text_repr_empty(small_sky_order1_catalog):
-    pixel_search = lsdb.PixelSearch.from_radec(80.0, 33.0)
-    cat = small_sky_order1_catalog.search(pixel_search)
-    text = repr(cat)
-    assert cat.name in text
-    assert "Empty Catalog" in text
-    assert "npartitions=0" in text
-    assert "available columns in the catalog have been loaded lazily" in text
-    assert "estimated size of 0.0 Bytes" in text
-
-
-def test_catalog_html_repr(small_sky_order1_catalog):
-    full_html = small_sky_order1_catalog._repr_html_()
-    assert small_sky_order1_catalog.name in full_html
-    assert str(small_sky_order1_catalog.get_ordered_healpix_pixels()[0]) in full_html
-    assert str(small_sky_order1_catalog.get_ordered_healpix_pixels()[-1]) in full_html
-    assert "available columns in the catalog have been loaded <strong>lazily</strong>" in full_html
-    assert "estimated size of" in full_html
-
-
-def test_catalog_html_repr_empty(small_sky_order1_catalog):
-    pixel_search = lsdb.PixelSearch.from_radec(80.0, 33.0)
-    cat = small_sky_order1_catalog.search(pixel_search)
-    full_html = cat._repr_html_()
-    assert cat.name in full_html
-    assert "Empty Catalog" in full_html
-    assert "npartitions=0" in full_html
-    assert "available columns in the catalog have been loaded <strong>lazily</strong>" in full_html
-    assert "estimated size of 0.0 Bytes" in full_html
-
-
-def test_repr_mimebundle(small_sky_order1_dir):
-    # Notebook display requests both text/plain and text/html.
-    catalog = lsdb.open_catalog(small_sky_order1_dir, show_statistics=True)
-    bundle = catalog._repr_mimebundle_()
-    assert set(bundle) == {"text/plain", "text/html"}
-    assert bundle["text/plain"] == repr(catalog)
-    assert bundle["text/html"] == catalog._repr_html_()
 
 
 def _assert_statistics(catalog, *, shown):
@@ -60,6 +13,37 @@ def _assert_statistics(catalog, *, shown):
     """
     assert ("..." not in repr(catalog)) == shown
     assert ("..." not in catalog._repr_html_()) == shown
+
+
+@pytest.mark.parametrize("repr_method", ["__repr__", "_repr_html_"])
+def test_catalog_repr(small_sky_order1_catalog, repr_method):
+    text = getattr(small_sky_order1_catalog, repr_method)()
+    assert small_sky_order1_catalog.name in text
+    assert str(small_sky_order1_catalog.get_ordered_healpix_pixels()[0]) in text
+    assert str(small_sky_order1_catalog.get_ordered_healpix_pixels()[-1]) in text
+    assert "available columns in the catalog have been loaded" in text
+    assert "estimated size of" in text
+
+
+@pytest.mark.parametrize("repr_method", ["__repr__", "_repr_html_"])
+def test_catalog_text_repr_empty(small_sky_order1_catalog, repr_method):
+    pixel_search = lsdb.PixelSearch.from_radec(80.0, 33.0)
+    cat = small_sky_order1_catalog.search(pixel_search)
+    text = getattr(cat, repr_method)()
+    assert cat.name in text
+    assert "Empty Catalog" in text
+    assert "npartitions=0" in text
+    assert "available columns in the catalog have been loaded" in text
+    assert "estimated size of 0.0 Bytes" in text
+
+
+def test_repr_mimebundle(small_sky_order1_dir):
+    # Notebook display requests both text/plain and text/html.
+    catalog = lsdb.open_catalog(small_sky_order1_dir, show_statistics=True)
+    bundle = catalog._repr_mimebundle_()
+    assert set(bundle) == {"text/plain", "text/html"}
+    assert bundle["text/plain"] == repr(catalog)
+    assert bundle["text/html"] == catalog._repr_html_()
 
 
 def test_repr_statistics(small_sky_order1_dir):
@@ -116,7 +100,7 @@ def test_repr_does_not_warn_about_modified_catalog(small_sky_order1_dir):
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         _assert_statistics(catalog, shown=True)
-    assert not any("modified catalog" in str(w.message) for w in caught)
+    assert len(caught) == 0
 
 
 def test_hides_statistics_with_fine_search(small_sky_order1_dir):

--- a/tests/lsdb/catalog/test_repr.py
+++ b/tests/lsdb/catalog/test_repr.py
@@ -1,0 +1,160 @@
+import lsdb
+
+
+def test_catalog_text_repr(small_sky_order1_catalog):
+    text = repr(small_sky_order1_catalog)
+    assert small_sky_order1_catalog.name in text
+    assert str(small_sky_order1_catalog.get_ordered_healpix_pixels()[0]) in text
+    assert str(small_sky_order1_catalog.get_ordered_healpix_pixels()[-1]) in text
+    assert "available columns in the catalog have been loaded lazily" in text
+    assert "estimated size of" in text
+
+
+def test_catalog_text_repr_empty(small_sky_order1_catalog):
+    pixel_search = lsdb.PixelSearch.from_radec(80.0, 33.0)
+    cat = small_sky_order1_catalog.search(pixel_search)
+    text = repr(cat)
+    assert cat.name in text
+    assert "Empty Catalog" in text
+    assert "npartitions=0" in text
+    assert "available columns in the catalog have been loaded lazily" in text
+    assert "estimated size of 0.0 Bytes" in text
+
+
+def test_catalog_html_repr(small_sky_order1_catalog):
+    full_html = small_sky_order1_catalog._repr_html_()
+    assert small_sky_order1_catalog.name in full_html
+    assert str(small_sky_order1_catalog.get_ordered_healpix_pixels()[0]) in full_html
+    assert str(small_sky_order1_catalog.get_ordered_healpix_pixels()[-1]) in full_html
+    assert "available columns in the catalog have been loaded <strong>lazily</strong>" in full_html
+    assert "estimated size of" in full_html
+
+
+def test_catalog_html_repr_empty(small_sky_order1_catalog):
+    pixel_search = lsdb.PixelSearch.from_radec(80.0, 33.0)
+    cat = small_sky_order1_catalog.search(pixel_search)
+    full_html = cat._repr_html_()
+    assert cat.name in full_html
+    assert "Empty Catalog" in full_html
+    assert "npartitions=0" in full_html
+    assert "available columns in the catalog have been loaded <strong>lazily</strong>" in full_html
+    assert "estimated size of 0.0 Bytes" in full_html
+
+
+def _assert_statistics(catalog, *, shown):
+    """Assert whether the statistics table is rendered in both repr forms.
+
+    When shown, the "min..max" table replaces the "..." placeholders; when hidden, the
+    plain "..." placeholder table is rendered.
+    """
+    assert ("..." not in repr(catalog)) == shown
+    assert ("..." not in catalog._repr_html_()) == shown
+
+
+def test_repr_statistics(small_sky_order1_dir):
+    # By default the repr does not show statistics.
+    catalog = lsdb.open_catalog(small_sky_order1_dir)
+    assert catalog._operation.preserves_pixel_stats
+    _assert_statistics(catalog, shown=False)
+    catalog = lsdb.open_catalog(small_sky_order1_dir, show_statistics=True)
+    _assert_statistics(catalog, shown=True)
+
+
+def test_shows_statistics_when_columns_are_selected(small_sky_order1_dir):
+    # Selecting columns does not change the rows, so the on-disk statistics remain valid.
+    catalog = lsdb.open_catalog(small_sky_order1_dir, columns=["ra", "dec"], show_statistics=True)
+    assert list(catalog.columns) == ["ra", "dec"]
+    assert catalog._operation.preserves_pixel_stats
+    _assert_statistics(catalog, shown=True)
+
+    # Same when the column selection happens a posteriori.
+    catalog = lsdb.open_catalog(small_sky_order1_dir, show_statistics=True)[["ra", "dec"]]
+    assert list(catalog.columns) == ["ra", "dec"]
+    assert catalog._operation.preserves_pixel_stats
+    _assert_statistics(catalog, shown=True)
+
+
+def test_shows_statistics_with_coarse_search(small_sky_order1_dir):
+    # A coarse spatial search retains whole partitions, so the on-disk statistics remain valid.
+    catalog = lsdb.open_catalog(
+        small_sky_order1_dir,
+        search_filter=lsdb.ConeSearch(0, -80, 20 * 3600, fine=False),
+        show_statistics=True,
+    )
+    assert catalog._operation.preserves_pixel_stats
+    # The search adds MOC pruning filters, but those are not user-provided.
+    assert not catalog.loading_config.user_provided_filters
+    _assert_statistics(catalog, shown=True)
+
+    # Same when the coarse search happens a posteriori.
+    catalog = lsdb.open_catalog(small_sky_order1_dir, show_statistics=True)
+    catalog = catalog.cone_search(0, -80, 20 * 3600, fine=False)
+    assert catalog._operation.preserves_pixel_stats
+    _assert_statistics(catalog, shown=True)
+
+
+def test_hides_statistics_with_fine_search(small_sky_order1_dir):
+    # A fine search filters rows within partitions, so the statistics are not preserved.
+    catalog = lsdb.open_catalog(
+        small_sky_order1_dir,
+        search_filter=lsdb.ConeSearch(0, -80, 20 * 3600),
+        show_statistics=True,
+    )
+    assert not catalog._operation.preserves_pixel_stats
+    _assert_statistics(catalog, shown=False)
+
+    # Same when the fine search happens a posteriori.
+    catalog = lsdb.open_catalog(small_sky_order1_dir, show_statistics=True)
+    catalog = catalog.cone_search(0, -80, 20 * 3600)
+    assert not catalog._operation.preserves_pixel_stats
+    _assert_statistics(catalog, shown=False)
+
+
+def test_hides_statistics_when_user_filters_applied(small_sky_order1_dir):
+    # User-provided row `filters` drop rows, so the statistics are not preserved.
+    catalog = lsdb.open_catalog(small_sky_order1_dir, filters=[("id", ">", 700)], show_statistics=True)
+    assert catalog.loading_config.user_provided_filters
+    assert catalog.hc_structure.catalog_info.total_rows is None
+    _assert_statistics(catalog, shown=False)
+
+
+def test_hides_statistics_when_modified_by_map_partitions(small_sky_order1_dir):
+    # Operations involving map partitions do not preserve statistics.
+    catalog = lsdb.open_catalog(small_sky_order1_dir, show_statistics=True).query("id > 700")
+    assert not catalog._operation.preserves_pixel_stats
+    _assert_statistics(catalog, shown=False)
+
+
+def test_hides_statistics_for_in_memory_catalog():
+    # In-memory catalogs have no on-disk statistics.
+    catalog = lsdb.generate_catalog(100, 1, seed=1)
+    assert catalog.loading_config is None
+    _assert_statistics(catalog, shown=False)
+
+
+def test_repr_when_statistics_unavailable(small_sky_order1_dir, monkeypatch):
+    # If the statistics cannot be loaded, the repr will fall back to the "..." placeholder table.
+    catalog = lsdb.open_catalog(small_sky_order1_dir, show_statistics=True)
+
+    def _not_found(*args, **kwargs):
+        raise FileNotFoundError()
+
+    monkeypatch.setattr(catalog, "per_partition_statistics", _not_found)
+    _assert_statistics(catalog, shown=False)
+
+
+def test_shows_statistics_except_for_nested_columns(small_sky_with_nested_sources_dir):
+    # Nested columns have no per-column on-disk statistics, so they render the "..."
+    # placeholder while every non-nested column shows its min..max range.
+    catalog = lsdb.open_catalog(small_sky_with_nested_sources_dir, show_statistics=True)
+    assert catalog._operation.preserves_pixel_stats
+    assert catalog.nested_columns == ["sources"]
+
+    # The dtype/type header is the first row; the remaining rows hold the per-pixel values.
+    pixel_rows = catalog._repr_data().iloc[1:]
+    assert (pixel_rows["sources"] == "...").all()
+    for col in [c for c in pixel_rows.columns if c not in catalog.nested_columns]:
+        assert not (pixel_rows[col] == "...").any()
+
+    # A stats request for only nested columns has nothing to read.
+    assert catalog._get_repr_pixel_stats(catalog.nested_columns) is None

--- a/tests/lsdb/loaders/hats/test_read_hats.py
+++ b/tests/lsdb/loaders/hats/test_read_hats.py
@@ -402,11 +402,12 @@ def test_set_columns_includes_healpix_column():
         dec_column="dec",
         hats_col_healpix="_healpix_29",
     )
-    config = HatsLoadingConfig(columns=["id"])
+    config = HatsLoadingConfig(columns=["id"], filters=[("id", ">", 0)])
     config.set_columns_from_catalog_info(catalog_info)
     assert "_healpix_29" in config.columns
     assert "ra" in config.columns
     assert "dec" in config.columns
+    assert config.user_provided_filters
 
 
 def test_read_hats_with_extra_kwargs(small_sky_order1_dir):

--- a/tests/lsdb/loaders/hats/test_read_hats.py
+++ b/tests/lsdb/loaders/hats/test_read_hats.py
@@ -414,8 +414,8 @@ def test_read_hats_with_extra_kwargs(small_sky_order1_dir):
     catalog = lsdb.open_catalog(small_sky_order1_dir, filters=[("ra", ">", 300)])
     assert isinstance(catalog, lsdb.Catalog)
     assert np.greater(catalog.compute()["ra"].to_numpy(), 300).all()
-
     assert catalog.loading_config.make_query_url_params() == {"filters": "ra>300"}
+    assert catalog.hc_structure.catalog_info.total_rows is None
 
 
 def test_read_hats_with_mistaken_kwargs(small_sky_order1_dir, small_sky_xmatch_margin_dir):


### PR DESCRIPTION
Implements a lazy catalog view, similar to the one we had previously, before operations was merged.

I added the possibility of requesting partition/column statistics when opening a catalog: `open_catalog(..., show_statistics=True)`. The flag's default is set to False because this feature depends on either the `_metadata` or the `per_partition_statistics` parquet files that might (1) not be present in the catalog's directory, or (2) be too large for the users to download (especially from remote).

I tried to ensure that `SelectPixels` and `SelectColumns` are operations that preserve the pixel statistics. A catalog can therefore be loaded with a set of columns and a coarse search filter and its statistics will still be valid for the view. User-defined row `filters` and other operations (e.g. `map_partitions`) should invalidate statistics.

When statistics are not present, or are invalid, the Catalog representation defaults to a table view with ellipses ("...") as placeholders.

Closes #692.