### PR TITLE
DP2 tutorials for interaction with alerts

### DIFF
--- a/docs/tutorials/pre_executed/rubin_dp2_historical_dia.ipynb
+++ b/docs/tutorials/pre_executed/rubin_dp2_historical_dia.ipynb
@@ -17,16 +17,18 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "4670c7a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T15:27:00.788438Z",
-     "iopub.status.busy": "2026-07-22T15:27:00.788180Z",
-     "iopub.status.idle": "2026-07-22T15:27:06.835959Z",
-     "shell.execute_reply": "2026-07-22T15:27:06.835060Z",
-     "shell.execute_reply.started": "2026-07-22T15:27:00.788413Z"
+     "iopub.execute_input": "2026-07-22T18:42:57.700115Z",
+     "iopub.status.busy": "2026-07-22T18:42:57.699683Z",
+     "iopub.status.idle": "2026-07-22T18:43:04.217714Z",
+     "shell.execute_reply": "2026-07-22T18:43:04.216570Z",
+     "shell.execute_reply.started": "2026-07-22T18:42:57.700091Z"
     }
    },
+   "outputs": [],
    "source": [
     "import lsdb\n",
     "import astropy.units as u\n",
@@ -37,9 +39,7 @@
     "from lsdb import ConeSearch\n",
     "\n",
     "lsdb.show_versions()"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -51,21 +51,21 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "f76e00d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T15:00:25.758303Z",
-     "iopub.status.busy": "2026-07-22T15:00:25.758073Z",
-     "iopub.status.idle": "2026-07-22T15:00:29.398313Z",
-     "shell.execute_reply": "2026-07-22T15:00:29.397020Z",
-     "shell.execute_reply.started": "2026-07-22T15:00:25.758284Z"
+     "iopub.execute_input": "2026-07-22T18:43:04.218850Z",
+     "iopub.status.busy": "2026-07-22T18:43:04.218557Z",
+     "iopub.status.idle": "2026-07-22T18:43:07.214048Z",
+     "shell.execute_reply": "2026-07-22T18:43:07.212526Z",
+     "shell.execute_reply.started": "2026-07-22T18:43:04.218817Z"
     }
    },
-   "source": [
-    "%pip install -q lsdb-rubin"
-   ],
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "%pip install -qq lsdb-rubin"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -82,37 +82,26 @@
    "source": [
     "## Load the catalogs\n",
     "\n",
-    "Let's define the paths to the data:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "id": "2a77dbfd",
-   "metadata": {},
-   "source": [
-    "ALERTS_PATH = \"https://data.lsdb.io/hats/rubin_alert_archive\"\n",
-    "DIA_OBJECT_PATH = \"/rubin/lsdb_data/dp2/dia_object_collection\""
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "04ff7e83",
-   "metadata": {},
-   "source": [
     "For demonstration purposes, we will select a small region in the sky defined by the following cone:"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "26dc421c",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T18:43:07.215132Z",
+     "iopub.status.busy": "2026-07-22T18:43:07.214896Z",
+     "iopub.status.idle": "2026-07-22T18:43:07.219456Z",
+     "shell.execute_reply": "2026-07-22T18:43:07.218551Z",
+     "shell.execute_reply.started": "2026-07-22T18:43:07.215105Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "cone = ConeSearch(ra=52.838, dec=-28.279, radius_arcsec=3600)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -124,34 +113,56 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "d5ca0ff6",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T18:43:07.220222Z",
+     "iopub.status.busy": "2026-07-22T18:43:07.220036Z",
+     "iopub.status.idle": "2026-07-22T18:43:09.739161Z",
+     "shell.execute_reply": "2026-07-22T18:43:09.738133Z",
+     "shell.execute_reply.started": "2026-07-22T18:43:07.220204Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "dia_object = lsdb.open_catalog(\n",
-    "    DIA_OBJECT_PATH, search_filter=cone, columns=[\"diaObjectId\", \"diaObjectForcedSource\"]\n",
+    "    \"/rubin/lsdb_data/dp2/dia_object_collection\",\n",
+    "    columns=[\"diaObjectId\", \"diaObjectForcedSource\"],\n",
+    "    search_filter=cone,\n",
     ")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "032d4532",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T18:43:09.740062Z",
+     "iopub.status.busy": "2026-07-22T18:43:09.739792Z",
+     "iopub.status.idle": "2026-07-22T18:43:11.853510Z",
+     "shell.execute_reply": "2026-07-22T18:43:11.852403Z",
+     "shell.execute_reply.started": "2026-07-22T18:43:09.740041Z"
+    }
+   },
+   "outputs": [],
    "source": [
-    "alerts = lsdb.open_catalog(ALERTS_PATH, search_filter=cone, columns=[\"diaSourceId\", \"prvDiaForcedSources\"])\n",
+    "alerts = lsdb.open_catalog(\n",
+    "    \"https://data.lsdb.io/hats/rubin_alert_archive\",\n",
+    "    columns=[\"diaSourceId\", \"prvDiaForcedSources\"],\n",
+    "    search_filter=cone,\n",
+    ")\n",
     "# Remove the alerts with no forced sources\n",
     "alerts = alerts.query(\"prvDiaForcedSources.len() > 0\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "f78a7f6d",
    "metadata": {},
    "source": [
-    "**Note:** This version of the alert archive has data until June 29th and remains frozen for the time being. If you're interested in a specific alert ID, add the following`filters=[(\"diaSourceId\", \"=\", <SOURCE_ID>)]` to the alerts `open_catalog` call."
+    "**Note:** This version of the alert archive has data until July 14th and remains frozen for the time being. If you're interested in a specific alert ID, add the following`filters=[(\"diaSourceId\", \"=\", <SOURCE_ID>)]` to the alerts `open_catalog` call."
    ]
   },
   {
@@ -166,14 +177,22 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "0dcc3bef",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T18:43:11.854350Z",
+     "iopub.status.busy": "2026-07-22T18:43:11.854141Z",
+     "iopub.status.idle": "2026-07-22T18:43:17.045280Z",
+     "shell.execute_reply": "2026-07-22T18:43:17.044228Z",
+     "shell.execute_reply.started": "2026-07-22T18:43:11.854332Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "xmatched = alerts.crossmatch(dia_object, suffix_method=\"overlapping_columns\", suffixes=(\"_alert\", \"_dia\"))\n",
     "xmatched"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -185,14 +204,22 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "3bfb35c9",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T18:43:17.046010Z",
+     "iopub.status.busy": "2026-07-22T18:43:17.045814Z",
+     "iopub.status.idle": "2026-07-22T18:43:22.104256Z",
+     "shell.execute_reply": "2026-07-22T18:43:22.103406Z",
+     "shell.execute_reply.started": "2026-07-22T18:43:17.045993Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "preview = xmatched.head(4)\n",
     "preview"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -208,8 +235,18 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "55545343",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T18:43:22.105187Z",
+     "iopub.status.busy": "2026-07-22T18:43:22.105003Z",
+     "iopub.status.idle": "2026-07-22T18:43:22.128363Z",
+     "shell.execute_reply": "2026-07-22T18:43:22.127268Z",
+     "shell.execute_reply.started": "2026-07-22T18:43:22.105169Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "def add_prv_mag(flux, flux_err):\n",
     "    \"\"\"Convert flux (nJy) to AB magnitude (asymmetric error from flux ± fluxErr)\"\"\"\n",
@@ -233,9 +270,7 @@
     "\n",
     "\n",
     "preview = append_prv_mag(preview)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -247,22 +282,40 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "a1b9601b",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T18:43:22.129273Z",
+     "iopub.status.busy": "2026-07-22T18:43:22.129075Z",
+     "iopub.status.idle": "2026-07-22T18:43:22.155714Z",
+     "shell.execute_reply": "2026-07-22T18:43:22.154683Z",
+     "shell.execute_reply.started": "2026-07-22T18:43:22.129256Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "def combined_light_curve(match, i):\n",
-    "    \"\"\"Concatenate both nested light curves, keeping band, time, and magnitude.\"\"\"\n",
+    "    \"\"\"Concatenate both nested light curves, keeping band, time, and magnitude\"\"\"\n",
     "    prv_dia_forced_source = match[\"prvDiaForcedSources\"].iloc[i]\n",
     "    forced_source = match[\"diaObjectForcedSource\"].iloc[i]\n",
     "    return pd.concat([prv_dia_forced_source, forced_source], ignore_index=True)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "26e37b15",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T18:43:22.156816Z",
+     "iopub.status.busy": "2026-07-22T18:43:22.156535Z",
+     "iopub.status.idle": "2026-07-22T18:43:23.220859Z",
+     "shell.execute_reply": "2026-07-22T18:43:23.220032Z",
+     "shell.execute_reply.started": "2026-07-22T18:43:22.156785Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "from lsdb_rubin.plot_light_curve import plot_light_curve\n",
     "\n",
@@ -270,9 +323,6 @@
     "axes = axes.flatten()\n",
     "\n",
     "for i, ax in enumerate(axes):\n",
-    "    if i >= len(preview):\n",
-    "        ax.set_visible(False)\n",
-    "        continue\n",
     "    plt.sca(ax)\n",
     "    plot_light_curve(\n",
     "        combined_light_curve(preview, i),\n",
@@ -282,9 +332,7 @@
     "\n",
     "fig.tight_layout()\n",
     "plt.show()"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -293,9 +341,9 @@
    "source": [
     "## About\n",
     "\n",
-    "**Authors:** Sandro Campos, Konstantin Malanchev\n",
+    "**Authors:** Sandro Campos, Konstantin Malanchev, Neven Caplar\n",
     "\n",
-    "**Last updated/verified on:** Jul 21, 2026\n",
+    "**Last updated/verified on:** Jul 22, 2026\n",
     "\n",
     "If you use `lsdb` for published research, please cite following [instructions](https://docs.lsdb.io/en/stable/citation.html)."
    ]

--- a/docs/tutorials/pre_executed/rubin_dp2_historical_dia.ipynb
+++ b/docs/tutorials/pre_executed/rubin_dp2_historical_dia.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Finding historical DIA light curves\n",
     "\n",
-    "In this notebook we will crossmatch alerts with the DP2 DIA object data and visualize their forced source light curves.\n",
+    "In this notebook we will crossmatch alerts with the Data Preview 2 (DP2) DIA object data and visualize their forced source light curves.\n",
     "\n",
     "1. Load the Rubin alert archive catalog and the DP2 DIA object collection.\n",
     "2. Crossmatch the alerts against the DIA objects. Both catalogs carry forced photometry timeseries.\n",
@@ -17,10 +17,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "4670c7a0",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T15:27:00.788438Z",
+     "iopub.status.busy": "2026-07-22T15:27:00.788180Z",
+     "iopub.status.idle": "2026-07-22T15:27:06.835959Z",
+     "shell.execute_reply": "2026-07-22T15:27:06.835060Z",
+     "shell.execute_reply.started": "2026-07-22T15:27:00.788413Z"
+    }
+   },
    "source": [
     "import lsdb\n",
     "import astropy.units as u\n",
@@ -29,27 +35,44 @@
     "import pandas as pd\n",
     "\n",
     "from lsdb import ConeSearch\n",
-    "from lsdb_rubin.plot_light_curve import plot_light_curve\n",
     "\n",
     "lsdb.show_versions()"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
    "id": "1d050a63",
    "metadata": {},
    "source": [
-    "We need `lsdb-rubin`, a package that contains a suite of utilities for interacting with Rubin LSST data within LSDB. It should already be installed in the container image at the RSP. However, if you run into import issues, please install it with:"
+    "We need `lsdb-rubin`, a package that contains a suite of utilities for interacting with Rubin LSST data within LSDB. Install it with:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "f76e00d7",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T15:00:25.758303Z",
+     "iopub.status.busy": "2026-07-22T15:00:25.758073Z",
+     "iopub.status.idle": "2026-07-22T15:00:29.398313Z",
+     "shell.execute_reply": "2026-07-22T15:00:29.397020Z",
+     "shell.execute_reply.started": "2026-07-22T15:00:25.758284Z"
+    }
+   },
    "source": [
-    "# %pip install lsdb-rubin"
+    "%pip install -q lsdb-rubin"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a6f31f9-c110-40be-9ccf-e879bc2f6bd5",
+   "metadata": {},
+   "source": [
+    "Restart the kernel to apply the changes before proceeding."
    ]
   },
   {
@@ -64,14 +87,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "2a77dbfd",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "ALERTS_PATH = \"/sdf/data/rubin/shared/lsdb_commissioning/alert_archive\"\n",
-    "DIA_OBJECT_PATH = \"/sdf/data/rubin/shared/lsdb_commissioning/hats/dp2_rc/dia_object_collection\""
-   ]
+    "ALERTS_PATH = \"https://data.lsdb.io/hats/rubin_alert_archive\"\n",
+    "DIA_OBJECT_PATH = \"/rubin/lsdb_data/dp2/dia_object_collection\""
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -83,13 +106,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "26dc421c",
    "metadata": {},
-   "outputs": [],
    "source": [
     "cone = ConeSearch(ra=52.838, dec=-28.279, radius_arcsec=3600)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -101,34 +124,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "d5ca0ff6",
    "metadata": {},
-   "outputs": [],
    "source": [
     "dia_object = lsdb.open_catalog(\n",
     "    DIA_OBJECT_PATH, search_filter=cone, columns=[\"diaObjectId\", \"diaObjectForcedSource\"]\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "032d4532",
    "metadata": {},
-   "outputs": [],
    "source": [
     "alerts = lsdb.open_catalog(ALERTS_PATH, search_filter=cone, columns=[\"diaSourceId\", \"prvDiaForcedSources\"])\n",
     "# Remove the alerts with no forced sources\n",
     "alerts = alerts.query(\"prvDiaForcedSources.len() > 0\")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
    "id": "f78a7f6d",
    "metadata": {},
    "source": [
-    "> If you're interested in a specific alert ID, add the following`filters=[(\"diaSourceId\", \"=\", <SOURCE_ID>)]` to the alerts `open_catalog` call."
+    "**Note:** This version of the alert archive has data until June 29th and remains frozen for the time being. If you're interested in a specific alert ID, add the following`filters=[(\"diaSourceId\", \"=\", <SOURCE_ID>)]` to the alerts `open_catalog` call."
    ]
   },
   {
@@ -143,14 +166,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "0dcc3bef",
    "metadata": {},
-   "outputs": [],
    "source": [
     "xmatched = alerts.crossmatch(dia_object, suffix_method=\"overlapping_columns\", suffixes=(\"_alert\", \"_dia\"))\n",
     "xmatched"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -162,14 +185,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "3bfb35c9",
    "metadata": {},
-   "outputs": [],
    "source": [
     "preview = xmatched.head(4)\n",
     "preview"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -185,10 +208,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "55545343",
    "metadata": {},
-   "outputs": [],
    "source": [
     "def add_prv_mag(flux, flux_err):\n",
     "    \"\"\"Convert flux (nJy) to AB magnitude (asymmetric error from flux ± fluxErr)\"\"\"\n",
@@ -212,7 +233,9 @@
     "\n",
     "\n",
     "preview = append_prv_mag(preview)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -224,25 +247,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "a1b9601b",
    "metadata": {},
-   "outputs": [],
    "source": [
     "def combined_light_curve(match, i):\n",
     "    \"\"\"Concatenate both nested light curves, keeping band, time, and magnitude.\"\"\"\n",
     "    prv_dia_forced_source = match[\"prvDiaForcedSources\"].iloc[i]\n",
     "    forced_source = match[\"diaObjectForcedSource\"].iloc[i]\n",
     "    return pd.concat([prv_dia_forced_source, forced_source], ignore_index=True)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "26e37b15",
    "metadata": {},
-   "outputs": [],
    "source": [
+    "from lsdb_rubin.plot_light_curve import plot_light_curve\n",
+    "\n",
     "fig, axes = plt.subplots(2, 2, figsize=(14, 10), dpi=150)\n",
     "axes = axes.flatten()\n",
     "\n",
@@ -259,7 +282,9 @@
     "\n",
     "fig.tight_layout()\n",
     "plt.show()"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -278,9 +303,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "LSST",
    "language": "python",
-   "name": "python3"
+   "name": "lsst"
   },
   "language_info": {
    "codemirror_mode": {
@@ -292,7 +317,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.9"
   },
   "nbsphinx": {
    "execute": "never"

--- a/docs/tutorials/pre_executed/rubin_dp2_historical_dia.ipynb
+++ b/docs/tutorials/pre_executed/rubin_dp2_historical_dia.ipynb
@@ -1,0 +1,303 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b1b168a6",
+   "metadata": {},
+   "source": [
+    "# Finding historical DIA light curves\n",
+    "\n",
+    "In this notebook we will crossmatch alerts with the DP2 DIA object data and visualize their forced source light curves.\n",
+    "\n",
+    "1. Load the Rubin alert archive catalog and the DP2 DIA object collection.\n",
+    "2. Crossmatch the alerts against the DIA objects. Both catalogs carry forced photometry timeseries.\n",
+    "3. Combine `prvDiaForcedSources` (from each alert) with the matching `diaObjectForcedSource`.\n",
+    "4. Visualize resulting light curves with [`lsdb_rubin.plot_light_curve`](https://lsdb-rubin.readthedocs.io/en/latest/reference/plot_light_curve.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4670c7a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import lsdb\n",
+    "import astropy.units as u\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from lsdb import ConeSearch\n",
+    "from lsdb_rubin.plot_light_curve import plot_light_curve\n",
+    "\n",
+    "lsdb.show_versions()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d050a63",
+   "metadata": {},
+   "source": [
+    "We need `lsdb-rubin`, a package that contains a suite of utilities for interacting with Rubin LSST data within LSDB. It should already be installed in the container image at the RSP. However, if you run into import issues, please install it with:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f76e00d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install lsdb-rubin"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7d5b22f",
+   "metadata": {},
+   "source": [
+    "## Load the catalogs\n",
+    "\n",
+    "Let's define the paths to the data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a77dbfd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ALERTS_PATH = \"/sdf/data/rubin/shared/lsdb_commissioning/alert_archive\"\n",
+    "DIA_OBJECT_PATH = \"/sdf/data/rubin/shared/lsdb_commissioning/hats/dp2_rc/dia_object_collection\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04ff7e83",
+   "metadata": {},
+   "source": [
+    "For demonstration purposes, we will select a small region in the sky defined by the following cone:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26dc421c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cone = ConeSearch(ra=52.838, dec=-28.279, radius_arcsec=3600)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28fc1d14",
+   "metadata": {},
+   "source": [
+    "Let's load both catalogs. It's important to specify the search region and the columns we need. This will keep the workflow light, especially in terms of memory usage."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5ca0ff6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dia_object = lsdb.open_catalog(\n",
+    "    DIA_OBJECT_PATH, search_filter=cone, columns=[\"diaObjectId\", \"diaObjectForcedSource\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "032d4532",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "alerts = lsdb.open_catalog(ALERTS_PATH, search_filter=cone, columns=[\"diaSourceId\", \"prvDiaForcedSources\"])\n",
+    "# Remove the alerts with no forced sources\n",
+    "alerts = alerts.query(\"prvDiaForcedSources.len() > 0\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f78a7f6d",
+   "metadata": {},
+   "source": [
+    "> If you're interested in a specific alert ID, add the following`filters=[(\"diaSourceId\", \"=\", <SOURCE_ID>)]` to the alerts `open_catalog` call."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01d4910b",
+   "metadata": {},
+   "source": [
+    "## Crossmatch alerts to DIA objects\n",
+    "\n",
+    "Next, we will match each alert to its nearest Rubin DP2 DIA object, within 1 arcsecond (the default). The columns we previously selected from both catalogs are carried into the result. `ra` and `dec` are suffixed with `_alert` and `_dia` since they overlap."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0dcc3bef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmatched = alerts.crossmatch(dia_object, suffix_method=\"overlapping_columns\", suffixes=(\"_alert\", \"_dia\"))\n",
+    "xmatched"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "085be341",
+   "metadata": {},
+   "source": [
+    "We can preview a few matched rows with `Catalog.head`, which this triggers a small amount of work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3bfb35c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preview = xmatched.head(4)\n",
+    "preview"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ddf109b5",
+   "metadata": {},
+   "source": [
+    "## Plot the light curves\n",
+    "\n",
+    "Let's visualize the matched light curves of our `preview` with [`lsdb_rubin.plot_light_curve`](https://lsdb-rubin.readthedocs.io/en/latest/reference/plot_light_curve.html). This utility method expects a flat table with `band`, `midpointMjdTai`, and a brightness field with a matching `<field>Err` column.\n",
+    "\n",
+    "We are interested to plot `psfMag` over time but the alerts don't ship `prvDiaForcedSources` with magnitudes. Let's convert the fluxes to magnitudes and append them as new subcolumns of `prvDiaForcedSources`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55545343",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def add_prv_mag(flux, flux_err):\n",
+    "    \"\"\"Convert flux (nJy) to AB magnitude (asymmetric error from flux ± fluxErr)\"\"\"\n",
+    "    flux = np.asarray(flux, dtype=\"float64\")\n",
+    "    flux_err = np.asarray(flux_err, dtype=\"float64\")\n",
+    "    mag = u.nJy.to(u.ABmag, flux)\n",
+    "    upper = u.nJy.to(u.ABmag, flux + flux_err)\n",
+    "    lower = u.nJy.to(u.ABmag, flux - flux_err)\n",
+    "    mag_err = -(upper - lower) / 2\n",
+    "    return {\"prvDiaForcedSources.psfMag\": mag, \"prvDiaForcedSources.psfMagErr\": mag_err}\n",
+    "\n",
+    "\n",
+    "def append_prv_mag(nf):\n",
+    "    \"\"\"Append psfMag/psfMagErr onto the nested prvDiaForcedSources column\"\"\"\n",
+    "    return nf.map_rows(\n",
+    "        add_prv_mag,\n",
+    "        columns=[\"prvDiaForcedSources.psfFlux\", \"prvDiaForcedSources.psfFluxErr\"],\n",
+    "        append_columns=True,\n",
+    "        row_container=\"args\",\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "preview = append_prv_mag(preview)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5549fdfc",
+   "metadata": {},
+   "source": [
+    "Now both nested light curves expose `band`, `midpointMjdTai`, `psfMag`, and `psfMagErr`. Let's combine them and plot them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b9601b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def combined_light_curve(match, i):\n",
+    "    \"\"\"Concatenate both nested light curves, keeping band, time, and magnitude.\"\"\"\n",
+    "    prv_dia_forced_source = match[\"prvDiaForcedSources\"].iloc[i]\n",
+    "    forced_source = match[\"diaObjectForcedSource\"].iloc[i]\n",
+    "    return pd.concat([prv_dia_forced_source, forced_source], ignore_index=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26e37b15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(2, 2, figsize=(14, 10), dpi=150)\n",
+    "axes = axes.flatten()\n",
+    "\n",
+    "for i, ax in enumerate(axes):\n",
+    "    if i >= len(preview):\n",
+    "        ax.set_visible(False)\n",
+    "        continue\n",
+    "    plt.sca(ax)\n",
+    "    plot_light_curve(\n",
+    "        combined_light_curve(preview, i),\n",
+    "        mag_field=\"psfMag\",\n",
+    "        title=f\"diaSourceId {preview[\"diaSourceId\"].iloc[i]}\",\n",
+    "    )\n",
+    "\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e3e5f77",
+   "metadata": {},
+   "source": [
+    "## About\n",
+    "\n",
+    "**Authors:** Sandro Campos, Konstantin Malanchev\n",
+    "\n",
+    "**Last updated/verified on:** Jul 21, 2026\n",
+    "\n",
+    "If you use `lsdb` for published research, please cite following [instructions](https://docs.lsdb.io/en/stable/citation.html)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.13"
+  },
+  "nbsphinx": {
+   "execute": "never"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/tutorials/pre_executed/rubin_dp2_host_galaxies.ipynb
+++ b/docs/tutorials/pre_executed/rubin_dp2_host_galaxies.ipynb
@@ -21,11 +21,11 @@
    "id": "02da81cb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T15:31:52.408094Z",
-     "iopub.status.busy": "2026-07-22T15:31:52.407816Z",
-     "iopub.status.idle": "2026-07-22T15:31:58.223060Z",
-     "shell.execute_reply": "2026-07-22T15:31:58.222171Z",
-     "shell.execute_reply.started": "2026-07-22T15:31:52.408071Z"
+     "iopub.execute_input": "2026-07-22T18:27:46.778159Z",
+     "iopub.status.busy": "2026-07-22T18:27:46.777894Z",
+     "iopub.status.idle": "2026-07-22T18:27:53.430251Z",
+     "shell.execute_reply": "2026-07-22T18:27:53.429415Z",
+     "shell.execute_reply.started": "2026-07-22T18:27:46.778135Z"
     }
    },
    "outputs": [],
@@ -55,7 +55,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "40cc0da4",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T18:27:53.433498Z",
+     "iopub.status.busy": "2026-07-22T18:27:53.433294Z",
+     "iopub.status.idle": "2026-07-22T18:27:55.610703Z",
+     "shell.execute_reply": "2026-07-22T18:27:55.609715Z",
+     "shell.execute_reply.started": "2026-07-22T18:27:53.433477Z"
+    }
+   },
    "outputs": [],
    "source": [
     "alerts = lsdb.open_catalog(\n",
@@ -77,7 +85,7 @@
     }
    },
    "source": [
-    "**Note:** This version of the alert archive has data until June 29th and remains frozen for the time being. If you're interested in a specific alert ID, add the following`filters=[(\"diaSourceId\", \"=\", <SOURCE_ID>)]` to the alerts `open_catalog` call."
+    "**Note:** This version of the alert archive has data until July 14th and remains frozen for the time being. If you're interested in a specific alert ID, add the following`filters=[(\"diaSourceId\", \"=\", <SOURCE_ID>)]` to the alerts `open_catalog` call."
    ]
   },
   {
@@ -92,7 +100,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "38fa1014",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T18:27:55.611361Z",
+     "iopub.status.busy": "2026-07-22T18:27:55.611169Z",
+     "iopub.status.idle": "2026-07-22T18:27:56.367224Z",
+     "shell.execute_reply": "2026-07-22T18:27:56.366174Z",
+     "shell.execute_reply.started": "2026-07-22T18:27:55.611344Z"
+    }
+   },
    "outputs": [],
    "source": [
     "fields = {\n",
@@ -125,7 +141,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e96a2eb8",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T18:27:56.367955Z",
+     "iopub.status.busy": "2026-07-22T18:27:56.367761Z",
+     "iopub.status.idle": "2026-07-22T18:27:56.371813Z",
+     "shell.execute_reply": "2026-07-22T18:27:56.371081Z",
+     "shell.execute_reply.started": "2026-07-22T18:27:56.367938Z"
+    }
+   },
    "outputs": [],
    "source": [
     "flag_cols = [f\"{band}_pixelFlags_bad\" for band in \"ugr\"]\n",
@@ -144,7 +168,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4602ec61",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T18:28:00.487522Z",
+     "iopub.status.busy": "2026-07-22T18:28:00.487260Z",
+     "iopub.status.idle": "2026-07-22T18:28:00.492878Z",
+     "shell.execute_reply": "2026-07-22T18:28:00.491818Z",
+     "shell.execute_reply.started": "2026-07-22T18:28:00.487493Z"
+    }
+   },
    "outputs": [],
    "source": [
     "columns = [\"objectId\", \"refExtendedness\", \"refSizeExtendedness\"]\n",
@@ -158,7 +190,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a0c90e5c",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T18:28:00.852171Z",
+     "iopub.status.busy": "2026-07-22T18:28:00.851900Z",
+     "iopub.status.idle": "2026-07-22T18:28:00.856795Z",
+     "shell.execute_reply": "2026-07-22T18:28:00.856007Z",
+     "shell.execute_reply.started": "2026-07-22T18:28:00.852149Z"
+    }
+   },
    "outputs": [],
    "source": [
     "filters = [(\"refExtendedness\", \">\", 0.7), (\"refSizeExtendedness\", \">\", 0.7)]\n",
@@ -178,7 +218,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "47bcdb1d-c58c-4fba-bafc-d2ed6ef66ef8",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T18:28:02.483074Z",
+     "iopub.status.busy": "2026-07-22T18:28:02.482803Z",
+     "iopub.status.idle": "2026-07-22T18:28:04.388009Z",
+     "shell.execute_reply": "2026-07-22T18:28:04.387145Z",
+     "shell.execute_reply.started": "2026-07-22T18:28:02.483050Z"
+    }
+   },
    "outputs": [],
    "source": [
     "dp2_galaxies = lsdb.open_catalog(\n",
@@ -205,7 +253,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ef6810ea",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T18:28:04.388938Z",
+     "iopub.status.busy": "2026-07-22T18:28:04.388714Z",
+     "iopub.status.idle": "2026-07-22T18:28:04.425933Z",
+     "shell.execute_reply": "2026-07-22T18:28:04.425179Z",
+     "shell.execute_reply.started": "2026-07-22T18:28:04.388920Z"
+    }
+   },
    "outputs": [],
    "source": [
     "dp2_galaxies = dp2_galaxies.query(\"not (\" + \" or \".join(c for c in flag_cols) + \")\")\n",
@@ -226,7 +282,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e632802a",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T18:28:07.543227Z",
+     "iopub.status.busy": "2026-07-22T18:28:07.542951Z",
+     "iopub.status.idle": "2026-07-22T18:28:12.806569Z",
+     "shell.execute_reply": "2026-07-22T18:28:12.805669Z",
+     "shell.execute_reply.started": "2026-07-22T18:28:07.543191Z"
+    }
+   },
    "outputs": [],
    "source": [
     "matches = alerts.crossmatch(\n",
@@ -249,7 +313,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9221684c",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T18:28:12.807801Z",
+     "iopub.status.busy": "2026-07-22T18:28:12.807564Z",
+     "iopub.status.idle": "2026-07-22T18:28:12.819166Z",
+     "shell.execute_reply": "2026-07-22T18:28:12.818176Z",
+     "shell.execute_reply.started": "2026-07-22T18:28:12.807781Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def color_diff(df):\n",
@@ -274,11 +346,11 @@
    "id": "0b0bf058",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T15:32:11.363603Z",
-     "iopub.status.busy": "2026-07-22T15:32:11.363262Z",
-     "iopub.status.idle": "2026-07-22T15:32:13.671869Z",
-     "shell.execute_reply": "2026-07-22T15:32:13.671018Z",
-     "shell.execute_reply.started": "2026-07-22T15:32:11.363571Z"
+     "iopub.execute_input": "2026-07-22T18:28:12.819929Z",
+     "iopub.status.busy": "2026-07-22T18:28:12.819600Z",
+     "iopub.status.idle": "2026-07-22T18:30:08.324820Z",
+     "shell.execute_reply": "2026-07-22T18:30:08.323593Z",
+     "shell.execute_reply.started": "2026-07-22T18:28:12.819908Z"
     }
    },
    "outputs": [],
@@ -291,7 +363,9 @@
    "cell_type": "markdown",
    "id": "e1c4ef60-2fc4-4fad-82f3-9b7b7e4095ba",
    "metadata": {},
-   "source": "Check on progress in the Dask dashboard at: `https://<username>.nb.data-int.lsst.cloud/nb/user/<username>/proxy/8787`. Replace the placeholder with your actual RSP username."
+   "source": [
+    "Check on progress in the Dask dashboard at: `https://<username>.nb.data-int.lsst.cloud/nb/user/<username>/proxy/8787`. Replace the placeholder with your actual RSP username."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -305,7 +379,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "272df8ff",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T18:30:08.325824Z",
+     "iopub.status.busy": "2026-07-22T18:30:08.325562Z",
+     "iopub.status.idle": "2026-07-22T18:30:08.885307Z",
+     "shell.execute_reply": "2026-07-22T18:30:08.884245Z",
+     "shell.execute_reply.started": "2026-07-22T18:30:08.325799Z"
+    }
+   },
    "outputs": [],
    "source": [
     "ax = plt.subplot()\n",
@@ -326,9 +408,9 @@
    "source": [
     "## About\n",
     "\n",
-    "**Authors:** Sandro Campos, Konstantin Malanchev\n",
+    "**Authors:** Sandro Campos, Konstantin Malanchev, Neven Caplar\n",
     "\n",
-    "**Last updated/verified on:** Jul 16, 2026\n",
+    "**Last updated/verified on:** Jul 22, 2026\n",
     "\n",
     "If you use `lsdb` for published research, please cite following [instructions](https://docs.lsdb.io/en/stable/citation.html)."
    ]

--- a/docs/tutorials/pre_executed/rubin_dp2_host_galaxies.ipynb
+++ b/docs/tutorials/pre_executed/rubin_dp2_host_galaxies.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ac656028-bedd-495d-bf1f-6159b1feb68a",
+   "metadata": {},
+   "source": [
+    "# Finding host galaxies from Rubin alerts\n",
+    "\n",
+    "In this notebook we will find host galaxies for APDB alerts.\n",
+    "\n",
+    "1. Select a region of the sky defined by the Deep Drilling fields.\n",
+    "2. Select DP2 objects with a filter on extendendedness, to capture galaxies.\n",
+    "3. Crossmatch the alerts with the DP2 objects.\n",
+    "3. Calculate the (u-g, g-r) differences and plot the respective color diagram."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02da81cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import lsdb\n",
+    "\n",
+    "from functools import reduce\n",
+    "from hats.pixel_math import region_to_moc\n",
+    "from hats.inspection.visualize_catalog import plot_moc\n",
+    "\n",
+    "from dask.distributed import Client\n",
+    "\n",
+    "from lsdb.core.search.region_search import MOCSearch\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.colors import LogNorm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf6d2cbe",
+   "metadata": {},
+   "source": [
+    "First, let's open the alert archive catalog:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40cc0da4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "alerts = lsdb.open_catalog(\n",
+    "    \"/sdf/data/rubin/shared/lsdb_commissioning/alert_archive\", columns=[\"diaSourceId\", \"ra\", \"dec\"]\n",
+    ")\n",
+    "alerts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4941dd51",
+   "metadata": {},
+   "source": [
+    "Let's select a region in the sky defined by the Deep Drilling Fields:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38fa1014",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fields = {\n",
+    "    \"ELAISS1\": (9.45, -44.02),  # ELAIS-S1\n",
+    "    \"XMM_LSS\": (35.57, -4.82),  # XMM Large Scale Structure\n",
+    "    \"ECDFS\": (52.98, -28.12),  # Extended Chandra Deep Field South\n",
+    "    \"COSMOS\": (150.11, 2.23),  # COSMOS\n",
+    "    \"EDFS_a\": (58.9, -49.32),  # Euclid Deep Field South a\n",
+    "    \"EDFS_b\": (63.6, -47.60),  # Euclid Deep Field South b\n",
+    "}\n",
+    "\n",
+    "cone_mocs = [\n",
+    "    # Using a 4 degree cone around each center.\n",
+    "    region_to_moc.cone_to_moc(ra=ra, dec=dec, radius_arcsec=4 * 3600, max_depth=10)\n",
+    "    for ra, dec in fields.values()\n",
+    "]\n",
+    "cone_moc = reduce(lambda a, b: a.union(b), cone_mocs)\n",
+    "plot_moc(cone_moc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46e22ede",
+   "metadata": {},
+   "source": [
+    "Let's select the flag columns for filtering:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e96a2eb8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flag_cols = [f\"{band}_pixelFlags_bad\" for band in \"ugr\"]\n",
+    "flag_cols"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc15576c",
+   "metadata": {},
+   "source": [
+    "As well as the extendedness and magnitude information:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4602ec61",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "columns = [\"objectId\", \"refExtendedness\", \"refSizeExtendedness\"]\n",
+    "columns += [f\"{band}_psfMag\" for band in \"ugr\"]\n",
+    "columns += [f\"{band}_psfMagErr\" for band in \"ugr\"]\n",
+    "columns += flag_cols\n",
+    "columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0c90e5c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filters = [(\"refExtendedness\", \">\", 0.7), (\"refSizeExtendedness\", \">\", 0.7)]\n",
+    "filters += [(f\"{band}_psfMagErr\", \"<\", 0.05) for band in \"ugr\"]\n",
+    "filters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6fb65828",
+   "metadata": {},
+   "source": [
+    "We can now open the DP2 collection. We will filter for galaxies and select the objects per-band magnitude information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47bcdb1d-c58c-4fba-bafc-d2ed6ef66ef8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dp2_galaxies = lsdb.open_catalog(\n",
+    "    \"/sdf/data/rubin/shared/lsdb_commissioning/hats/dp2_rc/object_collection\",\n",
+    "    # Select extendendness and per-band magnitude columns\n",
+    "    columns=columns,\n",
+    "    # Select the Deep Drilling Fields\n",
+    "    search_filter=MOCSearch(cone_moc),\n",
+    "    # Filter by large extendedness to avoid point sources and artifacts\n",
+    "    filters=filters,\n",
+    ")\n",
+    "dp2_galaxies"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9de04b8",
+   "metadata": {},
+   "source": [
+    "Let's remove any of the galaxies with at least one of the selected flags set:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef6810ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dp2_galaxies = dp2_galaxies.query(\"not (\" + \" or \".join(c for c in flag_cols) + \")\")\n",
+    "dp2_galaxies"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6bfb957d",
+   "metadata": {},
+   "source": [
+    "We then crossmatch the alerts to the DP2 data to find their galaxy hosts:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e632802a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "matches = alerts.crossmatch(\n",
+    "    dp2_galaxies, n_neighbors=3, radius_arcsec=5, min_radius_arcsec=0.02, suffix_method=\"overlapping_columns\"\n",
+    ")\n",
+    "matches"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26569260",
+   "metadata": {},
+   "source": [
+    "The last step is to calculate the per-band color information for each object in the resulting partitions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9221684c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def color_diff(df):\n",
+    "    return {\"u-g\": df[\"u_psfMag\"] - df[\"g_psfMag\"], \"g-r\": df[\"g_psfMag\"] - df[\"r_psfMag\"]}\n",
+    "\n",
+    "\n",
+    "result = matches.map_partitions(color_diff, meta={\"u-g\": float, \"g-r\": float})\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52e02bbd",
+   "metadata": {},
+   "source": [
+    "Let's setup a Dask Client to more effectively use the hardware available on this RSP machine (assuming a large 32GiB RAM instance):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b0bf058",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with Client(n_workers=4, memory_limit=\"8GiB\"):\n",
+    "    df = result.compute()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "141159ef",
+   "metadata": {},
+   "source": [
+    "Finally, let's plot the resulting color-color diagram:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "272df8ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = plt.subplot()\n",
+    "h = ax.hist2d(df[\"u-g\"], df[\"g-r\"], bins=500, cmin=1, norm=LogNorm())\n",
+    "ax.set_xlabel(\"u-g\")\n",
+    "ax.set_ylabel(\"g-r\")\n",
+    "ax.set_xlim(-0.5, 2.5)\n",
+    "ax.set_ylim(-1, 2.5)\n",
+    "plt.colorbar(h[3], label=\"Number of galaxies\")\n",
+    "plt.title(\"Color-color diagram\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2b8198a",
+   "metadata": {},
+   "source": [
+    "## About\n",
+    "\n",
+    "**Authors:** Sandro Campos, Konstantin Malanchev\n",
+    "\n",
+    "**Last updated/verified on:** Jul 16, 2026\n",
+    "\n",
+    "If you use `lsdb` for published research, please cite following [instructions](https://docs.lsdb.io/en/stable/citation.html)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.13"
+  },
+  "nbsphinx": {
+   "execute": "never"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/tutorials/pre_executed/rubin_dp2_host_galaxies.ipynb
+++ b/docs/tutorials/pre_executed/rubin_dp2_host_galaxies.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Finding host galaxies from Rubin alerts\n",
     "\n",
-    "In this notebook we will find host galaxies for APDB alerts.\n",
+    "In this notebook we will find Data Preview 2 (DP2) host galaxies for alerts.\n",
     "\n",
     "1. Select a region of the sky defined by the Deep Drilling fields.\n",
     "2. Select DP2 objects with a filter on extendendedness, to capture galaxies.\n",
@@ -19,19 +19,25 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "02da81cb",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T15:31:52.408094Z",
+     "iopub.status.busy": "2026-07-22T15:31:52.407816Z",
+     "iopub.status.idle": "2026-07-22T15:31:58.223060Z",
+     "shell.execute_reply": "2026-07-22T15:31:58.222171Z",
+     "shell.execute_reply.started": "2026-07-22T15:31:52.408071Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import lsdb\n",
+    "import matplotlib.pyplot as plt\n",
     "\n",
+    "from dask.distributed import Client\n",
     "from functools import reduce\n",
     "from hats.pixel_math import region_to_moc\n",
     "from hats.inspection.visualize_catalog import plot_moc\n",
-    "\n",
-    "from dask.distributed import Client\n",
-    "\n",
     "from lsdb.core.search.region_search import MOCSearch\n",
-    "import matplotlib.pyplot as plt\n",
     "from matplotlib.colors import LogNorm"
    ]
   },
@@ -40,6 +46,8 @@
    "id": "bf6d2cbe",
    "metadata": {},
    "source": [
+    "## Load the catalogs\n",
+    "\n",
     "First, let's open the alert archive catalog:"
    ]
   },
@@ -51,9 +59,25 @@
    "outputs": [],
    "source": [
     "alerts = lsdb.open_catalog(\n",
-    "    \"/sdf/data/rubin/shared/lsdb_commissioning/alert_archive\", columns=[\"diaSourceId\", \"ra\", \"dec\"]\n",
+    "    \"https://data.lsdb.io/hats/rubin_alert_archive\", columns=[\"diaSourceId\", \"ra\", \"dec\"]\n",
     ")\n",
     "alerts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ab63b51-f88f-4d0e-aa20-ac20cdfd2584",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T15:30:24.020685Z",
+     "iopub.status.busy": "2026-07-22T15:30:24.020373Z",
+     "iopub.status.idle": "2026-07-22T15:30:24.028082Z",
+     "shell.execute_reply": "2026-07-22T15:30:24.026831Z",
+     "shell.execute_reply.started": "2026-07-22T15:30:24.020618Z"
+    }
+   },
+   "source": [
+    "**Note:** This version of the alert archive has data until June 29th and remains frozen for the time being. If you're interested in a specific alert ID, add the following`filters=[(\"diaSourceId\", \"=\", <SOURCE_ID>)]` to the alerts `open_catalog` call."
    ]
   },
   {
@@ -158,7 +182,7 @@
    "outputs": [],
    "source": [
     "dp2_galaxies = lsdb.open_catalog(\n",
-    "    \"/sdf/data/rubin/shared/lsdb_commissioning/hats/dp2_rc/object_collection\",\n",
+    "    \"/rubin/lsdb_data/dp2/object_collection\",\n",
     "    # Select extendendness and per-band magnitude columns\n",
     "    columns=columns,\n",
     "    # Select the Deep Drilling Fields\n",
@@ -193,6 +217,8 @@
    "id": "6bfb957d",
    "metadata": {},
    "source": [
+    "## Crossmatch alerts to galaxies\n",
+    "\n",
     "We then crossmatch the alerts to the DP2 data to find their galaxy hosts:"
    ]
   },
@@ -214,6 +240,8 @@
    "id": "26569260",
    "metadata": {},
    "source": [
+    "## Plot a color-color diagram\n",
+    "\n",
     "The last step is to calculate the per-band color information for each object in the resulting partitions:"
    ]
   },
@@ -237,19 +265,33 @@
    "id": "52e02bbd",
    "metadata": {},
    "source": [
-    "Let's setup a Dask Client to more effectively use the hardware available on this RSP machine (assuming a large 32GiB RAM instance):"
+    "Let's setup a Dask Client to more effectively use the hardware available on this RSP machine. Here we assume a large 32GiB RAM instance:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "0b0bf058",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T15:32:11.363603Z",
+     "iopub.status.busy": "2026-07-22T15:32:11.363262Z",
+     "iopub.status.idle": "2026-07-22T15:32:13.671869Z",
+     "shell.execute_reply": "2026-07-22T15:32:13.671018Z",
+     "shell.execute_reply.started": "2026-07-22T15:32:11.363571Z"
+    }
+   },
    "outputs": [],
    "source": [
     "with Client(n_workers=4, memory_limit=\"8GiB\"):\n",
     "    df = result.compute()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1c4ef60-2fc4-4fad-82f3-9b7b7e4095ba",
+   "metadata": {},
+   "source": "Check on progress in the Dask dashboard at: `https://<username>.nb.data-int.lsst.cloud/nb/user/<username>/proxy/8787`. Replace the placeholder with your actual RSP username."
   },
   {
    "cell_type": "markdown",
@@ -294,9 +336,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "LSST",
    "language": "python",
-   "name": "python3"
+   "name": "lsst"
   },
   "language_info": {
    "codemirror_mode": {
@@ -308,7 +350,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.9"
   },
   "nbsphinx": {
    "execute": "never"


### PR DESCRIPTION
Add two documentation notebooks on using Rubin alert archive with DP2.

- Finding host galaxies (uses alerts and DP2 object data).
- Historical forced photometry (uses alerts and DP2 DIA object data).

Related to #1447 (and potentially closes).