### PR TITLE
Olivia/apply nb guide

### DIFF
--- a/docs/data-access/vizier.rst
+++ b/docs/data-access/vizier.rst
@@ -91,4 +91,4 @@ We recommend saving the result as a HATS catalog immediately so you can reload i
 
    cat = lsdb.open_catalog("./vmicro")
 
-For a complete worked example including cross-matching, see the :doc:`ZTF BTS × NGC tutorial </tutorials/pre_executed/ztf_bts-ngc>`.
+For a complete worked example including cross-matching, see the :doc:`ZTF BTS × NGC tutorial </tutorials/pre_executed/ztf_bts_ngc>`.

--- a/docs/developer/notebook_guide_pilot.md
+++ b/docs/developer/notebook_guide_pilot.md
@@ -1,0 +1,345 @@
+# Notebook style guide — pilot run
+
+*Working document for the pilot PR. Not part of the rendered docs; delete or
+archive once the full revision pass lands.*
+
+## What this PR does
+
+`docs/developer/notebook_style_guide.md` was added in `283c9c61` and had never been applied to
+anything. Rather than batch-editing all 43 tutorial notebooks against an untested guide, this PR
+runs it against a small, deliberately varied subset and reports back on where the guide itself was
+wrong.
+
+The headline result is in the next section: **six guide/template rules were wrong or ambiguous, and
+measuring the notebooks first turned what would have been edits to 30+ notebooks into edits to the
+guide.** That is the argument for piloting.
+
+## Changes to the guide and template (what the pilot bought us)
+
+Every change here came from measuring what the notebooks already do, then finding the guide in the
+minority. In each case the guide was changed, not the notebooks.
+
+### 1. Section numbering: `## 1 - Title` → `## 1. Title`
+
+The guide specified a dash. The notebooks overwhelmingly use a period:
+
+| Form | Occurrences across all 43 notebooks |
+|---|---|
+| `## 1. Title` | **120** |
+| `## 1 - Title` | 3 (all in `dask_client.ipynb`) |
+
+Following the guide literally would have meant editing **32 notebooks** to change punctuation, in
+the direction of a convention exactly one file uses. Changing the guide instead reduces the eventual
+numbering work to `dask_client.ipynb` alone.
+
+### 2. Sub-section numbering: `### 1.1 - Title` → `### 1.1 Title`
+
+Here there was no majority to defer to, so this one was an explicit editorial call rather than a
+measurement:
+
+| Form | Occurrences |
+|---|---|
+| `### 1.1 Title` | 29 |
+| `### 1.1. Title` | 28 |
+| `### 1.1 - Title` | 4 (the guide's form) |
+
+Chosen: no trailing dot, which avoids the awkward `1.1.` double period. This leaves 28 notebooks
+with a trailing dot to normalize during the full pass — the one place where the guide is
+deliberately asking for churn, with eyes open.
+
+The guide now spells the two levels out explicitly, since they differ:
+
+> Content sections, numbered (`## 1. ...`, with `### 1.1 ...` sub-sections as needed). Note the
+> punctuation: a period after a top-level number, nothing after a sub-section number.
+
+### 3. Objectives line: `In this tutorial we will:` → `In this tutorial, we will:`
+
+| Form | Occurrences |
+|---|---|
+| `In this tutorial, we will:` | **33** |
+| `In this tutorial we will:` | 1 (`map_partitions.ipynb`) |
+
+Same shape as the numbering case, smaller stakes. Changed in both the structure list and the
+checklist.
+
+### 4. Template: unnumbered sections ahead of `## 1.`
+
+The guide states that the template is its executable counterpart and that "where the two disagree,
+one of them is wrong." They disagreed. `tutorial_template.ipynb` placed two content sections —
+`## Open a catalog` and `## Plotting lightcurves` — *unnumbered*, ahead of the numbered
+`## 1. [Interesting thing 1]` placeholder. Anyone starting from the template produced a notebook
+that fails the guide's own checklist.
+
+The template's sections are now a single continuous sequence:
+
+```
+## Introduction
+## 1. Open a catalog
+## 2. Plotting lightcurves
+## 3. [Interesting thing 1]
+## 4. [Interesting thing 2]
+###   4.1 [Sub-section 1, if applicable]
+###   4.2 [Sub-section 2, if applicable]
+## Close the Dask client
+## About
+```
+
+This was a template bug, not a guide bug — the guide's stated section order was right all along.
+
+### 5. `## About` field labels: `**Author(s):**` → `**Authors**:`
+
+The template was in the minority on two axes at once:
+
+| Axis | Majority | Template had |
+|---|---|---|
+| Label | `Authors` (34) | `Author(s)` (6) |
+| Colon on the author line | outside the bold (33) | inside (7) |
+| Colon on the date line | outside the bold (27) | inside (14) |
+
+Template updated on all three; the guide now names the labels explicitly rather than leaving them
+to be inferred from the template. **Deliberately not pinned: the date format.** `January 19, 2026`
+(22), `Jan 19, 2026` (15), and `19 May 2026` (3) coexist with no clear winner, and normalizing them
+would mean touching 40 notebooks for no reader benefit. The guide says so out loud, so the next
+person doesn't re-open it.
+
+### 6. Imports placement — a descriptive rule instead of a prescriptive one
+
+The guide said only "import cells follow [the intro]," which was ambiguous enough to be unusable as
+a checklist item. Practice is genuinely split:
+
+| Placement | Count |
+|---|---|
+| Inside/after the first numbered section | 20 |
+| Before the first numbered section | 11 |
+| No numbered sections at all | 10 |
+
+Rather than pick a side and move imports by one or two cells across 20-odd notebooks for no
+functional gain, the guide now states the part that actually matters as a rule — **imports come no
+earlier than the Introduction**, so a reader is never hit with code before they know what the
+notebook is for — and the rest as a stated preference. Both existing placements are compliant.
+
+### Not changed, and why
+
+- **Logging level and Dask dashboard printing.** Frozen at the author's request pending a decision
+  on whether to keep those rules at all. Current state is inventoried below so that decision can be
+  made from data. Nothing was applied, removed, or reformatted.
+- **The Plotting section.** Untested this round — see the constraint below.
+
+## Constraints on this pilot
+
+**No re-execution is available.** Notebooks in `docs/tutorials/pre_executed/` ship with saved outputs
+and `nbsphinx.execute: "never"`. Editing a code cell there desyncs the code from the rendered output:
+the published page would show the old figure beside new code. So **this pilot makes no code-cell
+edits in `pre_executed/`**.
+
+That has a significant consequence: **the entire Plotting section of the guide goes untested.** Every
+matplotlib plot in the docs lives in `pre_executed/`. The 10 executed notebooks contain no matplotlib
+plots at all — `region_selection.ipynb`'s plots are LSDB `plot_pixels` sky maps, which the guide's
+rules (inverted magnitude axes, error bars, hexbin, colormaps) do not govern. Validating the plotting
+rules requires a follow-up pass by someone who can re-run these notebooks against real data.
+
+## Survey: all 43 notebooks
+
+Executed = `docs/tutorials/*.ipynb`, run at build time by nbsphinx; outputs stripped on commit by the
+`jupyter-nb-clear-output` hook. Pre-exec = `docs/tutorials/pre_executed/*.ipynb`, outputs preserved,
+`nbsphinx.execute: "never"`, enforced by the `pre-executed-nb-never-execute` hook.
+
+### Structure and footer
+
+| Notebook | Group | Numbering | Objectives | `## Introduction` | `## About` author | Last updated |
+|---|---|---|---|---|---|---|
+| catalog_object | exec | `1.` | yes | yes | Sandro Campos, Melissa DeLucchi, and Sean McGuire | Jan 19, 2026 |
+| column_filtering | exec | `1.` | yes | yes | Olivia Lynn | May 20, 2025 |
+| dask_client | exec | **`1 -`** | yes | yes | Olivia Lynn and Melissa DeLucchi | May 22, 2025 |
+| exporting_results | exec | none | **missing** | **missing** | Neven Caplar, Sandro Campos | April 27, 2025 |
+| import_catalogs | exec | `1.` | yes | yes | Sandro Campos | April 4, 2025 |
+| lazy_operations | exec | **none** | yes | yes | Sean McGuire | June 27, 2025 |
+| margins | exec | `1.` | yes | yes | Sean McGuire | April 18, 2025 |
+| region_selection | exec | `1.` | yes | yes | Sandro Campos and Melissa DeLucchi | August 29, 2025 |
+| row_filtering | exec | `1.` | yes | yes | Sandro Campos, Melissa DeLucchi, Olivia Lynn, and Derek Jones | April 14, 2025 |
+| small_scale | exec | `1.` | "we will cover" | yes | Olivia Lynn | May 18, 2026 |
+| access.pyvo | pre-exec | `1.` | yes | yes | Melissa DeLucchi | May 14, 2026 |
+| crossmatching | pre-exec | `1.` | yes | yes | Derek Jones | Oct 27, 2025 |
+| custom_search | pre-exec | `1.` | yes | yes | Melissa DeLucchi | October 27, 2025 |
+| des-gaia | pre-exec | `1.` | yes | yes | Konstantin Malanchev | Oct 27, 2025 |
+| dp1-gaia-epoch-prop | pre-exec | `1.` | **missing** | **missing** | **no About at all** | — |
+| explode_lightcurves | pre-exec | none | yes | **missing** | **no About at all** | — |
+| full_dp2_crossmatches | pre-exec | **none** | "In this notebook we'll" | **missing** | Doug Branton | July 27, 2026 |
+| index_table | pre-exec | `1.` | yes | yes | Melissa DeLucchi | October 27, 2025 |
+| join_catalogs | pre-exec | `1.` | yes | yes | Sandro Campos | Oct 27, 2025 |
+| manual_verification | pre-exec | `1.` | **missing** | **missing** | Melissa DeLucchi | Oct 27, 2025 |
+| map_partitions | pre-exec | `1.` | **no comma** | yes | Derek Jones | January 19, 2026 |
+| nestedframe | pre-exec | `1.` | yes | yes | Doug Branton | October 27, 2025 |
+| plotting | pre-exec | `1.` | yes | yes | Sean McGuire | October 27, 2025 |
+| rubin_dp1 | pre-exec | `1.` | yes | yes | Neven Caplar, Derek Jones, Konstantin Malanchev, Olivia Lynn | May 13, 2026 |
+| rubin_dp1_photoz | pre-exec | `1.` | yes | **missing** | Sandro Campos, Sarah Pelesky, Tianqing Zhang | Jan 29, 2026 |
+| rubin_dp1_vsx | pre-exec | `1.` | yes | yes | Konstantin Malanchev | May 12, 2026 |
+| rubin_dp2-da-white-dwarfs | pre-exec | `1.` | yes | yes | Konstantin Malanchev | July 27, 2026 |
+| rubin_dp2 | pre-exec | `1.` | yes | yes | Neven Caplar, Sandro Campos, Olivia Lynn, Konstantin Malanchev | July 27, 2026 |
+| rubin_dp2_historical_dia | pre-exec | **none** | **missing** | **missing** | Sandro Campos, Konstantin Malanchev, Neven Caplar | July 27, 2026 |
+| rubin_dp2_host_galaxies | pre-exec | **none** | **missing** | **missing** | Sandro Campos, Konstantin Malanchev, Neven Caplar | July 27, 2026 |
+| rubin_dp2_photoz | pre-exec | `1.` | yes | **missing** | Sandro Campos, Sarah Pelesky, Tianqing Zhang, Konstantin Malanchev | July 27, 2026 |
+| rubin_dp2_starter | pre-exec | **none** | **missing** | **missing** | Heather Sestili | July 27, 2026 |
+| rubin_dp2_tutorial | pre-exec | **none** | yes | **missing** | Heather Sestili | July 27, 2026 |
+| rubin_dp2_why_lazy_evaluation | pre-exec | **none** | **missing** | **missing** | Heather Sestili | July 27, 2026 |
+| scaling_workflows | pre-exec | **none** | yes | yes | Doug Branton | July 17, 2025 |
+| timeseries | pre-exec | `1.` | yes | yes | Konstantin Malanchev, Derek Jones | Oct 27, 2025 |
+| types_of_crossmatch | pre-exec | `1.` | yes | **missing** | Sean McGuire | 19 May 2026 |
+| using_rubin_data | pre-exec | `1.` | yes | yes | Doug Branton | 11 May 2026 |
+| visualize_periodic_lcs | pre-exec | **none** | yes | yes | Sandro Campos, Doug Branton | 7 Jan 2026 |
+| ztf-alerts-sne | pre-exec | `1.` | **missing** | **missing** | Konstantin Malanchev and Mi Dai | April 17, 2025 |
+| ztf_bts-ngc | pre-exec | `1.` | "In this notebook, we demonstrate" | **missing** | Konstantin Malanchev, Mi Dai | Oct 27, 2025 |
+| zubercal-ps1-snad | pre-exec | `1.` | **missing** | **missing** | Konstantin Malanchev | Oct 27, 2025 |
+
+Totals: numbering `1.` = 32, `1 -` = 1, none = 10 · objectives present = 35 · Introduction present =
+26 · **`## About` present = 40 of 42, and where present, author and date are filled in every one.**
+
+**The `## About` footer is in far better shape than a first pass suggested.** Only
+`dp1-gaia-epoch-prop.ipynb` and `explode_lightcurves.ipynb` lack the section entirely; those two are
+the whole of the work. What the footers need is not authorship research but *format* normalization
+— see the label and date-format inconsistencies below.
+
+### `## About` field formatting
+
+Three separate inconsistencies, none of which the guide currently rules on. In each case the
+template is either silent or in the minority.
+
+| Axis | Variants found | Template currently says |
+|---|---|---|
+| Label | `Authors` (34) · `Author(s)` (6) | `Author(s)` — **minority** |
+| Colon | `**Authors**:` outside the bold (33) · `**Authors:**` inside (7) | inside — **minority** |
+| Date label | `Last updated on` (23) · `Last run` (10) · `Last updated/verified on` (3) · `Last updated /verified on` (4) | `Last updated on` — majority ✓ |
+| Date format | `January 19, 2026` (22) · `Jan 19, 2026` (15) · `19 May 2026` (3) | `[Date]` — unspecified |
+
+Note that `Last run` (10 notebooks, all `pre_executed/`) is arguably the more accurate label for that
+group: a pre-executed notebook's outputs were produced on a specific date, which is a different fact
+from when someone last edited the prose. Worth deciding deliberately rather than flattening.
+
+### Dask logging / dashboard / client (frozen this round — inventory only)
+
+| Notebook | Logging calls | Dashboard link | Client form |
+|---|---|---|---|
+| full_dp2_crossmatches | root=WARNING; distributed=WARNING | prints | `with Client` |
+| rubin_dp2-da-white-dwarfs | root=WARNING; distributed=WARNING | prints | `with Client` |
+| rubin_dp2_host_galaxies | root=WARNING; distributed=WARNING | prints | `with Client` |
+| rubin_dp2_photoz | root=WARNING; distributed=WARNING | prints | `with Client` |
+| rubin_dp2_starter | root=WARNING; distributed=WARNING | prints | `client = Client(...)` |
+| rubin_dp2_tutorial | root=WARNING; distributed=WARNING | prints | `client = Client(...)` |
+| rubin_dp2_why_lazy_evaluation | root=WARNING; distributed=WARNING | prints | `client = Client(...)` |
+| rubin_dp2_historical_dia | root=WARNING; distributed=WARNING | — | no client |
+| rubin_dp2 | — | **prints** | `client = Client(...)` |
+| column_filtering, dask_client, lazy_operations, region_selection, row_filtering, small_scale | — | — | `client = Client(...)`, closed |
+| crossmatching, des-gaia, map_partitions, plotting, timeseries | — | — | `client = Client(...)`, closed |
+| **rubin_dp1** | — | — | `client = Client(...)`, **never closed** |
+| **rubin_dp2** | — | — | `client = Client(...)`, **never closed** |
+| import_catalogs, dp1-gaia-epoch-prop, rubin_dp1_vsx, scaling_workflows, visualize_periodic_lcs, ztf-alerts-sne, ztf_bts-ngc | — | — | `with Client` (already compliant) |
+| access.pyvo, catalog_object, custom_search, exporting_results, explode_lightcurves, index_table, join_catalogs, manual_verification, margins, nestedframe, rubin_dp1_photoz, types_of_crossmatch, using_rubin_data, zubercal-ps1-snad | — | — | no client |
+
+Two observations for the pending logging/dashboard decision:
+
+- **"Close what you open" is nearly satisfied already.** Only `rubin_dp1.ipynb` and `rubin_dp2.ipynb`
+  hold a persistent client and never close it. Everything else either uses `with Client(...)` — which
+  the guide should probably name as the preferred form — or already calls `client.close()`.
+- **The dashboard rule means something different in the two groups.** All 8 dashboard-printing
+  notebooks are `pre_executed/`, so their link was captured once on RSP and never re-runs. Applying
+  that rule to the 10 executed notebooks is a different proposition: those run on ReadTheDocs, where
+  `dashboard_link` resolves against the RTD build container and would bake a dead URL into the
+  published page.
+
+## Pilot subset
+
+Five notebooks, chosen to span every axis that could make the guide behave differently — not to be
+representative.
+
+| # | Notebook | Why it's in the pilot |
+|---|---|---|
+| 1 | `tutorials/lazy_operations.ipynb` | Executed, **no numbering at all** → tests inventing a scheme from scratch. Build-verifiable end to end. |
+| 2 | `tutorials/exporting_results.ipynb` | Executed, 2 cells, no objectives / Introduction / numbering → the "almost nothing to work with" case. |
+| 3 | `tutorials/pre_executed/types_of_crossmatch.ipynb` | Pre-exec, already numbered, missing Introduction, single author → the **cheap markdown-only pass**. Sets the floor for diff size. |
+| 4 | `tutorials/pre_executed/ztf_bts-ngc.ipynb` | Pre-exec, **hyphenated filename** (rename + toctree update), non-standard objectives phrasing, and **has plots we deliberately leave alone** → shows what a structure-only pass leaves visibly unfinished. |
+| 5 | `tutorials/pre_executed/rubin_dp2_starter.ipynb` | Pre-exec, **879 KB**, no numbering / objectives / Introduction, and **already has logging + dashboard** → worst-case diff noise, and proves the freeze held. |
+
+### Applied
+
+| Notebook | Diff (+/−) | What changed |
+|---|---|---|
+| `lazy_operations.ipynb` | 4 / 4 | Numbered 2 sections + 1 sub-section; promoted `### Closing the Dask client` to a top-level `## Close the Dask client` |
+| `exporting_results.ipynb` | 33 / 8 | Split 1 prose cell into 5: added objectives and `## Introduction`, split the body into 3 numbered sections |
+| `types_of_crossmatch.ipynb` | 12 / 1 | Added `## Introduction`; `**Author(s)**:` → `**Authors**:` |
+| `ztf_bts_ngc.ipynb` | 18 / 6 | Renamed from `ztf_bts-ngc.ipynb`; rewrote objectives into the standard form; added `## Introduction`; dropped trailing dots from `### 1.1.` / `### 1.2.` |
+| `rubin_dp2_starter.ipynb` | 37 / 7 | Added objectives and `## Introduction`; numbered 6 sections; added a `## Close the Dask client` heading for the existing `client.close()` cell; colon moved outside the bold on `**Last run**:` |
+
+**Verified: all three `pre_executed/` notebooks have byte-identical code cells *and* byte-identical
+outputs** before and after. Nothing desynced.
+
+### Deliberately not applied
+
+- Any code-cell edit in `pre_executed/` (no re-execution available)
+- The Plotting section in full (all plots live in `pre_executed/`)
+- Logging level and dashboard printing (frozen)
+- The other 6 hyphenated filenames — `des-gaia`, `ztf-alerts-sne`, `zubercal-ps1-snad`,
+  `rubin_dp2-da-white-dwarfs`, `dp1-gaia-epoch-prop`, `access.pyvo`. Renaming changes published
+  `docs.lsdb.io` URLs, so it belongs in one deliberate PR rather than as a side effect of this one.
+
+## What applying it actually taught us
+
+Four things surfaced only once the guide was used in anger, rather than read.
+
+**The "output-heavy notebooks will produce unreviewable diffs" worry was wrong.** That was the whole
+reason `rubin_dp2_starter.ipynb` (879 KB) was in the pilot. A markdown-only pass on it produced a
+**37-line insertion / 7-line deletion** diff — entirely reviewable. Because nbformat stores each
+output blob as a single long JSON line, output cells simply don't move when markdown cells around
+them change. **This removes the main objection to batch-revising the `pre_executed/` group.** The
+constraint that matters there is code-cell edits, not file size.
+
+**Renaming needs a repo-wide grep, not a `tutorial_toc/` grep.** The rename of `ztf_bts-ngc.ipynb`
+had a second inbound reference in `docs/data-access/vizier.rst`, outside the toctree directory
+entirely. A `:doc:` reference to a renamed notebook is a hard Sphinx error, so the eventual 6-file
+rename PR must grep all of `docs/`, not just the toc files.
+
+**The guide doesn't say where `## Close the Dask client` goes.** In `lazy_operations.ipynb` it
+existed as `### Closing the Dask client`, nested inside a content section. The template puts it at
+top level and unnumbered, which is what we did — but the guide should say so, and should pin the
+heading text, since "Close" vs "Closing" already varies.
+
+**The guide has nothing to say about `raw` cells.** `types_of_crossmatch.ipynb` uses `raw` cells for
+`.. nbinfo::` admonitions, interleaved with the markdown structure. They aren't prose, aren't code,
+and the section-order rule doesn't obviously apply to them. Worth a sentence.
+
+### Judgment calls left alone, flagged instead of fixed
+
+- **`## 4. Make some plot`** in `ztf_bts_ngc.ipynb` — a grammar slip in a heading. The guide has no
+  copyedit rule, and inventing one mid-pass would make the revision unbounded. Decide whether a
+  revision pass is allowed to fix obvious typos.
+- **`**Last run**:` in `rubin_dp2_starter.ipynb`** — normalized the colon but kept `Last run` rather
+  than forcing `Last updated on`, since the pilot doc flags that as an open question for
+  `pre_executed/` notebooks. Preempting it here would have decided it by accident.
+- **`## Introduction - What are Lazy Operations?`** — kept the descriptive suffix rather than
+  flattening to a bare `## Introduction`. The guide's intent is satisfied and the suffix carries
+  information.
+
+## Verification
+
+1. `pre-commit run --all-files` — confirms outputs stripped from the two executed notebooks, and that
+   the three pre-executed ones kept `nbsphinx.execute: "never"`.
+2. `cd docs && make no-nb` — structural build; catches a toctree break if the rename and
+   `toc_science.rst` fall out of sync.
+3. `cd docs && make html` — full build. Executes the two `tutorials/` notebooks for real; needs
+   network access for the catalogs they open.
+4. Spot-check the three pre-executed pages in `_readthedocs/html/`: no figure should now sit next to
+   code that did not produce it.
+5. `git diff --stat` on `rubin_dp2_starter.ipynb` — a large diff from a markdown-only pass on an
+   879 KB file is itself a finding about batch-revising this group.
+
+## Follow-up work this pilot identifies
+
+- **Decide the logging / dashboard rules**, using the inventory above. The RTD-vs-RSP split is the
+  crux.
+- **Add an `## About` section to the 2 notebooks missing one** — `dp1-gaia-epoch-prop.ipynb` and
+  `explode_lightcurves.ipynb`. These are the only two needing human authorship input.
+- **Normalize `## About` field formatting** across 42 notebooks — see the inconsistencies below.
+- **Validate the Plotting section** — requires someone who can re-execute `pre_executed/` notebooks.
+- **Normalize 28 notebooks** from `### 1.1.` to `### 1.1`, and `dask_client.ipynb` from `## 1 -` to `## 1.`.
+- **Rename the remaining 6 hyphenated notebooks** in a dedicated PR, accepting the URL breakage.
+- **Consider naming `with Client(...)` as the preferred form** in the guide's "close what you open"
+  rule — 7 notebooks already use it and it makes the rule unbreakable.

--- a/docs/developer/notebook_style_guide.md
+++ b/docs/developer/notebook_style_guide.md
@@ -15,21 +15,32 @@ rather than picking a side silently.
 Follow the section order in the template:
 
 1. Title (`# [Notebook Title]`)
-2. "In this tutorial we will:" — a short bulleted list of what the reader will learn
+2. "In this tutorial, we will:" — a short bulleted list of what the reader will learn
 3. `## Introduction` — what the feature is and, briefly, why it exists
-4. Content sections, numbered (`## 1 - ...`, with `### 1.1 - ...` sub-sections as needed)
+4. Content sections, numbered (`## 1. ...`, with `### 1.1 ...` sub-sections as needed). Note the
+   punctuation: a period after a top-level number, nothing after a sub-section number.
 5. `## Close the Dask client` — if a client was opened for the notebook
 6. `## About` footer
 
 **Prose comes before code.** The intro text is the first thing a reader sees, so they know what
-the notebook is for before they hit any setup. Import cells follow it.
+the notebook is for before they hit any setup.
+
+**Imports come no earlier than the Introduction, and as early after it as is practical.** The hard
+part of this rule is the "no earlier" — a reader should never hit a code cell before they have been
+told what the notebook is for. Beyond that it is a preference, not a requirement: putting the main
+import cell immediately after the Introduction is ideal, and putting it at the top of the first
+content section is fine. Both are common in our notebooks and neither is worth a revision pass on
+its own. Imports that genuinely belong to one later section (a plotting helper used once, in
+section 4) can stay there.
 
 **Close what you open.** If a notebook instantiates a Dask client that lives for the whole
 notebook, close it at the end with `client.close()`.
 
 **Every notebook needs the footer.** The `## About` section carries author(s), the date the
 notebook was last updated/run, and the citation reminder. Copy it verbatim from the template
-and fill in the fields.
+and fill in the fields. The field labels are `**Authors**:` and `**Last updated on**:` — note the
+colon outside the bold, which is what most of our notebooks already do. We do not pin a date
+format; write it however reads clearly.
 
 ## Logging and the Dask dashboard
 
@@ -115,7 +126,7 @@ axes to the region where the data actually lives rather than showing the full ra
 For a new notebook, or a revision pass over an existing one:
 
 - [ ] Filename uses underscores
-- [ ] Title, then the "In this tutorial we will:" objectives, then the Introduction, then the imports
+- [ ] Title, then the "In this tutorial, we will:" objectives, then the Introduction, then the imports
 - [ ] Logging cell present, at the bottom of / just after the main imports
 - [ ] Dashboard link printed above the bare `client` line, and the link works on the target platform
 - [ ] "Rubin", not "LSST", when naming data releases and data products

--- a/docs/developer/notebook_style_guide.md
+++ b/docs/developer/notebook_style_guide.md
@@ -1,0 +1,130 @@
+# Tutorial notebook style guide
+
+These are the conventions we follow for notebooks under `docs/tutorials/` (including
+`docs/tutorials/pre_executed/`). They are loose standards, not hard rules: the goal is that
+notebooks written by different authors look like they belong to the same documentation set,
+and that a batch revision pass across all of them is mechanical rather than a judgment call
+on every plot.
+
+Start from [`docs/developer/tutorial_template.ipynb`](tutorial_template.ipynb). The template is
+the executable version of this page. Where the two disagree, one of them is wrong — fix it
+rather than picking a side silently.
+
+## Structure
+
+Follow the section order in the template:
+
+1. Title (`# [Notebook Title]`)
+2. "In this tutorial we will:" — a short bulleted list of what the reader will learn
+3. `## Introduction` — what the feature is and, briefly, why it exists
+4. Content sections, numbered (`## 1 - ...`, with `### 1.1 - ...` sub-sections as needed)
+5. `## Close the Dask client` — if a client was opened for the notebook
+6. `## About` footer
+
+**Prose comes before code.** The intro text is the first thing a reader sees, so they know what
+the notebook is for before they hit any setup. Import cells follow it.
+
+**Close what you open.** If a notebook instantiates a Dask client that lives for the whole
+notebook, close it at the end with `client.close()`.
+
+**Every notebook needs the footer.** The `## About` section carries author(s), the date the
+notebook was last updated/run, and the citation reminder. Copy it verbatim from the template
+and fill in the fields.
+
+## Logging and the Dask dashboard
+
+Dask emits a lot of `INFO`-level logging, which drowns out the actual output of a tutorial.
+Raise the threshold at the bottom of the main import cell (or in a cell immediately after it):
+
+```python
+import logging
+
+logging.getLogger().setLevel(logging.WARNING)
+logging.getLogger("distributed").setLevel(logging.WARNING)
+```
+
+Suppressing `INFO` also suppresses the line where Dask announces its dashboard, so print the
+link explicitly when the client is created. Put the `print` *above* the bare `client` line, so
+the link appears before the client repr:
+
+```python
+from dask.distributed import Client
+
+client = Client(n_workers=4, threads_per_worker=1, memory_limit="auto")
+print(f"Dask dashboard: {client.dashboard_link}")
+client
+```
+
+> **Platform note.** `dashboard_link` fills in a template string from environment variables,
+> so it is only correct on the platform the notebook was written for. The snippet above is
+> right on the Rubin Science Platform. Elsewhere — USDF, for instance — `distributed` will
+> warn `Failed to format dashboard link, unknown value: 'JUPYTERHUB_PUBLIC_URL'` and hand back
+> a URL that does not resolve.
+>
+> There is no portable version of this line. Setting
+> `dask.config.set({"distributed.dashboard.link": ...})` only lets you hardcode the correct
+> URL for a platform you already know, so it is a fix per platform, not a general one. Before
+> committing, check that the link you print actually opens where you are running. If it does
+> not, drop the `print` and explain in prose how to reach the dashboard there instead.
+
+## Naming and terminology
+
+**Filenames use underscores**, not hyphens: `catalog_crossmatch_demo.ipynb`, not
+`catalog-crossmatch-demo.ipynb`.
+
+**Say "Rubin", not "LSST"**, when naming a data release or data product — "Rubin DP2", not
+"LSST DP2". This matches how Rubin names its own releases ("Rubin Data Preview 1", "Rubin
+Science Platform"). Applies to prose, plot titles, axis labels, and section headings.
+
+The survey itself is still the Legacy Survey of Space and Time (LSST), and instruments and
+software keep the names they have — LSSTCam, LSST Science Pipelines, `lsst.sphgeom`. The rule
+is about our data, not a global find-and-replace.
+
+## Plotting
+
+The template's lightcurve cell is the reference recipe. The rules below are what we want a
+reader to get out of any plot in the docs; use judgment on the exact numbers, but err toward
+"visible in a rendered doc page at half width" over matplotlib defaults.
+
+**Magnitude axes are inverted.** Brighter objects have lower magnitudes and belong at the top
+of the plot. `plt.gca().invert_yaxis()` — do this every time a magnitude is on an axis.
+
+**Show error bars, with caps.** If the catalog has an error column for the quantity being
+plotted, plot it. Use `capsize` so the bars are readable as error bars rather than as smudges;
+thicken them (`elinewidth`) so they survive the rendered page.
+
+**Size for legibility.** Axis labels, tick labels, and legends should be large; markers should
+be big enough to see against their error bars. The matplotlib defaults are too small for
+documentation. Label both axes, with units where they exist.
+
+**Do not silently drop points.** If you cut the axis range to make the interesting region
+visible, show the excluded points as downward-pointing arrows at the edge (`lolims`/`uplims`
+on `errorbar`, or a marker like `matplotlib.markers.CARETDOWNBASE`) so the reader knows they
+exist. A lightcurve with one or two outlying epochs is usually better served by a tight zoom
+plus arrows than by a full-range plot where the real variation is a flat line.
+
+**Dense scatter plots should not be scatter plots.** Above a few thousand points, overplotting
+hides the structure. Use `hexbin` or a 2D histogram instead, and consider a log color scale
+when the density spans orders of magnitude.
+
+**Prefer high-contrast colormaps.** `magma` or `viridis` over the matplotlib default. Zoom the
+axes to the region where the data actually lives rather than showing the full range.
+
+## Checklist
+
+For a new notebook, or a revision pass over an existing one:
+
+- [ ] Filename uses underscores
+- [ ] Title, then the "In this tutorial we will:" objectives, then the Introduction, then the imports
+- [ ] Logging cell present, at the bottom of / just after the main imports
+- [ ] Dashboard link printed above the bare `client` line, and the link works on the target platform
+- [ ] "Rubin", not "LSST", when naming data releases and data products
+- [ ] Plotting:
+    - [ ] Magnitude axes inverted
+    - [ ] Error bars present and capped where error columns exist
+    - [ ] Labels and markers legible at documentation size
+    - [ ] Points outside a cut shown as arrows, not dropped
+    - [ ] Dense scatters plotted as hexbin/2D histogram
+    - [ ] High-contrast colormap (`magma`, `viridis`) rather than the matplotlib default
+- [ ] `## About` footer with author, last-updated date, citation link
+- [ ] Any long-lived client is closed

--- a/docs/developer/tutorial_template.ipynb
+++ b/docs/developer/tutorial_template.ipynb
@@ -13,7 +13,7 @@
    "id": "6089e920",
    "metadata": {},
    "source": [
-    "In this tutorial we will:\n",
+    "In this tutorial, we will:\n",
     "- [List of things you can learn here]"
    ]
   },
@@ -32,7 +32,7 @@
    "id": "d15b80c5",
    "metadata": {},
    "source": [
-    "## Open a catalog"
+    "## 1. Open a catalog"
    ]
   },
   {
@@ -92,7 +92,7 @@
    "id": "41c3abff",
    "metadata": {},
    "source": [
-    "## Plotting lightcurves\n",
+    "## 2. Plotting lightcurves\n",
     "\n",
     "Standard recipe for a single-object lightcurve: `errorbar` of magnitude vs. MJD with an\n",
     "inverted y-axis. Adapt the column names to your catalog. "
@@ -122,20 +122,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "84137686",
-   "metadata": {},
-   "source": [
-    "## 1 - [Interesting thing 1]\n",
-    "\n",
-    "[Place markdown and code cells in this and following sections as needed]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "67f4345a",
    "metadata": {},
    "source": [
-    "## 2 - [Interesting thing 2]"
+    "## 3. [A notebook section]"
    ]
   },
   {
@@ -143,7 +133,7 @@
    "id": "24a2f5bf",
    "metadata": {},
    "source": [
-    "### 2.1 - [Sub-section 1, if applicable]"
+    "### 3.1 [Sub-section 1, if applicable]"
    ]
   },
   {
@@ -151,7 +141,7 @@
    "id": "383a715e",
    "metadata": {},
    "source": [
-    "### 2.2 - [Sub-section 2, if applicable]"
+    "### 3.2 [Sub-section 2, if applicable]"
    ]
   },
   {
@@ -178,9 +168,9 @@
    "metadata": {},
    "source": [
     "## About\n",
-    "**Author(s):** [Your name]\n",
+    "**Authors**: [Your name]\n",
     "\n",
-    "**Last updated on:** [Date]\n",
+    "**Last updated on**: [Date]\n",
     "\n",
     "If you use lsdb for published research, please cite following [instructions](https://docs.lsdb.io/en/stable/citation.html)."
    ]

--- a/docs/tutorial_toc/toc_science.rst
+++ b/docs/tutorial_toc/toc_science.rst
@@ -6,7 +6,7 @@ Notebooks going over specific, contributed scientific example use cases
 .. toctree::
     :maxdepth: 1
 
-    Cross-match ZTF BTS and NGC </tutorials/pre_executed/ztf_bts-ngc>
+    Cross-match ZTF BTS and NGC </tutorials/pre_executed/ztf_bts_ngc>
     Import and cross-match DES and Gaia </tutorials/pre_executed/des-gaia>
     Get a list of light-curves from ZTF and PS1 </tutorials/pre_executed/zubercal-ps1-snad>
     Cross-match Rubin DP1 and Gaia DR3 with epoch propagation </tutorials/pre_executed/dp1-gaia-epoch-prop>

--- a/docs/tutorials/exporting_results.ipynb
+++ b/docs/tutorials/exporting_results.ipynb
@@ -6,7 +6,26 @@
    "source": [
     "# Exporting results\n",
     "\n",
-    "You can save the results of your workflow to disk, in parquet, using the ``Catalog.write_catalog`` call.\n",
+    "In this tutorial, we will:\n",
+    "- write the result of a workflow to disk as a HATS catalog with `Catalog.write_catalog`\n",
+    "- go over the required and optional arguments, including writing to remote storage\n",
+    "- look at the directory structure the call produces"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "You can save the results of your workflow to disk, in parquet, using the ``Catalog.write_catalog`` call."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Arguments\n",
     "\n",
     "You must provide:\n",
     "- A `base_catalog_path`, which is the output path for your catalog directory.\n",
@@ -18,9 +37,14 @@
     "- Whether to `resume` a previously interrupted write to the same directory. By default, resumption is disabled.\n",
     "- Whether to `overwrite` the contents of the specified directory. By default, overwriting is disabled.\n",
     "\n",
-    "For more available arguments, please read the [method's signature](https://docs.lsdb.io/en/latest/reference/api/lsdb.catalog.Catalog.write_catalog.html).\n",
-    "\n",
-    "### Example\n",
+    "For more available arguments, please read the [method's signature](https://docs.lsdb.io/en/latest/reference/api/lsdb.catalog.Catalog.write_catalog.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Example\n",
     "\n",
     "We planned the crossmatching of Gaia with ZTF in the following `gaia_x_ztf` Catalog:\n",
     "\n",
@@ -39,7 +63,14 @@
     "```\n",
     "cloud_path = UPath(f\"{bucket_name}/gaia_x_ztf\", <your storage_options>)\n",
     "gaia_x_ztf.write_catalog(base_catalog_path=cloud_path, catalog_name=\"gaia_x_ztf\")\n",
-    "```\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. The catalog on disk\n",
     "\n",
     "The HATS catalog on disk follows a well-defined directory structure:\n",
     "```\n",

--- a/docs/tutorials/lazy_operations.ipynb
+++ b/docs/tutorials/lazy_operations.ipynb
@@ -88,7 +88,7 @@
    "id": "8cf6067746a17db2",
    "metadata": {},
    "source": [
-    "## Operating on the Catalog\n",
+    "## 1. Operating on the Catalog\n",
     "\n",
     "Once we have a catalog object, we can start planning operations on it. In the rest of the tutorials, we'll look deeper into exactly what kind of operations you can do with a catalog. The catalog is based on pandas `DataFrames` so you'll see some functions that work the same as in pandas, such as `columns`, `dtypes`, `query`, and selecting columns or filtering with `[]`."
    ]
@@ -121,7 +121,7 @@
    "id": "fc401709e9c59a64",
    "metadata": {},
    "source": [
-    "## Previewing part of the data\n",
+    "## 2. Previewing part of the data\n",
     "\n",
     "Computing an entire catalog will result in loading all of its data into memory on your local machine after the workers have computed it, which is expensive and may lead to out-of-memory issues.\n",
     "\n",
@@ -133,7 +133,7 @@
    "id": "7e23fe9dd7ee87d2",
    "metadata": {},
    "source": [
-    "### Making a Dask client\n",
+    "### 2.1 Making a Dask client\n",
     "\n",
     "LSDB is built on top of the [Dask](https://www.dask.org) framework, which allows the pipelines to be executed on distributed workers. Before we do anything that executes the pipeline such as `head()` or `compute()`, we recommend making a dask client."
    ]
@@ -216,7 +216,7 @@
    "id": "cb01bd4d0a456faa",
    "metadata": {},
    "source": [
-    "### Closing the Dask client\n"
+    "## Close the Dask client\n"
    ]
   },
   {

--- a/docs/tutorials/pre_executed/rubin_dp2_starter.ipynb
+++ b/docs/tutorials/pre_executed/rubin_dp2_starter.ipynb
@@ -10,6 +10,29 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this tutorial, we will:\n",
+    "- open an EDP2 catalog from the Rubin Science Platform and inspect its sky coverage\n",
+    "- plot pixel maps and source density\n",
+    "- apply a function across partitions with `map_partitions`\n",
+    "- compute a catalog, write it to disk, and read it back\n",
+    "- cross-match EDP2 against DES DR2 and plot the result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "This is a condensed reference for working with the Rubin Early Data Preview 2 (EDP2) HATS catalogs on the Rubin Science Platform: short, mostly self-contained cells covering the operations you are likely to reach for first. It is meant to be copied from rather than read start to finish.\n",
+    "\n",
+    "For a guided walkthrough of the same material, see the EDP2 Beginner Tutorial."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "25b87d1d-0203-4e86-b9de-1971b14024b7",
    "metadata": {
     "execution": {
@@ -29,7 +52,7 @@
    "id": "3ec180e3-9464-4b30-b6f4-65a4d4556bf4",
    "metadata": {},
    "source": [
-    "## Setup"
+    "## 1. Setup"
    ]
   },
   {
@@ -130,7 +153,7 @@
    "id": "e7285a78-8444-4336-99cc-c38252d6fb39",
    "metadata": {},
    "source": [
-    "## Open catalog"
+    "## 2. Open catalog"
    ]
   },
   {
@@ -310,7 +333,7 @@
    "id": "cb20d64f-35ce-4da4-8be3-e1e4e294676c",
    "metadata": {},
    "source": [
-    "## Plot skymaps"
+    "## 3. Plot skymaps"
    ]
   },
   {
@@ -414,7 +437,7 @@
    "id": "fe696f6a-6254-4931-bebe-46994f52a443",
    "metadata": {},
    "source": [
-    "## Map a function"
+    "## 4. Map a function"
    ]
   },
   {
@@ -450,7 +473,7 @@
    "id": "cf4fdb8d-37b3-4dfe-b72e-cfb7d7114ffd",
    "metadata": {},
    "source": [
-    "## Compute catalog"
+    "## 5. Compute catalog"
    ]
   },
   {
@@ -776,7 +799,7 @@
    "id": "aad61497-e2ce-41bb-bedc-38bbab711120",
    "metadata": {},
    "source": [
-    "## Crossmatch"
+    "## 6. Crossmatch"
    ]
   },
   {
@@ -1332,6 +1355,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Close the Dask client"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 24,
    "id": "a265b038-58a1-47bb-b9e4-0992e7b8e6f4",
@@ -1359,7 +1389,7 @@
     "\n",
     "**Authors**: Heather Sestili\n",
     "\n",
-    "**Last run:** July 27, 2026\n",
+    "**Last run**: July 27, 2026\n",
     "\n",
     "If you use `lsdb` for published research, please cite following [instructions](https://docs.lsdb.io/en/stable/citation.html)."
    ]

--- a/docs/tutorials/pre_executed/types_of_crossmatch.ipynb
+++ b/docs/tutorials/pre_executed/types_of_crossmatch.ipynb
@@ -14,6 +14,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "When you crossmatch two catalogs, the `how` argument decides what happens to rows that find no counterpart. `how='inner'` keeps only the rows that matched in both catalogs; `how='left'` keeps every row of the left catalog and fills the right catalog's columns with `<NA>` where nothing matched. The choice changes both the row count and the column values of the result, so it is worth being deliberate about it.\n",
+    "\n",
+    "The same rule applies to `crossmatch_nested()`, covered at the end."
+   ]
+  },
+  {
    "cell_type": "raw",
    "metadata": {
     "raw_mimetype": "text/restructuredtext"
@@ -1770,7 +1781,7 @@
    "source": [
     "## About\n",
     "\n",
-    "**Author(s)**: Sean McGuire\n",
+    "**Authors**: Sean McGuire\n",
     "\n",
     "**Last updated on**: 19 May 2026\n",
     "\n",

--- a/docs/tutorials/pre_executed/ztf_bts_ngc.ipynb
+++ b/docs/tutorials/pre_executed/ztf_bts_ngc.ipynb
@@ -2,14 +2,26 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "baf860d14e6e9d0d",
    "metadata": {},
    "source": [
     "# Cross-match ZTF BTS and NGC\n",
     "\n",
-    "In this notebook, we demonstrate how to cross-match [Zwicky Transient Facility](https://ztf.caltech.edu) (ZTF) [Bright Transient Survey](https://sites.astro.caltech.edu/ztf/bts) (BTS) and [New General Catalogue](https://en.wikipedia.org/wiki/New_General_Catalogue) (NGC) using LSDB.\n",
+    "In this tutorial, we will:\n",
+    "- download the ZTF Bright Transient Survey (BTS) catalog over HTTP and the New General Catalogue (NGC) via `astroquery`\n",
+    "- load both into LSDB from their original survey formats, rather than from pre-built HATS catalogs\n",
+    "- plan and run a cross-match between them on a Dask cluster\n",
+    "- plot a PanSTARRS cutout of a matched supernova host galaxy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
     "\n",
-    "We are using the original survey datasets, as presented by the original survey providers, instead of catalogs that have already been converted to HATS format."
+    "This notebook cross-matches [Zwicky Transient Facility](https://ztf.caltech.edu) (ZTF) [Bright Transient Survey](https://sites.astro.caltech.edu/ztf/bts) (BTS) transients against the [New General Catalogue](https://en.wikipedia.org/wiki/New_General_Catalogue) (NGC) of galaxies, to find which nearby galaxies host known bright transients.\n",
+    "\n",
+    "It starts from the original survey datasets as the survey providers publish them, rather than from catalogs already converted to HATS. That makes it a useful example of getting arbitrary tabular data into LSDB."
    ]
   },
   {
@@ -65,7 +77,7 @@
    "source": [
     "## 1. Download data\n",
     "\n",
-    "### 1.1. Download ZTF BTS and convert coordinates to degrees\n",
+    "### 1.1 Download ZTF BTS and convert coordinates to degrees\n",
     "\n",
     "We download the ZTF BTS data via HTTP, but must first convert the coordinates into degrees before loading as LSDB catalogs.\n",
     "\n",
@@ -285,7 +297,7 @@
    "id": "2789dc15c2f46954",
    "metadata": {},
    "source": [
-    "### 1.2. Download NGC with `astroquery`\n",
+    "### 1.2 Download NGC with `astroquery`\n",
     "\n",
     "Please install astroquery first with `pip install astroquery` or `conda install -c conda-forge astroquery`."
    ]


### PR DESCRIPTION
# Tutorial notebook style guide: cross-check + pilot application

## What happened

Last week I wrote up my notes on how our tutorial notebooks *should* look into
`docs/developer/notebook_style_guide.md`. It had never been checked against the notebooks it
describes.

This PR does that check, then applies the guide to five notebooks to see whether it holds up in
practice.

The check was worth doing: **six of the guide's rules were wrong or ambiguous.** In every case the
notebooks were already consistent and the guide was the outlier — so the guide changed, not the
notebooks. Following it as written would have meant editing 30+ notebooks to match conventions that
one or two files used.

## 1. Changes to the guide and template

| # | Rule | Guide said | Notebooks actually do | Action |
|---|---|---|---|---|
| 1 | Section numbering | `## 1 - Title` | `## 1. Title` (**120** vs 3) | Guide changed |
| 2 | Sub-section numbering | `### 1.1 - Title` | `### 1.1 Title` (29) vs `### 1.1. Title` (28) — no majority | Editorial call: no trailing dot |
| 3 | Objectives line | `In this tutorial we will:` | `In this tutorial, we will:` (**33** vs 1) | Guide changed |
| 4 | About label | `**Author(s):**` | `**Authors**:` (34 vs 6), colon *outside* the bold (33 vs 7) | Template + guide changed |
| 5 | Date format | silent | `January 19, 2026` (22), `Jan 19, 2026` (15), `19 May 2026` (3) | Guide now explicitly declines to pin one |
| 6 | Imports placement | "import cells follow [the intro]" — unusable as a checklist item | split 20 / 11 | Rewritten as descriptive: **no earlier than the Introduction**, as early after as practical. Both existing placements are compliant. |

Also fixed a **template bug**: `tutorial_template.ipynb` put two content sections *unnumbered* ahead
of the numbered `## 1.` placeholder, so anyone starting from the template produced a notebook that
failed the guide's own checklist. Its sections are now one continuous sequence.

Net effect: the eventual full pass drops from "renumber 32 notebooks" to "renumber
`dask_client.ipynb`, and drop a trailing dot in 28 sub-headings."

## 2. Pilot: five notebooks

Chosen to span every axis that could make the guide behave differently — not to be representative.

| Notebook | Diff | What changed |
|---|---|---|
| `lazy_operations.ipynb` | +4/−4 | Numbered 2 sections + 1 sub-section; promoted `### Closing the Dask client` to top-level `## Close the Dask client` |
| `exporting_results.ipynb` | +33/−8 | Split 1 prose cell into 5: objectives, `## Introduction`, 3 numbered sections |
| `types_of_crossmatch.ipynb` | +12/−1 | Added `## Introduction`; `**Author(s)**:` → `**Authors**:` |
| `ztf_bts-ngc.ipynb` → `ztf_bts_ngc.ipynb` | +18/−6 | Renamed; objectives rewritten to the standard form; added `## Introduction`; de-dotted `### 1.1.` / `### 1.2.` |
| `rubin_dp2_starter.ipynb` | +37/−7 | Objectives + `## Introduction`; 6 sections numbered; `## Close the Dask client` heading; colon on `**Last run**:` |

**No code cells were edited in `pre_executed/`.** Those notebooks ship with saved outputs and
`nbsphinx.execute: "never"`; editing code there would leave the published page showing an old figure
beside new code. Verified: all three have **byte-identical code cells and outputs** before and after.

### What applying it taught us

- **Renames need a repo-wide grep, not a `tutorial_toc/` grep.** `ztf_bts-ngc` had a second inbound
  `:doc:` reference in `docs/data-access/vizier.rst` — a hard Sphinx error had it been missed.
- **The guide doesn't say where `## Close the Dask client` goes**, or pin its wording ("Close" vs
  "Closing" already varies).
- **The guide says nothing about `raw` cells** (`.. nbinfo::` admonitions), which interleave with the
  markdown structure.

## Deliberately not done

- **Logging level + Dask dashboard printing** — frozen pending a decision on whether to keep these
  rules. Nothing applied, removed, or reformatted. Note the two groups differ: all 8 dashboard-printing
  notebooks are `pre_executed/`, so their link was captured once on RSP. The 10 executed notebooks run
  on ReadTheDocs, where `dashboard_link` would bake a dead URL into the published page.
- **The Plotting section — entirely untested.** Every matplotlib plot in the docs lives in
  `pre_executed/`, and we can't re-execute those right now. Needs a follow-up from someone with data
  access.
- **The other 6 hyphenated filenames** (`des-gaia`, `ztf-alerts-sne`, `zubercal-ps1-snad`,
  `rubin_dp2-da-white-dwarfs`, `dp1-gaia-epoch-prop`, `access.pyvo`) — renaming changes published
  `docs.lsdb.io` URLs, so it deserves its own PR.
- **Grammar/copyedit fixes** (e.g. `## 4. Make some plot`) — the guide has no copyedit rule and
  inventing one mid-pass makes the revision unbounded.

## Follow-ups

- Decide the logging / dashboard rules (RTD-vs-RSP split is the crux)
- Add an `## About` section to `dp1-gaia-epoch-prop.ipynb` and `explode_lightcurves.ipynb` — the only
  two missing one
- Validate the Plotting section, with re-execution
- Normalize 28 notebooks from `### 1.1.` → `### 1.1`, and `dask_client.ipynb` from `## 1 -` → `## 1.`
- Rename the remaining 6 hyphenated notebooks
- Consider naming `with Client(...)` as the preferred form — 7 notebooks already use it

Full survey of all 43 notebooks in a comment below.
