### PR TITLE
Add placeholder page for DP2

### DIFF
--- a/docs/tutorial_toc/toc_rubin.rst
+++ b/docs/tutorial_toc/toc_rubin.rst
@@ -4,6 +4,7 @@ Working with Rubin Data
 .. toctree::
     :maxdepth: 1
 
+    Accessing Rubin Data Preview 2 </tutorials/pre_executed/rubin_dp2>
     Accessing Rubin Data Preview 1 </tutorials/pre_executed/rubin_dp1>
     Intro to Rubin Catalog Operations </tutorials/pre_executed/using_rubin_data>
     Accessing Rubin Data Preview 1 photo-z </tutorials/pre_executed/rubin_dp1_photoz>

--- a/docs/tutorials/pre_executed/rubin_dp1.ipynb
+++ b/docs/tutorials/pre_executed/rubin_dp1.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "### Available data\n",
     "\n",
-    "This page focus on Rubin Data Preview 1. For information about Rubin Data Preview 2, please visit [Accessing Rubin Data Preview 2 (DP2)](https://docs.lsdb.io/en/latest/tutorials/pre_executed/rubin_dp2.html)."
+    "This page focuses on Rubin Data Preview 1. For information about Rubin Data Preview 2, please visit [Accessing Rubin Data Preview 2 (DP2)](https://docs.lsdb.io/en/latest/tutorials/pre_executed/rubin_dp2.html)."
    ]
   },
   {

--- a/docs/tutorials/pre_executed/rubin_dp1.ipynb
+++ b/docs/tutorials/pre_executed/rubin_dp1.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "### Available data\n",
     "\n",
-    "At the moment, only Data Preview 1 is available; we plan to have Data Preview 2 ready as soon as it too is released."
+    "This page focus on Rubin Data Preview 1. For information about Rubin Data Preview 2, please visit [Accessing Rubin Data Preview 2 (DP2)](https://docs.lsdb.io/en/latest/tutorials/pre_executed/rubin_dp2.html)."
    ]
   },
   {

--- a/docs/tutorials/pre_executed/rubin_dp2.ipynb
+++ b/docs/tutorials/pre_executed/rubin_dp2.ipynb
@@ -1,0 +1,401 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6b790eee",
+   "metadata": {
+    "panel-layout": {
+     "height": 314.46875,
+     "visible": true,
+     "width": 100
+    }
+   },
+   "source": [
+    "# Accessing Rubin Data Preview 2 (DP2)\n",
+    "\n",
+    "In this tutorial, we will:\n",
+    "\n",
+    "- access Rubin's Data Preview 2 with LSDB\n",
+    "  * at RSP (Rubin Science Platform), based in the USA and the UK\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "### Prerequisites\n",
+    "\n",
+    "In order to access Rubin data, you must be a [Rubin data rights holder](https://rubinobservatory.org/for-scientists/data-products/data-policy)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2dbecd41",
+   "metadata": {
+    "panel-layout": {
+     "height": 76.53125,
+     "visible": true,
+     "width": 100
+    }
+   },
+   "source": [
+    "## 1. Accessing the data on Rubin Science Platform (RSP)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d9d83f9-e1c6-4db3-a799-47eef7bfa693",
+   "metadata": {},
+   "source": [
+    "### 1.1 Prepare your RSP container"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6eab1ffd-359d-4079-9adb-50587d354820",
+   "metadata": {
+    "panel-layout": {
+     "height": 114.56253051757812,
+     "visible": true,
+     "width": 100
+    }
+   },
+   "source": [
+    "- Visit https://data.lsst.cloud, unless you are accessing RSP through UK IDAC participation program - in that case, visit https://rsp.lsst.ac.uk.\n",
+    "- Log in using your identity provider.\n",
+    "- Once in, you will see Portal, Notebooks, and APIs.  Choose Notebooks.\n",
+    "- When it asks you what container to start, choose either \"Recommended\" or one of the latest weekly releases on the left, and \"Large\" on the right.\n",
+    "  - At the time of this writing, \"Recommended\" comes with an older version of lsdb - run the cell below to see if you'll need to target a weekly release instead.\n",
+    "- Once this has started, create a new notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f10b1e7-1eb8-43c6-a37a-6a6618bbed78",
+   "metadata": {},
+   "source": [
+    "#### 1.1.1 Ensure your notebook kernel has the right version of lsdb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5dbc72f3-3668-4fa5-a999-4495a89b1aac",
+   "metadata": {
+    "panel-layout": {
+     "height": 51.140594482421875,
+     "visible": true,
+     "width": 100
+    }
+   },
+   "source": "Make sure you've got at least **version 0.10.1 of lsdb**.  Try the following."
+  },
+  {
+   "cell_type": "code",
+   "id": "aabec3fc-1df7-498d-a665-b7c4c31777be",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-14T19:19:40.450318Z",
+     "iopub.status.busy": "2026-05-14T19:19:40.449995Z",
+     "iopub.status.idle": "2026-05-14T19:19:44.465292Z",
+     "shell.execute_reply": "2026-05-14T19:19:44.464096Z",
+     "shell.execute_reply.started": "2026-05-14T19:19:40.450292Z"
+    }
+   },
+   "source": [
+    "%pip list | grep -E 'lsdb|hats'"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "id": "bb92b98a-d5b0-44ee-b9dd-912216b29ba8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-14T19:19:44.466354Z",
+     "iopub.status.busy": "2026-05-14T19:19:44.466038Z",
+     "iopub.status.idle": "2026-05-14T19:19:51.676259Z",
+     "shell.execute_reply": "2026-05-14T19:19:51.675483Z",
+     "shell.execute_reply.started": "2026-05-14T19:19:44.466317Z"
+    },
+    "panel-layout": {
+     "height": 51.140625,
+     "visible": true,
+     "width": 100
+    }
+   },
+   "source": [
+    "# Or for even more detail:\n",
+    "\n",
+    "import lsdb\n",
+    "\n",
+    "lsdb.show_versions()"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87f84ba5-bd62-42c3-8e41-a851b7ee8cf8",
+   "metadata": {
+    "panel-layout": {
+     "height": 68.78125,
+     "visible": true,
+     "width": 100
+    }
+   },
+   "source": [
+    "<div class=\"alert alert-warning\">\n",
+    "If the above shows a version that is very old, we suggest using RSP with a latest weekly release rather than the \"Recommended\" build.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f146eb42",
+   "metadata": {},
+   "source": [
+    "### 1.2. Create a Dask Client\n",
+    "\n",
+    "When working on RSP, with a Large container you have access to 32 GB of RAM. To ensure each worker has enough memory to work with the data, we recommend using 4 workers with 1 thread each, and memory limit of \"auto\" (which will divide the available memory across the workers). Dask also will sometimes spill to disk when it needs to, so we recommend setting the local directory to the `/deleted-sundays` directory, which is a large scratch space available on RSP that will be cleared every Sunday. You can set up your Dask client with the following code:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "f0a41ef2-3115-4ec3-8d06-9323a50ff9b6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-13T17:45:28.942090Z",
+     "iopub.status.busy": "2026-05-13T17:45:28.941814Z",
+     "iopub.status.idle": "2026-05-13T17:45:28.946004Z",
+     "shell.execute_reply": "2026-05-13T17:45:28.945375Z",
+     "shell.execute_reply.started": "2026-05-13T17:45:28.942055Z"
+    }
+   },
+   "source": [
+    "# Dask puts out more advisory logging than we care for in this tutorial.\n",
+    "# It takes some doing to quiet all of it, but this recipe works.\n",
+    "\n",
+    "import dask\n",
+    "import os\n",
+    "\n",
+    "dask.config.set({\"logging.distributed\": \"critical\"})\n",
+    "\n",
+    "import logging\n",
+    "\n",
+    "# This also has to be done, for the above to be effective\n",
+    "logger = logging.getLogger(\"distributed\")\n",
+    "logger.setLevel(logging.CRITICAL)\n",
+    "\n",
+    "import warnings\n",
+    "\n",
+    "# Finally, suppress the specific warning about Dask dashboard port usage\n",
+    "warnings.filterwarnings(\"ignore\", message=\"Port 8787 is already in use.\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "id": "628683f8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-13T17:45:31.690087Z",
+     "iopub.status.busy": "2026-05-13T17:45:31.689736Z",
+     "iopub.status.idle": "2026-05-13T17:45:34.651554Z",
+     "shell.execute_reply": "2026-05-13T17:45:34.650718Z",
+     "shell.execute_reply.started": "2026-05-13T17:45:31.690050Z"
+    }
+   },
+   "source": [
+    "from dask.distributed import Client\n",
+    "\n",
+    "client = Client(\n",
+    "    n_workers=4,\n",
+    "    threads_per_worker=1,\n",
+    "    memory_limit=\"auto\",\n",
+    "    local_directory=f\"/deleted-sundays/{os.environ.get('USER', 'dask_scratch')}\",\n",
+    ")\n",
+    "client"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "533beb98",
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": "Your Dask dashboard will be accessible at `https://{username}.nb.data.lsst.cloud/nb/user/{username}/proxy/{port}/status`."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f556d55a-b898-484c-86bf-afbc99ecec76",
+   "metadata": {
+    "panel-layout": {
+     "height": 78.71099853515625,
+     "visible": true,
+     "width": 100
+    }
+   },
+   "source": [
+    "### 1.3 Opening a Catalog\n",
+    "\n",
+    "The data is divided into `objects` and `dia_objects`.  Let's open both catalogs:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "219f222a-c8ff-4d81-999f-0fccba4a9e0f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-13T17:45:39.548246Z",
+     "iopub.status.busy": "2026-05-13T17:45:39.547942Z",
+     "iopub.status.idle": "2026-05-13T17:45:44.487480Z",
+     "shell.execute_reply": "2026-05-13T17:45:44.486517Z",
+     "shell.execute_reply.started": "2026-05-13T17:45:39.548221Z"
+    }
+   },
+   "source": [
+    "from upath import UPath\n",
+    "\n",
+    "base_path = UPath(\"/rubin/lsdb_data/dp2\")\n",
+    "\n",
+    "object_cat = lsdb.open_catalog(base_path / \"object_collection\")\n",
+    "dia_object_cat = lsdb.open_catalog(base_path / \"dia_object_collection\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "id": "a0b4eff4-8c01-4655-ad62-f3c290e23ffd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-13T17:45:44.488483Z",
+     "iopub.status.busy": "2026-05-13T17:45:44.488251Z",
+     "iopub.status.idle": "2026-05-13T17:45:44.527790Z",
+     "shell.execute_reply": "2026-05-13T17:45:44.526595Z",
+     "shell.execute_reply.started": "2026-05-13T17:45:44.488463Z"
+    },
+    "panel-layout": {
+     "height": 295.96875,
+     "visible": true,
+     "width": 100
+    }
+   },
+   "source": [
+    "object_cat"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "id": "239044e4-fa77-4fb9-873b-f5462318dd23",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-13T17:45:44.528400Z",
+     "iopub.status.busy": "2026-05-13T17:45:44.528174Z",
+     "iopub.status.idle": "2026-05-13T17:45:44.541952Z",
+     "shell.execute_reply": "2026-05-13T17:45:44.540864Z",
+     "shell.execute_reply.started": "2026-05-13T17:45:44.528378Z"
+    },
+    "panel-layout": {
+     "height": 347.390625,
+     "visible": true,
+     "width": 100
+    }
+   },
+   "source": "dia_object_cat",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84e9c6ce-ca93-4fc1-9c11-0d9243cb0d48",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext",
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "You've accessed the data!  You can see the schema of both catalogs.  \n",
+    "\n",
+    "To learn how to use this data,\n",
+    "see [Using Rubin Data](https://docs.lsdb.io/en/latest/tutorials/pre_executed/using_rubin_data.html) \n",
+    "and follow the lsdb quickstart at [Getting Started](https://docs.lsdb.io/en/latest/getting-started.html). \n",
+    "\n",
+    "\n",
+    "If you have questions about data from the Rubin Observatory, the best place to ask is https://community.lsst.org \n",
+    "in the [LSST Data Products category](https://community.lsst.org/c/support/data/34)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e0726ac",
+   "metadata": {
+    "panel-layout": {
+     "height": 143.1875,
+     "visible": true,
+     "width": 100
+    }
+   },
+   "source": [
+    "## About\n",
+    "\n",
+    "**Authors**: Neven Caplar, Sandro Campos\n",
+    "\n",
+    "**Last updated on**: July 17, 2026\n",
+    "\n",
+    "**Last run:** Never, waiting for DP2 release\n",
+    "\n",
+    "If you use `lsdb` for published research, please cite following [instructions](https://docs.lsdb.io/en/stable/citation.html)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "LSST",
+   "language": "python",
+   "name": "lsst"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.9"
+  },
+  "nbsphinx": {
+   "execute": "never"
+  },
+  "panel-cell-order": [
+   "6b790eee",
+   "2dbecd41",
+   "6eab1ffd-359d-4079-9adb-50587d354820",
+   "5dbc72f3-3668-4fa5-a999-4495a89b1aac",
+   "bb92b98a-d5b0-44ee-b9dd-912216b29ba8",
+   "87f84ba5-bd62-42c3-8e41-a851b7ee8cf8",
+   "973a36af-a6e2-42e2-953c-60c2445c5ae2",
+   "3ac28414-57fb-4e68-b0c5-837e4cb2a43b",
+   "91648419-0c5d-4df2-80b2-c261c3a8b136",
+   "f556d55a-b898-484c-86bf-afbc99ecec76",
+   "a0b4eff4-8c01-4655-ad62-f3c290e23ffd",
+   "239044e4-fa77-4fb9-873b-f5462318dd23",
+   "036d0560",
+   "eb134afe",
+   "0aa390b4-cf26-4d69-aaeb-525979f79bc7",
+   "8e0726ac",
+   "220b7c5e"
+  ]
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/tutorials/pre_executed/rubin_dp2.ipynb
+++ b/docs/tutorials/pre_executed/rubin_dp2.ipynb
@@ -345,7 +345,7 @@
    "source": [
     "## About\n",
     "\n",
-    "**Authors**: Neven Caplar, Sandro Campos\n",
+    "**Authors**: Neven Caplar, Sandro Campos, Olivia Lynn\n",
     "\n",
     "**Last updated on**: July 17, 2026\n",
     "\n",


### PR DESCRIPTION
Creates a placeholder page for the Data Preview 2 release (similar to the one we have for [DP1](https://docs.lsdb.io/en/latest/tutorials/pre_executed/rubin_dp1.html)). Related to #1490.