### PR TITLE
Round sky coverage to five significant digits

### DIFF
--- a/src/lsdb/io/common.py
+++ b/src/lsdb/io/common.py
@@ -1,3 +1,4 @@
+import math as m
 from importlib.metadata import version
 from pathlib import Path
 
@@ -34,6 +35,30 @@ def new_provenance_properties(
             "publisher_id": None,
         }
     return TableProperties.new_provenance_dict(path, builder=f"lsdb v{version('lsdb')}", **kwargs)
+
+
+def round_sig(value: float, digits: int = 5) -> float:
+    """Round a float to a number of significant figures, keeping it a float.
+
+    Equivalent to ``float(f"{value:.{digits}g}")``, but computes the rounding
+    numerically instead of round-tripping through a string.
+
+    Parameters
+    ----------
+    value : float
+        The value to round.
+    digits : int, default 5
+        The number of significant figures to keep.
+
+    Returns
+    -------
+    float
+        The value rounded to the given number of significant figures.
+    """
+    if value == 0:
+        return 0.0
+    decimal_places = digits - 1 - m.floor(m.log10(abs(value)))
+    return round(value, decimal_places)
 
 
 def set_default_write_table_kwargs(write_table_kwargs):

--- a/src/lsdb/io/to_association.py
+++ b/src/lsdb/io/to_association.py
@@ -13,7 +13,7 @@ from hats.catalog.catalog_collection import CatalogCollection
 from hats.pixel_math import HealpixPixel
 from upath import UPath
 
-from lsdb.io.common import new_provenance_properties, set_default_write_table_kwargs
+from lsdb.io.common import new_provenance_properties, round_sig, set_default_write_table_kwargs
 
 if TYPE_CHECKING:
     from lsdb.catalog.dataset.healpix_dataset import HealpixDataset
@@ -233,7 +233,7 @@ def to_association(
         "contains_leaf_files": True,
         "hats_order": partition_info.get_highest_order(),
         "total_rows": int(np.sum(counts)),
-        "moc_sky_fraction": f"{partition_info.calculate_fractional_coverage():.5}",
+        "moc_sky_fraction": round_sig(partition_info.calculate_fractional_coverage()),
     } | new_provenance_properties(inherit_provenance=inherit_provenance)
 
     max_separation = np.max(max_separations)

--- a/src/lsdb/io/to_hats.py
+++ b/src/lsdb/io/to_hats.py
@@ -21,7 +21,7 @@ from tqdm.dask import TqdmCallback
 from upath import UPath
 
 from lsdb.catalog.dataset.healpix_dataset import HealpixDataset
-from lsdb.io.common import new_provenance_properties, set_default_write_table_kwargs
+from lsdb.io.common import new_provenance_properties, round_sig, set_default_write_table_kwargs
 
 DONE_DIR_NAME = "done"
 HISTOGRAM_DIR_NAME = "hists"
@@ -425,7 +425,7 @@ def to_hats(
         total_rows=int(np.sum(counts)),
         default_columns=default_columns,
         hats_max_rows=hats_max_rows,
-        moc_sky_fraction=f"{partition_info.calculate_fractional_coverage():.5}",
+        moc_sky_fraction=round_sig(partition_info.calculate_fractional_coverage()),
         hats_order=partition_info.get_highest_order() if len(partition_info) else None,
         npix_suffix=npix_suffix,
         **addl_hats_properties,

--- a/tests/lsdb/io/test_common.py
+++ b/tests/lsdb/io/test_common.py
@@ -1,0 +1,39 @@
+import pytest
+
+from lsdb.io.common import round_sig
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        0.0,
+        1.0,
+        0.25,
+        1 / 12,
+        1e-10,
+        0.99999999,
+        8.765432e-300,
+        123456789.123,
+        0.000012345678,
+        5.0,
+        100000.0,
+        99999.5,
+        0.1,
+        -0.1,
+        -1 / 3,
+    ],
+)
+def test_round_sig_matches_string_formatting(value):
+    assert round_sig(value) == float(f"{value:.5g}")
+
+
+@pytest.mark.parametrize("exponent", range(-20, 21))
+def test_round_sig_matches_string_formatting_across_magnitudes(exponent):
+    for sign in (1, -1):
+        value = sign * (10**exponent) * 1.23456789
+        assert round_sig(value) == float(f"{value:.5g}")
+
+
+def test_round_sig_custom_digits():
+    assert round_sig(1 / 3, digits=2) == float(f"{1 / 3:.2g}")
+    assert round_sig(1 / 3, digits=8) == float(f"{1 / 3:.8g}")


### PR DESCRIPTION
Fix type of `moc_sky_fraction`, which was accidentally changed from `float` to `str` by #1488