### PR TITLE
Avoid pandas FutureWarning when concatenating an empty margin

### DIFF
--- a/src/lsdb/operations/functions/merge_catalog_functions.py
+++ b/src/lsdb/operations/functions/merge_catalog_functions.py
@@ -225,10 +225,12 @@ def concat_partition_and_margin(
     npd.NestedFrame
         The concatenated dataframe with the partition on top and the margin on the bottom
     """
-    if margin is None:
-        return partition
     if partition is None:
         return margin
+    if margin is None or len(margin) == 0:
+        # An empty (but not None) margin contributes no rows. Skipping the concat
+        # avoids a pandas FutureWarning about concatenating empty/all-NA entries.
+        return partition
     joined_df = pd.concat([partition, margin])
     return npd.NestedFrame(joined_df)
 

--- a/src/lsdb/operations/functions/merge_catalog_functions.py
+++ b/src/lsdb/operations/functions/merge_catalog_functions.py
@@ -229,7 +229,7 @@ def concat_partition_and_margin(
         return margin
     if margin is None or len(margin) == 0:
         # An empty (but not None) margin contributes no rows. Skipping the concat
-        # avoids a pandas FutureWarning about concatenating empty/all-NA entries.
+        # avoids a pandas FutureWarning about concatenating empty frames.
         return partition
     joined_df = pd.concat([partition, margin])
     return npd.NestedFrame(joined_df)

--- a/tests/lsdb/dask/test_merge_functions.py
+++ b/tests/lsdb/dask/test_merge_functions.py
@@ -1,8 +1,38 @@
 import logging
+import warnings
+
+import nested_pandas as npd
+import pandas as pd
 
 from lsdb.operations.functions.merge_catalog_functions import (
+    concat_partition_and_margin,
     create_merged_catalog_info,
 )
+
+
+def test_concat_partition_and_margin_empty_margin_no_warning():
+    """An empty (but not None) margin must not raise the pandas empty/all-NA
+    concatenation FutureWarning, and the partition is returned unchanged."""
+    partition = npd.NestedFrame({"a": [1, 2, 3], "b": [4.0, 5.0, 6.0]})
+    # An empty margin cache can carry columns with a different (object) dtype,
+    # which is what triggers the FutureWarning under pd.concat.
+    empty_margin = npd.NestedFrame({"a": pd.Series([], dtype="object"), "b": pd.Series([], dtype="object")})
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        result = concat_partition_and_margin(partition, empty_margin)
+
+    assert len(result) == len(partition)
+
+
+def test_concat_partition_and_margin_nonempty_margin_concatenates():
+    """A non-empty margin is still concatenated below the partition."""
+    partition = npd.NestedFrame({"a": [1, 2, 3], "b": [4.0, 5.0, 6.0]})
+    margin = npd.NestedFrame({"a": [7, 8], "b": [7.0, 8.0]})
+
+    result = concat_partition_and_margin(partition, margin)
+
+    assert len(result) == len(partition) + len(margin)
 
 
 def test_create_merged_catalog_info_suffix_logging(small_sky_catalog, small_sky_xmatch_catalog, caplog):


### PR DESCRIPTION
Fixes #1471.

`concat_partition_and_margin` already returns early when the margin (or partition) is `None`, but a margin that is **present yet empty** still went through `pd.concat([partition, margin])`. Under pandas 2.x, concatenating an empty / all-NA frame raises:

```
FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes...
```

which surfaces during crossmatch and other operations that build an (empty) margin, as reported in the issue.

### Fix
Return the partition directly when the margin has no rows — an empty margin contributes nothing to the concatenation result — so both the `concat` and the warning are skipped. The `None` handling and the non-empty-margin path are unchanged. I kept the existing `partition is None` guard first so all previous None-handling behavior is preserved.

### Tests
Added two tests in `tests/lsdb/dask/test_merge_functions.py`:
- `test_concat_partition_and_margin_empty_margin_no_warning` — turns `FutureWarning` into an error and passes an empty margin with object-dtype columns (the shape that triggers the warning); it fails on the previous code and passes with the fix.
- `test_concat_partition_and_margin_nonempty_margin_concatenates` — guards that a non-empty margin is still concatenated.

`black`, `pylint` (10.00/10 with the repo rcfiles) and the `test_merge_functions.py` suite all pass on the changed files.