### PR TITLE
Fix missing docstring parameter descriptions and enable pylint docparams extension

### DIFF
--- a/src/.pylintrc
+++ b/src/.pylintrc
@@ -80,7 +80,7 @@ limit-inference-results=100
 
 # List of plugins (as comma separated values of python module names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=pylint.extensions.docparams
 
 # Pickle collected data for later comparisons.
 persistent=yes

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -1259,6 +1259,8 @@ class Catalog(HealpixDataset):
             the name provided in ``nested_name``. All columns in list_columns must have pyarrow list
             dtypes, otherwise the operation will fail. If None, is defined as all columns not in
             ``base_columns``.
+        name : str, default "nested"
+            The name of the resulting nested column.
 
         Returns
         -------
@@ -1298,14 +1300,14 @@ class Catalog(HealpixDataset):
 
     def map_rows(
         self,
-        func,
-        columns=None,
+        func: Callable,
+        columns: str | list[str] | None = None,
         *,
-        meta,
-        row_container="dict",
-        output_names=None,
-        infer_nesting=True,
-        append_columns=False,
+        meta: object,
+        row_container: Literal["dict", "args"] = "dict",
+        output_names: str | list[str] | None = None,
+        infer_nesting: bool = True,
+        append_columns: bool = False,
         **kwargs,
     ) -> Catalog:
         """Takes a function and applies it to each top-level row of the Catalog.

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -5,7 +5,7 @@ import random
 import warnings
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Type, cast, overload
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Literal, Type, cast, overload
 
 import astropy
 import dask.dataframe as dd
@@ -546,7 +546,7 @@ class HealpixDataset:
             return self.meta.copy()
         return npd.NestedFrame(pd.concat(result))
 
-    def to_dask_dataframe(self, divisions=True):
+    def to_dask_dataframe(self, divisions: bool | list = True):
         """Converts to a Dask DataFrame
 
         Parameters
@@ -1196,7 +1196,9 @@ class HealpixDataset:
         return self.search(OrderSearch(min_order, max_order))
 
     def pixel_search(
-        self, pixels: tuple[int, int] | HealpixPixel | list[tuple[int, int] | HealpixPixel], fine=False
+        self,
+        pixels: tuple[int, int] | HealpixPixel | list[tuple[int, int] | HealpixPixel],
+        fine: bool = False,
     ) -> Self:
         """Finds all catalog pixels that overlap with the requested pixel set.
 
@@ -1204,6 +1206,8 @@ class HealpixDataset:
         ----------
         pixels : list[tuple[int, int]]
             The list of HEALPix tuples (order, pixel) that define the region for the search.
+        fine : bool, default False
+            True if points are to be filtered, False if only partitions. Defaults to False.
 
         Returns
         -------
@@ -1289,11 +1293,6 @@ class HealpixDataset:
 
     def prune_empty_partitions(self) -> Self:
         """Prunes the catalog of its empty partitions
-
-        Parameters
-        ----------
-        persist : bool, default False
-            If True previous computations are saved. Defaults to False.
 
         Returns
         -------
@@ -1599,14 +1598,14 @@ class HealpixDataset:
 
     def map_rows(
         self,
-        func,
-        columns=None,
+        func: Callable,
+        columns: str | list[str] | None = None,
         *,
-        meta,
-        row_container="dict",
-        output_names=None,
-        infer_nesting=True,
-        append_columns=False,
+        meta: object,
+        row_container: Literal["dict", "args"] = "dict",
+        output_names: str | list[str] | None = None,
+        infer_nesting: bool = True,
+        append_columns: bool = False,
         **kwargs,
     ) -> Self:
         """Takes a function and applies it to each top-level row of the Catalog.
@@ -1720,22 +1719,22 @@ class HealpixDataset:
         if meta is None:
             raise ValueError("Please specify `meta`.")
         self_meta = self.meta.copy()
-        meta = npd.NestedFrame(make_meta(meta))
+        meta_frame = npd.NestedFrame(make_meta(meta))
 
         if append_columns:
             ra_col = self.hc_structure.catalog_info.ra_column
             dec_col = self.hc_structure.catalog_info.dec_column
-            overlapping_columns = set(self_meta.columns) & set(meta.columns)
+            overlapping_columns = set(self_meta.columns) & set(meta_frame.columns)
             if overlapping_columns:
                 raise ValueError(
                     f"`meta` specifies columns to append that already exist: {list(overlapping_columns)}."
                 )
-            if ra_col in meta.columns or dec_col in meta.columns:
+            if ra_col in meta_frame.columns or dec_col in meta_frame.columns:
                 raise ValueError("ra and dec columns can not be modified using `map_rows`")
-            added_nested_subcols = [str(col) for col in meta.columns if "." in str(col)]
-            self_meta = self_meta.assign(**{col: meta[col] for col in added_nested_subcols})
-            meta = meta.drop(columns=added_nested_subcols)
-            meta = concat_metas([self_meta, meta])
+            added_nested_subcols = [str(col) for col in meta_frame.columns if "." in str(col)]
+            self_meta = self_meta.assign(**{col: meta_frame[col] for col in added_nested_subcols})
+            meta_frame = meta_frame.drop(columns=added_nested_subcols)
+            meta_frame = concat_metas([self_meta, meta_frame])
 
         def perform_map_rows(df, func, *args, **kwargs):
             return df.map_rows(func, *args, **kwargs)
@@ -1749,7 +1748,7 @@ class HealpixDataset:
             output_names=output_names,
             infer_nesting=infer_nesting,
             append_columns=append_columns,
-            meta=meta,
+            meta=meta_frame,
             **kwargs,
         )
 
@@ -1758,8 +1757,8 @@ class HealpixDataset:
             ra_col = self.hc_structure.catalog_info.ra_column
             dec_col = self.hc_structure.catalog_info.dec_column
             hc_updates = {
-                "ra_column": ra_col if ra_col in meta.columns else "",
-                "dec_column": dec_col if dec_col in meta.columns else "",
+                "ra_column": ra_col if ra_col in meta_frame.columns else "",
+                "dec_column": dec_col if dec_col in meta_frame.columns else "",
             }
         return self._create_updated_dataset(op=op, updated_catalog_info_params=hc_updates)
 

--- a/src/lsdb/catalog/generation.py
+++ b/src/lsdb/catalog/generation.py
@@ -19,7 +19,7 @@ def generate_data(
     ----------
     n_base : int
         The number of rows to generate for the base layer
-    n_layer : int, or dict
+    n_layer : int or dict
         The number of rows per n_base row to generate for a nested layer.
         Alternatively, a dictionary of layer label, layer_size pairs may be
         specified to created multiple nested columns with custom sizing.
@@ -179,7 +179,7 @@ def generate_catalog(
     ----------
     n_base : int
         The number of rows to generate for the base layer
-    n_layer : int, or dict
+    n_layer : int or dict
         The number of rows per n_base row to generate for a nested layer.
         Alternatively, a dictionary of layer label, layer_size pairs may be
         specified to created multiple nested columns with custom sizing.

--- a/src/lsdb/core/plotting/plot_points.py
+++ b/src/lsdb/core/plotting/plot_points.py
@@ -36,6 +36,8 @@ def plot_points(
 
     Parameters
     ----------
+    df : pd.DataFrame
+        The dataframe containing the points to plot
     ra_column : str | None
         The column to use as the RA of the points to plot. Defaults to the
         catalog's default RA column. Useful for plotting joined or cross-matched points

--- a/src/lsdb/core/search/index_search.py
+++ b/src/lsdb/core/search/index_search.py
@@ -57,8 +57,6 @@ class IndexSearch(AbstractSearch):
         ----------
         frame: npd.NestedFrame
             A pixel data frame.
-        _: hc.catalog.TableProperties
-            The HATS catalog properties.
 
         Returns
         -------

--- a/src/lsdb/io/common.py
+++ b/src/lsdb/io/common.py
@@ -32,7 +32,7 @@ def set_default_write_table_kwargs(write_table_kwargs):
 
     Parameters
     ----------
-    **kwargs :
+    write_table_kwargs : dict or None
         Arguments to pass to the parquet write operations
 
     Returns

--- a/src/lsdb/io/to_association.py
+++ b/src/lsdb/io/to_association.py
@@ -106,12 +106,16 @@ def to_association(
     join_column_association : str or None, default None
         The column in the association catalog
         that matches the joining (right) side of join
+    join_to_primary_id_column : str or None, default None
+        The name of the primary id column as it appears in the join catalog
     join_id_column : str or None, default None
         The id column in the join catalog
     separation_column : str or None, default None
         The name of the crossmatch separation column
     overwrite : bool, default False
         If True existing catalog is overwritten
+    addl_hats_properties : dict or None, default None
+        Additional properties to add to the output catalog's hats properties
     **kwargs
         Arguments to pass to the parquet write operations
 

--- a/src/lsdb/io/to_collection.py
+++ b/src/lsdb/io/to_collection.py
@@ -29,7 +29,7 @@ def to_collection(
     ----------
     catalog : HealpixDataset
         A catalog to export
-    base_catalog_path : path-like
+    base_collection_path : path-like
         Location where catalog is saved to
     catalog_name : str or None, default None
         The name of the catalog to be saved
@@ -39,6 +39,8 @@ def to_collection(
         original hats catalog if they exist.
     overwrite : bool, default False
         If True existing collection is overwritten
+    resume : bool, default False
+        If True, resumes a previous, incomplete write of the collection
     progress_bar : bool, default True
         If True, shows a progress bar during the export process
     tqdm_kwargs : dict or None, default None

--- a/src/lsdb/io/to_hats.py
+++ b/src/lsdb/io/to_hats.py
@@ -248,7 +248,7 @@ def to_hats(
     overwrite: bool = False,
     resume: bool = False,
     progress_bar: bool = True,
-    tqdm_kwargs=None,
+    tqdm_kwargs: dict | None = None,
     create_thumbnail: bool = False,
     skymap_alt_orders: list[int] | None = None,
     npix_suffix: str = ".parquet",

--- a/src/lsdb/loaders/dataframe/from_astropy.py
+++ b/src/lsdb/loaders/dataframe/from_astropy.py
@@ -21,7 +21,7 @@ def from_astropy(
     should_generate_moc: bool = True,
     moc_max_order: int = 10,
     use_pyarrow_types: bool = True,
-    schema=None,
+    schema: pa.Schema | None = None,
     flatten_tensors: bool = False,
     **kwargs,
 ):

--- a/src/lsdb/loaders/hats/read_hats.py
+++ b/src/lsdb/loaders/hats/read_hats.py
@@ -479,6 +479,12 @@ def read_pixel(
         The HEALPix file whose file is to be read.
     path_generator : Callable[[UPath, HealpixPixel, dict | None, str], UPath]
         The object that translates HEALPix to their respective files.
+    catalog_base_dir : UPath
+        The base directory of the catalog.
+    npix_suffix : str
+        The suffix used for the pixel's file or directory name.
+    query_url_params : dict or None, default None
+        Additional URL query parameters to use, for HTTP-backed catalogs.
     index_column : str, default SPATIAL_INDEX_COLUMN
         The index column.
     columns: list[str] or str or None, default None
@@ -487,6 +493,8 @@ def read_pixel(
         The pyarrow schema expected for the file.
     is_dir : bool, optional
         (Default value = False) If True, the pixel data is stored in a directory.
+    **kwargs
+        Additional keyword arguments to pass to the parquet read operation.
 
     Returns
     -------

--- a/src/lsdb/operations/functions/crossmatch_catalog_data.py
+++ b/src/lsdb/operations/functions/crossmatch_catalog_data.py
@@ -226,18 +226,24 @@ def perform_crossmatch_nested(
         Partition from the right catalog.
     right_margin_df: npd.NestedFrame | None
         Partition from the right catalog margin cache.
+    aligned_df : npd.NestedFrame | None
+        The partition of the aligned pixel
     left_pix : HealpixPixel | None
         HealpixPixel for the left partition.
     right_pix : HealpixPixel | None
         HealpixPixel for the right partition.
     right_margin_pix : HealpixPixel | None
         HealpixPixel for the right margin partition.
+    aligned_pixel : HealpixPixel
+        HealpixPixel for the aligned partition.
     left_catalog_info : hats.catalog.TableProperties
         Catalog info for the left partition.
     right_catalog_info : hats.catalog.TableProperties
         Catalog info for the right partition.
     right_margin_catalog_info : hats.catalog.TableProperties
         Catalog info for the right margin partition.
+    aligned_catalog_info : hats.catalog.TableProperties | None
+        Catalog info for the aligned partition; usually None
     algorithm : AbstractCrossmatchAlgorithm
         The algorithm to use to perform the crossmatch. Specified by subclassing
         `AbstractCrossmatchAlgorithm`. For more details, see `crossmatch` method

--- a/src/lsdb/operations/functions/merge_catalog_functions.py
+++ b/src/lsdb/operations/functions/merge_catalog_functions.py
@@ -830,6 +830,8 @@ def generate_meta_df_for_nested_tables(
         The name of the column in the right catalog to join on
     extra_columns : pd.Dataframe or None, default None
         Any additional columns to the merged catalogs
+    extra_nested_columns : pd.Dataframe or None, default None
+        Any additional columns to add to the nested column
     index_name : str, default SPATIAL_INDEX_COLUMN
         The name of the index in the resulting DataFrame
     index_type : Dtype or None, default None


### PR DESCRIPTION
Some of the parameter descriptions in the docstrings are outdated, and some parameters have type hints that do not match the docstrings. Here I'm fixing it and also enabling pylint's lints for tracking in the future.

Fixes #1428