### PR TITLE
Print missing ranges in the catalog statistics

### DIFF
--- a/src/lsdb/catalog/dataset/repr.py
+++ b/src/lsdb/catalog/dataset/repr.py
@@ -156,7 +156,7 @@ def _make_pixel_range(index, stats_by_pixel, min_col, max_col, dtype) -> list[st
     values = []
     for pixel in index:
         row = stats_by_pixel.get(pixel)
-        if row is None or pd.isna(row[min_col]) or pd.isna(row[max_col]):
+        if row is None:
             values.append("...")
             continue
         min_str, max_str = formatter(row[min_col]), formatter(row[max_col])
@@ -165,23 +165,34 @@ def _make_pixel_range(index, stats_by_pixel, min_col, max_col, dtype) -> list[st
 
 
 def _get_formatter(dtype):
-    """Return a function to format a given scalar of dtype"""
+    """Return a function to format a given scalar of dtype.
+
+    Missing values are printed as they come, e.g. 'nan' for floats and 'None' for null objects.
+    """
     if pd.api.types.is_bool_dtype(dtype):
-        return lambda v: str(bool(v))
+        fmt_value = _fmt_bool
+    elif pd.api.types.is_float_dtype(dtype):
+        fmt_value = _fmt_float
+    elif pd.api.types.is_integer_dtype(dtype):
+        fmt_value = _fmt_int
+    else:
+        fmt_value = _fmt_str
+    return lambda v: str(v) if pd.isna(v) else fmt_value(v)
 
-    if pd.api.types.is_float_dtype(dtype):
-        return lambda v: f"{float(v):.4g}"
 
-    if pd.api.types.is_integer_dtype(dtype):
+def _fmt_bool(v) -> str:
+    return str(bool(v))
 
-        def fmt_int(v):
-            s = int_comma(int(v))
-            return s if len(s) <= _MAX_STR_WIDTH else f"{int(v):.4g}"
 
-        return fmt_int
+def _fmt_float(v) -> str:
+    return f"{float(v):.4g}"
 
-    def fmt_str(v):
-        s = str(v)
-        return s if len(s) <= _MAX_STR_WIDTH else s[: _MAX_STR_WIDTH - 1] + "»"
 
-    return fmt_str
+def _fmt_int(v) -> str:
+    s = int_comma(int(v))
+    return s if len(s) <= _MAX_STR_WIDTH else f"{int(v):.4g}"
+
+
+def _fmt_str(v) -> str:
+    s = str(v)
+    return s if len(s) <= _MAX_STR_WIDTH else s[: _MAX_STR_WIDTH - 1] + "»"

--- a/tests/lsdb/catalog/test_repr.py
+++ b/tests/lsdb/catalog/test_repr.py
@@ -1,7 +1,10 @@
+import numpy as np
+import pandas as pd
+import pyarrow as pa
 import pytest
 
 import lsdb
-from lsdb.catalog.dataset.repr import CatalogRepr
+from lsdb.catalog.dataset.repr import CatalogRepr, _make_pixel_range
 
 
 def _assert_statistics(catalog, *, shown):
@@ -181,3 +184,15 @@ def test_shows_statistics_except_for_nested_columns(small_sky_with_nested_source
 
     # A catalog of only nested columns has no statistics.
     assert catalog_repr._pixel_stats(catalog.nested_columns, []) is None
+
+
+def test_missing_min_max_in_pixel_range():
+    min_col, max_col = "id: min_value", "id: max_value"
+    stats_by_pixel = {
+        "nan": {min_col: None, max_col: np.nan},
+        "none_and_inf": {min_col: 0, max_col: np.inf},
+        "na_and_nat": {min_col: pd.NA, max_col: pd.NaT},
+    }
+    index = [*stats_by_pixel, "no_stats"]
+    values = _make_pixel_range(index, stats_by_pixel, min_col, max_col, pa.int64())
+    assert values == ["None..nan", "0..inf", "<NA>..NaT", "..."]

--- a/tests/lsdb/catalog/test_repr.py
+++ b/tests/lsdb/catalog/test_repr.py
@@ -189,8 +189,8 @@ def test_shows_statistics_except_for_nested_columns(small_sky_with_nested_source
 def test_missing_min_max_in_pixel_range():
     min_col, max_col = "id: min_value", "id: max_value"
     stats_by_pixel = {
-        "nan": {min_col: None, max_col: np.nan},
-        "none_and_inf": {min_col: 0, max_col: np.inf},
+        "none_and_nan": {min_col: None, max_col: np.nan},
+        "zero_and_inf": {min_col: 0, max_col: np.inf},
         "na_and_nat": {min_col: pd.NA, max_col: pd.NaT},
     }
     index = [*stats_by_pixel, "no_stats"]


### PR DESCRIPTION
In the Catalog representation, when the statistics are requested, a missing min/max value for a pixel was represented with the placeholder, `...`. This PR prints missing values as they come from `per_partition_statistics` (e.g. a float column with missing stats will now show `nan`). The placeholder is still shown for pixels and columns that have no statistics at all.