### PR TITLE
Augment write_catalog arguments

### DIFF
--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -1440,7 +1440,7 @@ class Catalog(HealpixDataset):
         return catalog
 
     @deprecated(
-        version="0.7.3", reason="`to_hats` will be removed in the future, " "use `write_catalog` instead."
+        version="0.7.3", reason="`to_hats` will be removed in the future, use `write_catalog` instead."
     )
     def to_hats(
         self,
@@ -1474,14 +1474,23 @@ class Catalog(HealpixDataset):
         *,
         catalog_name: str | None = None,
         default_columns: list[str] | None = None,
+        inherit_provenance: bool = False,
+        addl_hats_properties: dict | None = None,
         as_collection: bool = True,
         overwrite: bool = False,
         resume: bool = False,
         progress_bar: bool = True,
         tqdm_kwargs: dict | None = None,
-        create_thumbnail: bool = True,
+        create_parquet_metadata: bool = True,
+        create_thumbnail: bool = False,
+        create_per_partition_statistics: bool = True,
         error_if_empty: bool = True,
         create_summary: bool = True,
+        should_write_skymap: bool = True,
+        skymap_alt_orders: list[int] | None = None,
+        npix_suffix: str = ".parquet",
+        npix_parquet_name: str | None = None,
+        write_table_kwargs: dict | None = None,
         **kwargs,
     ):
         """Save the catalog to disk in HATS format.
@@ -1536,13 +1545,22 @@ class Catalog(HealpixDataset):
                 base_collection_path=base_catalog_path,
                 catalog_name=catalog_name,
                 default_columns=default_columns,
+                inherit_provenance=inherit_provenance,
+                addl_hats_properties=addl_hats_properties,
                 overwrite=overwrite,
                 resume=resume,
                 progress_bar=progress_bar,
                 tqdm_kwargs=tqdm_kwargs,
-                error_if_empty=error_if_empty,
+                create_parquet_metadata=create_parquet_metadata,
                 create_thumbnail=create_thumbnail,
+                create_per_partition_statistics=create_per_partition_statistics,
+                error_if_empty=error_if_empty,
                 create_summary=create_summary,
+                should_write_skymap=should_write_skymap,
+                skymap_alt_orders=skymap_alt_orders,
+                write_table_kwargs=write_table_kwargs,
+                npix_suffix=npix_suffix,
+                npix_parquet_name=npix_parquet_name,
                 **kwargs,
             )
         else:
@@ -1550,12 +1568,21 @@ class Catalog(HealpixDataset):
                 base_catalog_path,
                 catalog_name=catalog_name,
                 default_columns=default_columns,
+                inherit_provenance=inherit_provenance,
+                addl_hats_properties=addl_hats_properties,
                 overwrite=overwrite,
                 resume=resume,
                 progress_bar=progress_bar,
                 tqdm_kwargs=tqdm_kwargs,
+                create_parquet_metadata=create_parquet_metadata,
                 create_thumbnail=create_thumbnail,
+                create_per_partition_statistics=create_per_partition_statistics,
                 error_if_empty=error_if_empty,
                 create_summary=create_summary,
+                should_write_skymap=should_write_skymap,
+                skymap_alt_orders=skymap_alt_orders,
+                write_table_kwargs=write_table_kwargs,
+                npix_suffix=npix_suffix,
+                npix_parquet_name=npix_parquet_name,
                 **kwargs,
             )

--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -1468,6 +1468,7 @@ class Catalog(HealpixDataset):
             **kwargs,
         )
 
+    # pylint: disable=too-many-locals,too-many-arguments
     def write_catalog(
         self,
         base_catalog_path: str | Path | UPath,
@@ -1491,7 +1492,6 @@ class Catalog(HealpixDataset):
         npix_suffix: str = ".parquet",
         npix_parquet_name: str | None = None,
         write_table_kwargs: dict | None = None,
-        **kwargs,
     ):
         """Save the catalog to disk in HATS format.
 
@@ -1505,6 +1505,12 @@ class Catalog(HealpixDataset):
             A metadata property with the list of the columns in the
             catalog to be loaded by default. By default, uses the default columns from the
             original hats catalog if they exist.
+        inherit_provenance : bool, default False
+            If the original catalog had some provenance info (like creator or bib references),
+            should this new catalog retain all of it?
+        addl_hats_properties : dict or None, default None
+            key-value pairs of additional properties to write in the
+            ``hats.properties`` file.
         as_collection : bool, default True
             If True, saves the catalog and its margin as a collection
         overwrite : bool, default False
@@ -1516,16 +1522,32 @@ class Catalog(HealpixDataset):
             If True, shows a progress bar for the export process. Defaults to True.
         tqdm_kwargs : dict, default None
             Additional kwargs to pass to the tqdm progress bar.
-        create_thumbnail : bool, default True
-            If True, creates a ``data_thumbnail.parquet`` file containing one row
-            per partition, for quick previewing of the catalog's contents.
+        create_parquet_metadata : bool, default True
+            Should we create /dataset/_metadata parquet from all data partitions.
+        create_thumbnail : bool, default False
+            If True, create a data thumbnail of the catalog for
+            previewing purposes. Defaults to False.
+        create_per_partition_statistics : bool, default True
+            Should we create per_partition_statistics.parquet, based on footers from all data partitions
         error_if_empty : bool, default True
-            If True, raises an error if the catalog is empty.
+            If True, raises an error if the output catalog is empty
         create_summary : bool, default True
             If True, writes ``README.md`` summary file(s) describing the catalog. When
             ``as_collection`` is True, this generates a summary for the collection, the
             main catalog, and the margin (if it exists).
-        **kwargs
+        should_write_skymap: bool, default True
+            Should we write a `skymap.fits` file, with the point distribution of the catalog?
+            Main catalogs should contain skymap fits files, generally.
+        skymap_alt_orders : list[int] or None, default None
+            We will write a skymap file at the ``histogram_order``,
+            but can also write down-sampled skymaps, for easier previewing of the data.
+        npix_suffix : str, default '.parquet'
+            Extension for the parquet file (or `/` if a directory)
+        npix_parquet_name : str | None, default None
+            Name of the pixel parquet file to be used when npix_suffix=/.
+            By default, it will be named after the pixel with a .parquet
+            extension (e.g. 'Npix=10.parquet').
+        write_table_kwargs: dict or None, default None
             Arguments to pass to the parquet write operations
 
         Examples
@@ -1561,7 +1583,6 @@ class Catalog(HealpixDataset):
                 write_table_kwargs=write_table_kwargs,
                 npix_suffix=npix_suffix,
                 npix_parquet_name=npix_parquet_name,
-                **kwargs,
             )
         else:
             super().write_catalog(
@@ -1584,5 +1605,4 @@ class Catalog(HealpixDataset):
                 write_table_kwargs=write_table_kwargs,
                 npix_suffix=npix_suffix,
                 npix_parquet_name=npix_parquet_name,
-                **kwargs,
             )

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -1379,61 +1379,107 @@ class HealpixDataset:
             **kwargs,
         )
 
+    # pylint: disable=too-many-locals,too-many-arguments
     def write_catalog(
         self,
         base_catalog_path: str | Path | UPath,
         *,
         catalog_name: str | None = None,
         default_columns: list[str] | None = None,
+        inherit_provenance: bool = False,
+        addl_hats_properties: dict | None = None,
         overwrite: bool = False,
         resume: bool = False,
         progress_bar: bool = True,
         tqdm_kwargs: dict | None = None,
+        create_parquet_metadata: bool = True,
+        create_thumbnail: bool = False,
+        create_per_partition_statistics: bool = True,
         error_if_empty: bool = True,
         create_summary: bool = True,
-        **kwargs,
+        should_write_skymap: bool = True,
+        skymap_alt_orders: list[int] | None = None,
+        npix_suffix: str = ".parquet",
+        npix_parquet_name: str | None = None,
+        write_table_kwargs: dict | None = None,
     ):
         """Save the catalog to disk in HATS format.
 
         Parameters
         ----------
-        base_catalog_path : str | Path | UPath
+        base_catalog_path : str | Path | UPath,
             Location where catalog is saved to
-        catalog_name : str or None, default None
+        catalog_name : str
             The name of the catalog to be saved
-        default_columns : list[str] or None, default None
-            A metadata property with the list of the columns in the catalog to
-            be loaded by default. By default, uses the default columns from the
-            original hats catalogs if they exist.
+        default_columns : list[str]
+            A metadata property with the list of the columns in the
+            catalog to be loaded by default. By default, uses the default columns from the
+            original hats catalog if they exist.
+        inherit_provenance : bool, default False
+            If the original catalog had some provenance info (like creator or bib references),
+            should this new catalog retain all of it?
+        addl_hats_properties : dict or None, default None
+            key-value pairs of additional properties to write in the
+            ``hats.properties`` file.
         overwrite : bool, default False
             If True existing catalog is overwritten
         resume : bool, default False
             If True, resumes a previous write operation, skipping partitions that were
             already written to disk.
         progress_bar : bool, default True
-            If True, displays a progress bar during the save operation
-        tqdm_kwargs : dict or None, default None
-            Keyword arguments to pass to tqdm for customizing the progress bar
+            If True, shows a progress bar for the export process. Defaults to True.
+        tqdm_kwargs : dict, default None
+            Additional kwargs to pass to the tqdm progress bar.
+        create_parquet_metadata : bool, default True
+            Should we create /dataset/_metadata parquet from all data partitions.
+        create_thumbnail : bool, default False
+            If True, create a data thumbnail of the catalog for
+            previewing purposes. Defaults to False.
+        create_per_partition_statistics : bool, default True
+            Should we create per_partition_statistics.parquet, based on footers from all data partitions
         error_if_empty : bool, default True
-            If True, raises an error if the catalog is empty.
+            If True, raises an error if the output catalog is empty
         create_summary : bool, default True
-            If True, writes a ``README.md`` summary file describing the catalog.
-        **kwargs
+            If True, writes ``README.md`` summary file(s) describing the catalog. When
+            ``as_collection`` is True, this generates a summary for the collection, the
+            main catalog, and the margin (if it exists).
+        should_write_skymap: bool, default True
+            Should we write a `skymap.fits` file, with the point distribution of the catalog?
+            Main catalogs should contain skymap fits files, generally.
+        skymap_alt_orders : list[int] or None, default None
+            We will write a skymap file at the ``histogram_order``,
+            but can also write down-sampled skymaps, for easier previewing of the data.
+        npix_suffix : str, default '.parquet'
+            Extension for the parquet file (or `/` if a directory)
+        npix_parquet_name : str | None, default None
+            Name of the pixel parquet file to be used when npix_suffix=/.
+            By default, it will be named after the pixel with a .parquet
+            extension (e.g. 'Npix=10.parquet').
+        write_table_kwargs: dict or None, default None
             Arguments to pass to the parquet write operations
         """
         self._check_unloaded_columns(default_columns)
         io.to_hats(
             self,
-            base_catalog_path=base_catalog_path,
             catalog_name=catalog_name,
+            base_catalog_path=base_catalog_path,
             default_columns=default_columns,
+            inherit_provenance=inherit_provenance,
+            addl_hats_properties=addl_hats_properties,
             overwrite=overwrite,
             resume=resume,
             progress_bar=progress_bar,
             tqdm_kwargs=tqdm_kwargs,
+            create_parquet_metadata=create_parquet_metadata,
+            create_thumbnail=create_thumbnail,
+            create_per_partition_statistics=create_per_partition_statistics,
             error_if_empty=error_if_empty,
             create_summary=create_summary,
-            **kwargs,
+            should_write_skymap=should_write_skymap,
+            skymap_alt_orders=skymap_alt_orders,
+            write_table_kwargs=write_table_kwargs,
+            npix_suffix=npix_suffix,
+            npix_parquet_name=npix_parquet_name,
         )
 
     def to_lance(

--- a/src/lsdb/io/common.py
+++ b/src/lsdb/io/common.py
@@ -14,6 +14,9 @@ def new_provenance_properties(
     ----------
     path: str | Path | UPath | None, default None
         The path to the catalog.
+    inherit_provenance : bool, default False
+        If the original catalog had some provenance info (like creator or bib references),
+        should this new catalog retain all of it?
     **kwargs
         Additional provenance properties.
 
@@ -30,9 +33,7 @@ def new_provenance_properties(
             "creator_did": None,
             "publisher_id": None,
         }
-    return TableProperties.new_provenance_dict(
-        path, builder=f"lsdb v{version('lsdb')}", **kwargs
-    )
+    return TableProperties.new_provenance_dict(path, builder=f"lsdb v{version('lsdb')}", **kwargs)
 
 
 def set_default_write_table_kwargs(write_table_kwargs):

--- a/src/lsdb/io/common.py
+++ b/src/lsdb/io/common.py
@@ -5,7 +5,9 @@ from hats.catalog import TableProperties
 from upath import UPath
 
 
-def new_provenance_properties(path: str | Path | UPath | None = None, **kwargs) -> dict:
+def new_provenance_properties(
+    path: str | Path | UPath | None = None, inherit_provenance: bool = False, **kwargs
+) -> dict:
     """Create a new provenance properties dictionary for the dataset.
 
     Parameters
@@ -20,7 +22,17 @@ def new_provenance_properties(path: str | Path | UPath | None = None, **kwargs) 
     dict
         A new provenance dictionary.
     """
-    return TableProperties.new_provenance_dict(path, builder=f"lsdb v{version('lsdb')}", **kwargs)
+    if not inherit_provenance:
+        kwargs |= {
+            "hats_creator": None,
+            "bib_reference": None,
+            "bib_reference_url": None,
+            "creator_did": None,
+            "publisher_id": None,
+        }
+    return TableProperties.new_provenance_dict(
+        path, builder=f"lsdb v{version('lsdb')}", **kwargs
+    )
 
 
 def set_default_write_table_kwargs(write_table_kwargs):

--- a/src/lsdb/io/to_association.py
+++ b/src/lsdb/io/to_association.py
@@ -233,7 +233,7 @@ def to_association(
         "contains_leaf_files": True,
         "hats_order": partition_info.get_highest_order(),
         "total_rows": int(np.sum(counts)),
-        "moc_sky_fraction": f"{partition_info.calculate_fractional_coverage():.5f}",
+        "moc_sky_fraction": f"{partition_info.calculate_fractional_coverage():.5}",
     } | new_provenance_properties(inherit_provenance=inherit_provenance)
 
     max_separation = np.max(max_separations)

--- a/src/lsdb/io/to_association.py
+++ b/src/lsdb/io/to_association.py
@@ -12,6 +12,7 @@ from hats.catalog import CatalogType, PartitionInfo, TableProperties
 from hats.catalog.catalog_collection import CatalogCollection
 from hats.pixel_math import HealpixPixel
 from upath import UPath
+from lsdb.io.common import new_provenance_properties
 
 from lsdb.io.common import set_default_write_table_kwargs
 
@@ -67,6 +68,8 @@ def to_association(
     *,
     base_catalog_path: str | Path | UPath,
     catalog_name: str | None = None,
+    inherit_provenance: bool = False,
+    addl_hats_properties: dict | None = None,
     primary_catalog_dir: str | Path | UPath | None = None,
     primary_column_association: str | None = None,
     primary_id_column: str | None = None,
@@ -75,9 +78,11 @@ def to_association(
     join_to_primary_id_column: str | None = None,
     join_id_column: str | None = None,
     separation_column: str | None = None,
+    create_parquet_metadata: bool = True,
+    create_per_partition_statistics: bool = True,
+    error_if_empty: bool = True,
     overwrite: bool = False,
-    addl_hats_properties: dict | None = None,
-    **kwargs,
+    write_table_kwargs: dict | None = None,
 ):
     """Writes a crossmatching product to disk, in HATS association table format.
     The output catalog comprises partition parquet files and respective metadata.
@@ -192,13 +197,22 @@ def to_association(
     file_io.file_io.make_directory(base_catalog_path, exist_ok=True)
 
     # Save partition parquet files
-    kwargs = set_default_write_table_kwargs(kwargs)
+    write_table_kwargs = set_default_write_table_kwargs(write_table_kwargs)
     pixels, counts, max_separations = write_partitions(
-        catalog, base_catalog_dir_fp=base_catalog_path, separation_column=separation_column, **kwargs
+        catalog,
+        base_catalog_dir_fp=base_catalog_path,
+        separation_column=separation_column,
+        error_if_empty=error_if_empty,
+        **write_table_kwargs,
     )
 
     # Save parquet metadata
-    file_io.write_parquet_metadata(base_catalog_path, create_thumbnail=False)
+    file_io.write_parquet_metadata(
+        base_catalog_path,
+        create_metadata=create_parquet_metadata,
+        create_per_partition_stats=create_per_partition_statistics,
+        create_thumbnail=False,
+    )
 
     # Save partition info
     partition_info = PartitionInfo(pixels)
@@ -211,8 +225,8 @@ def to_association(
         "contains_leaf_files": True,
         "hats_order": partition_info.get_highest_order(),
         "total_rows": int(np.sum(counts)),
-        "moc_sky_fraction": f"{partition_info.calculate_fractional_coverage():0.5f}",
-    }
+        "moc_sky_fraction": partition_info.calculate_fractional_coverage(),
+    } | new_provenance_properties(inherit_provenance=inherit_provenance)
 
     max_separation = np.max(max_separations)
     if max_separation != -1:
@@ -229,6 +243,7 @@ def write_partitions(
     catalog: HealpixDataset,
     base_catalog_dir_fp: str | Path | UPath,
     separation_column: str | None,
+    error_if_empty: bool = True,
     **kwargs,
 ) -> tuple[list[HealpixPixel], list[int], list[float]]:
     """Saves catalog partitions as parquet to disk and computes the sparse
@@ -270,7 +285,7 @@ def write_partitions(
     non_empty_max_separations = np.array(max_separations)[non_empty_indices]
 
     # Check that the catalog is not empty
-    if len(non_empty_pixels) == 0:
+    if len(non_empty_pixels) == 0 and error_if_empty:
         raise RuntimeError("The output catalog is empty")
 
     return list(non_empty_pixels), list(non_empty_counts), list(non_empty_max_separations)

--- a/src/lsdb/io/to_association.py
+++ b/src/lsdb/io/to_association.py
@@ -12,9 +12,8 @@ from hats.catalog import CatalogType, PartitionInfo, TableProperties
 from hats.catalog.catalog_collection import CatalogCollection
 from hats.pixel_math import HealpixPixel
 from upath import UPath
-from lsdb.io.common import new_provenance_properties
 
-from lsdb.io.common import set_default_write_table_kwargs
+from lsdb.io.common import new_provenance_properties, set_default_write_table_kwargs
 
 if TYPE_CHECKING:
     from lsdb.catalog.dataset.healpix_dataset import HealpixDataset
@@ -99,6 +98,11 @@ def to_association(
         Location where catalog is saved to
     catalog_name : str or None, default None
         The name of the output catalog
+    inherit_provenance : bool, default False
+        If the original catalog had some provenance info (like creator or bib references),
+        should this new catalog retain all of it?
+    addl_hats_properties : dict or None, default None
+        Additional properties to add to the output catalog's hats properties
     primary_catalog_dir : path-like or None, default None
         The path to the primary catalog
     primary_column_association : str or None, default None
@@ -117,11 +121,15 @@ def to_association(
         The id column in the join catalog
     separation_column : str or None, default None
         The name of the crossmatch separation column
+    create_parquet_metadata : bool, default True
+        Should we create /dataset/_metadata parquet from all data partitions.
+    create_per_partition_statistics : bool, default True
+        Should we create per_partition_statistics.parquet, based on footers from all data partitions
+    error_if_empty : bool, default True
+        If True, raises an error if the output catalog is empty
     overwrite : bool, default False
         If True existing catalog is overwritten
-    addl_hats_properties : dict or None, default None
-        Additional properties to add to the output catalog's hats properties
-    **kwargs
+    write_table_kwargs: dict or None, default None
         Arguments to pass to the parquet write operations
 
     Notes
@@ -258,6 +266,8 @@ def write_partitions(
         Path to the base directory of the catalog
     separation_column : str or None
         The name of the crossmatch separation column
+    error_if_empty : bool, default True
+        If True, raises an error if the output catalog is empty
     **kwargs
         Arguments to pass to the parquet write operations
 

--- a/src/lsdb/io/to_association.py
+++ b/src/lsdb/io/to_association.py
@@ -233,7 +233,7 @@ def to_association(
         "contains_leaf_files": True,
         "hats_order": partition_info.get_highest_order(),
         "total_rows": int(np.sum(counts)),
-        "moc_sky_fraction": partition_info.calculate_fractional_coverage(),
+        "moc_sky_fraction": f"{partition_info.calculate_fractional_coverage():.5f}",
     } | new_provenance_properties(inherit_provenance=inherit_provenance)
 
     max_separation = np.max(max_separations)

--- a/src/lsdb/io/to_hats.py
+++ b/src/lsdb/io/to_hats.py
@@ -425,7 +425,7 @@ def to_hats(
         total_rows=int(np.sum(counts)),
         default_columns=default_columns,
         hats_max_rows=hats_max_rows,
-        moc_sky_fraction=f"{partition_info.calculate_fractional_coverage():.5f}",
+        moc_sky_fraction=f"{partition_info.calculate_fractional_coverage():.5}",
         hats_order=partition_info.get_highest_order() if len(partition_info) else None,
         npix_suffix=npix_suffix,
         **addl_hats_properties,

--- a/src/lsdb/io/to_hats.py
+++ b/src/lsdb/io/to_hats.py
@@ -238,7 +238,7 @@ def remove_done_files(base_catalog_path: UPath):
     file_io.remove_directory(done_path, ignore_errors=True)
 
 
-# pylint: disable=protected-access,too-many-locals,too-many-arguments
+# pylint: disable=protected-access,too-many-locals,too-many-arguments,too-many-statements
 def to_hats(
     catalog: HealpixDataset,
     *,
@@ -283,6 +283,12 @@ def to_hats(
         A metadata property with the list of the columns in the
         catalog to be loaded by default. Uses the default columns from the original hats
         catalog if they exist.
+    inherit_provenance : bool, default False
+        If the original catalog had some provenance info (like creator or bib references),
+        should this new catalog retain all of it?
+    addl_hats_properties : dict or None, default None
+        key-value pairs of additional properties to write in the
+        ``hats.properties`` file.
     histogram_order : int or None, default None
         The default order for the count histogram. Defaults to the same
         skymap order as original catalog, or the highest order healpix of the current
@@ -295,11 +301,20 @@ def to_hats(
         If True, shows a progress bar for the export process. Defaults to True.
     tqdm_kwargs : dict, default None
         Additional kwargs to pass to the tqdm progress bar.
+    create_parquet_metadata : bool, default True
+        Should we create /dataset/_metadata parquet from all data partitions.
     create_thumbnail : bool, default False
         If True, create a data thumbnail of the catalog for
         previewing purposes. Defaults to False.
+    create_per_partition_statistics : bool, default True
+        Should we create per_partition_statistics.parquet, based on footers from all data partitions
+    error_if_empty : bool, default True
+        If True, raises an error if the output catalog is empty
     create_summary : bool, default True
         If True, writes a ``README.md`` summary file describing the catalog.
+    should_write_skymap: bool, default True
+        Should we write a `skymap.fits` file, with the point distribution of the catalog?
+        Main catalogs should contain skymap fits files, generally.
     skymap_alt_orders : list[int] or None, default None
         We will write a skymap file at the ``histogram_order``,
         but can also write down-sampled skymaps, for easier previewing of the data.
@@ -309,12 +324,7 @@ def to_hats(
         Name of the pixel parquet file to be used when npix_suffix=/.
         By default, it will be named after the pixel with a .parquet
         extension (e.g. 'Npix=10.parquet').
-    addl_hats_properties : dict or None, default None
-        key-value pairs of additional properties to write in the
-        ``hats.properties`` file.
-    error_if_empty : bool, default True
-        If True, raises an error if the output catalog is empty
-    **kwargs :
+    write_table_kwargs: dict or None, default None
         Arguments to pass to the parquet write operations
     """
     if overwrite and resume:

--- a/src/lsdb/io/to_hats.py
+++ b/src/lsdb/io/to_hats.py
@@ -245,19 +245,23 @@ def to_hats(
     base_catalog_path: str | Path | UPath,
     catalog_name: str | None = None,
     default_columns: list[str] | None = None,
+    inherit_provenance: bool = False,
+    addl_hats_properties: dict | None = None,
     histogram_order: int | None = None,
     overwrite: bool = False,
     resume: bool = False,
     progress_bar: bool = True,
     tqdm_kwargs: dict | None = None,
+    create_parquet_metadata: bool = True,
     create_thumbnail: bool = False,
+    create_per_partition_statistics: bool = True,
+    error_if_empty: bool = True,
     create_summary: bool = True,
+    should_write_skymap: bool = True,
     skymap_alt_orders: list[int] | None = None,
     npix_suffix: str = ".parquet",
     npix_parquet_name: str | None = None,
-    addl_hats_properties: dict | None = None,
-    error_if_empty: bool = True,
-    **kwargs,
+    write_table_kwargs: dict | None = None,
 ):
     """Writes a catalog to disk, in HATS format.
 
@@ -342,7 +346,7 @@ def to_hats(
             )
             histogram_order = max(max_catalog_depth, 8)
     # Save partition parquet files
-    kwargs = set_default_write_table_kwargs(kwargs)
+    write_table_kwargs = set_default_write_table_kwargs(write_table_kwargs)
 
     desc = tqdm_kwargs.pop("desc", "Writing Catalog") if tqdm_kwargs else "Writing Catalog"
 
@@ -354,7 +358,7 @@ def to_hats(
             existing_pixels=existing_pixels,
             npix_suffix=npix_suffix,
             npix_parquet_name=npix_parquet_name,
-            **kwargs,
+            **write_table_kwargs,
         )
         pixels = existing_pixels + new_pixels
         histograms = histograms + new_histograms
@@ -367,9 +371,18 @@ def to_hats(
     # Save parquet metadata and create a data thumbnail if needed
     hats_max_rows = int(max(counts)) if counts else 0
 
-    _write_parquet_metadata(base_catalog_path, catalog, create_thumbnail, hats_max_rows, pixels)
+    _write_parquet_metadata(
+        base_catalog_path,
+        catalog,
+        pixels=pixels,
+        create_parquet_metadata=create_parquet_metadata,
+        create_thumbnail=create_thumbnail,
+        hats_max_rows=hats_max_rows,
+        create_per_partition_statistics=create_per_partition_statistics,
+    )
     # Save partition info
-    PartitionInfo(pixels).write_to_file(base_catalog_path / "partition_info.csv")
+    partition_info = PartitionInfo(pixels)
+    partition_info.write_to_file(base_catalog_path / "partition_info.csv")
 
     # Save catalog info
     if default_columns:
@@ -385,10 +398,15 @@ def to_hats(
             "skymap_order": int(histogram_order),
             "skymap_alt_orders": skymap_alt_orders,
         }
+        if should_write_skymap:
+            _write_skymaps(
+                base_catalog_path, histogram_order, histograms, skymap_alt_orders=skymap_alt_orders
+            )
 
-        _write_skymaps(base_catalog_path, histogram_order, histograms, skymap_alt_orders)
-
-    addl_hats_properties = addl_hats_properties | new_provenance_properties(base_catalog_path)
+    addl_hats_properties = (
+        new_provenance_properties(base_catalog_path, inherit_provenance=inherit_provenance)
+        | addl_hats_properties
+    )
 
     new_hc_structure = create_modified_catalog_structure(
         catalog.hc_structure,
@@ -397,7 +415,9 @@ def to_hats(
         total_rows=int(np.sum(counts)),
         default_columns=default_columns,
         hats_max_rows=hats_max_rows,
-        hats_npix_suffix=npix_suffix,
+        moc_sky_fraction=partition_info.calculate_fractional_coverage(),
+        hats_order=partition_info.get_highest_order() if len(partition_info) else 0,
+        npix_suffix=npix_suffix,
         **addl_hats_properties,
     )
     new_hc_structure.catalog_info.to_properties_file(base_catalog_path)
@@ -436,15 +456,22 @@ def _read_existing_progress(
 def _write_parquet_metadata(
     base_catalog_path: UPath,
     catalog: HealpixDataset,
-    create_thumbnail: bool,
-    hats_max_rows: int,
     pixels: list[Any],
+    *,
+    create_parquet_metadata: bool = True,
+    create_thumbnail: bool = False,
+    hats_max_rows: int = 1_000_000,
+    create_per_partition_statistics: bool = True,
 ):
     """Writes the parquet metadata for the catalog. If there are no pixels,
     writes empty metadata files with the correct schema."""
     if len(pixels) > 0:
         hc.io.write_parquet_metadata(
-            base_catalog_path, create_thumbnail=create_thumbnail, thumbnail_threshold=hats_max_rows
+            base_catalog_path,
+            create_metadata=create_parquet_metadata,
+            create_thumbnail=create_thumbnail,
+            thumbnail_threshold=hats_max_rows,
+            create_per_partition_stats=create_per_partition_statistics,
         )
     else:
         metadata_path = hc.io.paths.get_parquet_metadata_pointer(base_catalog_path)
@@ -460,7 +487,8 @@ def _write_skymaps(
     base_catalog_path: UPath,
     histogram_order: int,
     histograms: list[Any] | Any,
-    skymap_alt_orders: list[int] | None,
+    *,
+    skymap_alt_orders: list[int] | None = None,
 ):
     """Writes the skymap files for the catalog, based on the histograms for each partition."""
     # Save the point distribution map
@@ -497,6 +525,7 @@ def write_partitions(
     catalog: HealpixDataset,
     base_catalog_dir_fp: str | Path | UPath,
     histogram_order: int,
+    *,
     existing_pixels: list[HealpixPixel] | None = None,
     npix_suffix: str = ".parquet",
     npix_parquet_name: str | None = None,

--- a/src/lsdb/io/to_hats.py
+++ b/src/lsdb/io/to_hats.py
@@ -425,8 +425,8 @@ def to_hats(
         total_rows=int(np.sum(counts)),
         default_columns=default_columns,
         hats_max_rows=hats_max_rows,
-        moc_sky_fraction=partition_info.calculate_fractional_coverage(),
-        hats_order=partition_info.get_highest_order() if len(partition_info) else 0,
+        moc_sky_fraction=f"{partition_info.calculate_fractional_coverage():.5f}",
+        hats_order=partition_info.get_highest_order() if len(partition_info) else None,
         npix_suffix=npix_suffix,
         **addl_hats_properties,
     )

--- a/src/lsdb/loaders/dataframe/margin_catalog_generator.py
+++ b/src/lsdb/loaders/dataframe/margin_catalog_generator.py
@@ -271,7 +271,7 @@ class MarginCatalogGenerator:
         if kwargs is None:
             kwargs = {}
         kwargs.pop("catalog_type", None)
-        kwargs = kwargs | new_provenance_properties() | {"hats_estsize": 0}
+        kwargs = kwargs | new_provenance_properties() | {"hats_estsize": None}
         if not catalog_name:
             catalog_name = self.hc_structure.catalog_info.catalog_name
         return TableProperties(

--- a/src/lsdb/loaders/dataframe/margin_catalog_generator.py
+++ b/src/lsdb/loaders/dataframe/margin_catalog_generator.py
@@ -271,7 +271,7 @@ class MarginCatalogGenerator:
         if kwargs is None:
             kwargs = {}
         kwargs.pop("catalog_type", None)
-        kwargs = kwargs | new_provenance_properties(hats_estsize=0)
+        kwargs = kwargs | new_provenance_properties() | {"hats_estsize": 0}
         if not catalog_name:
             catalog_name = self.hc_structure.catalog_info.catalog_name
         return TableProperties(

--- a/src/lsdb/operations/functions/merge_catalog_functions.py
+++ b/src/lsdb/operations/functions/merge_catalog_functions.py
@@ -926,6 +926,7 @@ def create_merged_catalog_info(
         The catalog info of the resulting merged catalog
     """
     left_info = left.hc_structure.catalog_info
+    right_info = right.hc_structure.catalog_info
     ra_col = (
         apply_left_suffix(left_info.ra_column, right.columns, suffixes, suffix_method)
         if left_info.ra_column is not None
@@ -936,8 +937,11 @@ def create_merged_catalog_info(
         if left_info.dec_column is not None
         else None
     )
+    types = [left_info.catalog_type, right_info.catalog_type]
+    catalog_type = min(types)
     return left_info.copy_and_update(
         catalog_name=updated_name,
+        catalog_type=catalog_type,
         ra_column=ra_col,
         dec_column=dec_col,
         total_rows=None,

--- a/tests/data/small_sky/hats.properties
+++ b/tests/data/small_sky/hats.properties
@@ -15,4 +15,4 @@ hats_release_date=2025-08-22
 hats_version=v1.0
 hats_max_rows=1000000
 hats_order=0
-moc_sky_fraction=0.08333
+moc_sky_fraction=0.083333

--- a/tests/data/small_sky/properties
+++ b/tests/data/small_sky/properties
@@ -15,4 +15,4 @@ hats_release_date=2025-08-22
 hats_version=v1.0
 hats_max_rows=1000000
 hats_order=0
-moc_sky_fraction=0.08333
+moc_sky_fraction=0.083333

--- a/tests/data/small_sky_order1_collection/small_sky_order1/hats.properties
+++ b/tests/data/small_sky_order1_collection/small_sky_order1/hats.properties
@@ -16,4 +16,4 @@ hats_version=v1.0
 obs_regime=Optical
 hats_max_rows=1000000
 hats_order=1
-moc_sky_fraction=0.08333
+moc_sky_fraction=0.083333

--- a/tests/data/small_sky_order1_collection/small_sky_order1/properties
+++ b/tests/data/small_sky_order1_collection/small_sky_order1/properties
@@ -16,4 +16,4 @@ hats_version=v1.0
 obs_regime=Optical
 hats_max_rows=1000000
 hats_order=1
-moc_sky_fraction=0.08333
+moc_sky_fraction=0.083333

--- a/tests/lsdb/io/test_to_association.py
+++ b/tests/lsdb/io/test_to_association.py
@@ -74,7 +74,7 @@ def test_to_association_join_through_roundtrip(
         overwrite=False,
         **association_kwargs,
         addl_hats_properties={"obs_regime": "Optical"},
-        compression="SNAPPY",
+        write_table_kwargs={"compression": "SNAPPY"},
     )
     association_table = lsdb.read_hats(tmp_path)
     assert isinstance(association_table, AssociationCatalog)

--- a/tests/lsdb/io/test_to_collection.py
+++ b/tests/lsdb/io/test_to_collection.py
@@ -221,7 +221,7 @@ def test_save_collection_provenance(small_sky_order1_df, tmp_path):
         base_collection_path,
         catalog_name="small_sky_order1",
         default_columns=["ra", "dec"],
-        addl_hats_properties={"obs_regime": "Optical","hats_creator": "LSDB Unit Test"},
+        addl_hats_properties={"obs_regime": "Optical", "hats_creator": "LSDB Unit Test"},
     )
 
     catalog = lsdb.read_hats(base_collection_path)

--- a/tests/lsdb/io/test_to_collection.py
+++ b/tests/lsdb/io/test_to_collection.py
@@ -18,7 +18,7 @@ def test_save_collection(small_sky_order1_collection_catalog, tmp_path, helpers)
         catalog_name="small_sky_order1",
         default_columns=["ra", "dec"],
         addl_hats_properties={"obs_regime": "Optical"},
-        compression="SNAPPY",
+        write_table_kwargs={"compression": "SNAPPY"},
     )
 
     catalog = lsdb.read_hats(base_collection_path)
@@ -88,7 +88,7 @@ def test_save_collection_progress_bar(small_sky_order1_collection_catalog, tmp_p
         catalog_name="small_sky_order1",
         default_columns=["ra", "dec"],
         addl_hats_properties={"obs_regime": "Optical"},
-        compression="SNAPPY",
+        write_table_kwargs={"compression": "SNAPPY"},
     )
 
     assert tqdm_callback.call_args_list == [
@@ -108,7 +108,7 @@ def test_save_collection_no_progress_bar(small_sky_order1_collection_catalog, tm
         catalog_name="small_sky_order1",
         default_columns=["ra", "dec"],
         addl_hats_properties={"obs_regime": "Optical"},
-        compression="SNAPPY",
+        write_table_kwargs={"compression": "SNAPPY"},
         progress_bar=False,
     )
 
@@ -204,3 +204,73 @@ def test_save_collection_no_summary(small_sky_order1_collection_catalog, tmp_pat
     assert not (base_collection_path / "README.md").exists()
     assert not (base_collection_path / "small_sky_order1" / "README.md").exists()
     assert not (base_collection_path / "small_sky_order1_3600arcs" / "README.md").exists()
+
+
+def test_save_collection_provenance(small_sky_order1_df, tmp_path):
+    """Test inheriting the provenance of the original catalog, with property like 'hats_creator'."""
+    expected_catalog = lsdb.from_dataframe(
+        small_sky_order1_df,
+        catalog_name="small_sky_order1",
+        catalog_type="object",
+        margin_threshold=3000,
+    )
+
+    # save the catalog initially with the property and confirm its presence
+    base_collection_path = Path(tmp_path) / "small_sky_order1_collection"
+    expected_catalog.write_catalog(
+        base_collection_path,
+        catalog_name="small_sky_order1",
+        default_columns=["ra", "dec"],
+        addl_hats_properties={"obs_regime": "Optical","hats_creator": "LSDB Unit Test"},
+    )
+
+    catalog = lsdb.read_hats(base_collection_path)
+    assert catalog.hc_structure.catalog_info.obs_regime == "Optical"
+    extras = catalog.hc_structure.catalog_info.extra_dict()
+    assert "hats_creator" in extras
+    assert extras["hats_creator"] == "LSDB Unit Test"
+
+    assert catalog.margin is not None
+    assert catalog.margin.hc_structure.catalog_info.obs_regime == "Optical"
+    extras = catalog.margin.hc_structure.catalog_info.extra_dict()
+    assert "hats_creator" in extras
+    assert extras["hats_creator"] == "LSDB Unit Test"
+
+    # create a copy of the catalog, without explicitly inheriting the provenance
+    round_trip_catalog_path = Path(tmp_path) / "small_sky_drop_provenance"
+    catalog.write_catalog(
+        round_trip_catalog_path,
+        catalog_name="small_sky_order1",
+        default_columns=["ra", "dec"],
+    )
+
+    round_trip_catalog = lsdb.read_hats(round_trip_catalog_path)
+    assert round_trip_catalog.hc_structure.catalog_info.obs_regime == "Optical"
+    extras = round_trip_catalog.hc_structure.catalog_info.extra_dict()
+    assert "hats_creator" not in extras
+
+    assert round_trip_catalog.margin is not None
+    assert round_trip_catalog.margin.hc_structure.catalog_info.obs_regime == "Optical"
+    extras = round_trip_catalog.margin.hc_structure.catalog_info.extra_dict()
+    assert "hats_creator" not in extras
+
+    # create a copy of the catalog, *explicitly* inheriting the provenance
+    round_trip_catalog_path = Path(tmp_path) / "small_sky_inherit_provenance"
+    catalog.write_catalog(
+        round_trip_catalog_path,
+        catalog_name="small_sky_order1",
+        default_columns=["ra", "dec"],
+        inherit_provenance=True,
+    )
+
+    round_trip_catalog = lsdb.read_hats(round_trip_catalog_path)
+    assert round_trip_catalog.hc_structure.catalog_info.obs_regime == "Optical"
+    extras = round_trip_catalog.hc_structure.catalog_info.extra_dict()
+    assert "hats_creator" in extras
+    assert extras["hats_creator"] == "LSDB Unit Test"
+
+    assert round_trip_catalog.margin is not None
+    assert round_trip_catalog.margin.hc_structure.catalog_info.obs_regime == "Optical"
+    extras = round_trip_catalog.margin.hc_structure.catalog_info.extra_dict()
+    assert "hats_creator" in extras
+    assert extras["hats_creator"] == "LSDB Unit Test"

--- a/tests/lsdb/io/test_to_hats.py
+++ b/tests/lsdb/io/test_to_hats.py
@@ -32,7 +32,10 @@ def test_save_catalog(small_sky_catalog, tmp_path, helpers):
     new_catalog_name = "small_sky"
     base_catalog_path = Path(tmp_path) / new_catalog_name
     small_sky_catalog.write_catalog(
-        base_catalog_path, catalog_name=new_catalog_name, addl_hats_properties={"obs_regime": "Optical"}
+        base_catalog_path,
+        catalog_name=new_catalog_name,
+        create_thumbnail=True,
+        addl_hats_properties={"obs_regime": "Optical"},
     )
 
     expected_catalog = lsdb.read_hats(base_catalog_path)


### PR DESCRIPTION
This change effects several open issues. 

--------------

Closes #1377

- dataproduct_type: addressed with picking the best catalog type when you merge (and you still have both catalog types). this uses the ordering from the catalog type enumeration, and seems to make enough sense (e.g. object or source? source; map or object? object; source or association? source). note that we still have issues related to provenance tracking for crossmatch results in #31 and #71 (single digit issues - woah)
- hats_npix_suffix: was being passed by the wrong name
- hats_creator: added flag on `write_catalog:inherit_provenance` that tries to clear out known provenance-related fields. i can imagine a case where someone has been keeping their own provenance fields, and would be sad to have to set them every time they wrote out a derived data product.
- hats_order/moc_sky_fraction: updated with the new partition info

Remaining on #1457
- properties referring to columns / coordinate columns

--------------

Related to (but does not close) #1361

Added:
- create_metadata (but renamed to create_parquet_metadata, because loads of OTHER metadata gets written)
- create_per_partition_stats 
- should_write_skymap
- write_table_kwargs (to better distinguish all the kinds of kwargs)

NOT added:
- drop_empty_siblings: write_catalog just uses whatever partitioning the catalog already has, so this doesn't make sense.
- row_group_kwargs: this would be a lot of work that i don't feel like doing today
- columns: same - don't need to add more things today

--------------

Extra changes:
- tried to be a little more consistent with ordering/passing arguments through
- tidied up some of association creation
- also have a change to hats to tidy up the float serialization (https://github.com/astronomy-commons/hats/pull/710)
- tried to switch long positional parameter lists to mostly optional parameters with a `*`
