### PR TITLE
Set default to false for generate summary for write_catalog 

### DIFF
--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -1481,7 +1481,7 @@ class Catalog(HealpixDataset):
         tqdm_kwargs: dict | None = None,
         create_thumbnail: bool = True,
         error_if_empty: bool = True,
-        create_summary: bool = True,
+        create_summary: bool = False,
         **kwargs,
     ):
         """Save the catalog to disk in HATS format.
@@ -1512,7 +1512,7 @@ class Catalog(HealpixDataset):
             per partition, for quick previewing of the catalog's contents.
         error_if_empty : bool, default True
             If True, raises an error if the catalog is empty.
-        create_summary : bool, default True
+        create_summary : bool, default False
             If True, writes ``README.md`` summary file(s) describing the catalog. When
             ``as_collection`` is True, this generates a summary for the collection, the
             main catalog, and the margin (if it exists).

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -1390,7 +1390,7 @@ class HealpixDataset:
         progress_bar: bool = True,
         tqdm_kwargs: dict | None = None,
         error_if_empty: bool = True,
-        create_summary: bool = True,
+        create_summary: bool = False,
         **kwargs,
     ):
         """Save the catalog to disk in HATS format.
@@ -1416,7 +1416,7 @@ class HealpixDataset:
             Keyword arguments to pass to tqdm for customizing the progress bar
         error_if_empty : bool, default True
             If True, raises an error if the catalog is empty.
-        create_summary : bool, default True
+        create_summary : bool, default False
             If True, writes a ``README.md`` summary file describing the catalog.
         **kwargs
             Arguments to pass to the parquet write operations

--- a/src/lsdb/catalog/margin_catalog.py
+++ b/src/lsdb/catalog/margin_catalog.py
@@ -61,7 +61,7 @@ class MarginCatalog(HealpixDataset):
         overwrite: bool = False,
         resume: bool = False,
         error_if_empty: bool = False,
-        create_summary: bool = True,
+        create_summary: bool = False,
         **kwargs,
     ):
         super().write_catalog(

--- a/src/lsdb/io/to_collection.py
+++ b/src/lsdb/io/to_collection.py
@@ -20,7 +20,7 @@ def to_collection(
     progress_bar: bool = True,
     tqdm_kwargs: dict | None = None,
     error_if_empty: bool = True,
-    create_summary: bool = True,
+    create_summary: bool = False,
     **kwargs,
 ):
     """Saves the catalog collection to disk in the HATS format.
@@ -49,7 +49,7 @@ def to_collection(
         If progress_bar is True, these kwargs are passed to tqdm when creating the progress bar
     error_if_empty : bool, default True
         If True, raises an error if the catalog is empty
-    create_summary : bool, default True
+    create_summary : bool, default False
         If True, writes ``README.md`` summary files for the collection, the main
         catalog, and the margin (if it exists).
     **kwargs

--- a/src/lsdb/io/to_hats.py
+++ b/src/lsdb/io/to_hats.py
@@ -251,7 +251,7 @@ def to_hats(
     progress_bar: bool = True,
     tqdm_kwargs: dict | None = None,
     create_thumbnail: bool = False,
-    create_summary: bool = True,
+    create_summary: bool = False,
     skymap_alt_orders: list[int] | None = None,
     npix_suffix: str = ".parquet",
     npix_parquet_name: str | None = None,
@@ -294,7 +294,7 @@ def to_hats(
     create_thumbnail : bool, default False
         If True, create a data thumbnail of the catalog for
         previewing purposes. Defaults to False.
-    create_summary : bool, default True
+    create_summary : bool, default False
         If True, writes a ``README.md`` summary file describing the catalog.
     skymap_alt_orders : list[int] or None, default None
         We will write a skymap file at the ``histogram_order``,

--- a/tests/lsdb/io/test_to_collection.py
+++ b/tests/lsdb/io/test_to_collection.py
@@ -185,9 +185,11 @@ def test_save_collection_with_empty_margin(small_sky_order1_df, tmp_path):
     pd.testing.assert_frame_equal(expected_catalog.margin.compute(), catalog.margin.compute())
 
 
-def test_save_collection_creates_summary_by_default(small_sky_order1_collection_catalog, tmp_path):
+def test_save_collection_creates_summary_when_enabled(small_sky_order1_collection_catalog, tmp_path):
     base_collection_path = Path(tmp_path) / "small_sky_order1_collection"
-    small_sky_order1_collection_catalog.write_catalog(base_collection_path, catalog_name="small_sky_order1")
+    small_sky_order1_collection_catalog.write_catalog(
+        base_collection_path, catalog_name="small_sky_order1", create_summary=True
+    )
     collection_summary = base_collection_path / "README.md"
     catalog_summary = base_collection_path / "small_sky_order1" / "README.md"
     margin_summary = base_collection_path / "small_sky_order1_3600arcs" / "README.md"
@@ -196,11 +198,9 @@ def test_save_collection_creates_summary_by_default(small_sky_order1_collection_
         assert len(summary_path.read_text()) > 0
 
 
-def test_save_collection_no_summary(small_sky_order1_collection_catalog, tmp_path):
+def test_save_collection_no_summary_by_default(small_sky_order1_collection_catalog, tmp_path):
     base_collection_path = Path(tmp_path) / "small_sky_order1_collection"
-    small_sky_order1_collection_catalog.write_catalog(
-        base_collection_path, catalog_name="small_sky_order1", create_summary=False
-    )
+    small_sky_order1_collection_catalog.write_catalog(base_collection_path, catalog_name="small_sky_order1")
     assert not (base_collection_path / "README.md").exists()
     assert not (base_collection_path / "small_sky_order1" / "README.md").exists()
     assert not (base_collection_path / "small_sky_order1_3600arcs" / "README.md").exists()

--- a/tests/lsdb/io/test_to_hats.py
+++ b/tests/lsdb/io/test_to_hats.py
@@ -578,15 +578,15 @@ def test_resume_and_overwrite_catalog_write(small_sky_order1_catalog, tmp_path):
         small_sky_order1_catalog.write_catalog(base_catalog_path, resume=True, overwrite=True)
 
 
-def test_save_catalog_creates_summary_by_default(small_sky_order1_catalog, tmp_path):
+def test_save_catalog_creates_summary_when_enabled(small_sky_order1_catalog, tmp_path):
     base_catalog_path = tmp_path / "small_sky"
-    small_sky_order1_catalog.write_catalog(base_catalog_path, as_collection=False)
+    small_sky_order1_catalog.write_catalog(base_catalog_path, as_collection=False, create_summary=True)
     summary_path = base_catalog_path / "README.md"
     assert summary_path.exists()
     assert len(summary_path.read_text()) > 0
 
 
-def test_save_catalog_no_summary(small_sky_order1_catalog, tmp_path):
+def test_save_catalog_no_summary_by_default(small_sky_order1_catalog, tmp_path):
     base_catalog_path = tmp_path / "small_sky"
-    small_sky_order1_catalog.write_catalog(base_catalog_path, as_collection=False, create_summary=False)
+    small_sky_order1_catalog.write_catalog(base_catalog_path, as_collection=False)
     assert not (base_catalog_path / "README.md").exists()


### PR DESCRIPTION
Before write_catalog had generate_summary=True by default, meaning summary files would generate automatically. I'm setting the default to False as a placeholder while we try to fix #1501. 

