### PR TITLE
Combine both catalog names in join()/join_nested() default output name

### DIFF
--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -1073,7 +1073,7 @@ class Catalog(HealpixDataset):
             between pixels and individual rows.
         suffixes : tuple[str,str]
             Suffixes to apply to the columns of each table
-        output_catalog_name : str
+        output_catalog_name : str, default {left_name}_x_{right_name}
             The name of the resulting catalog to be stored in metadata
         suffix_method : str, default "all_columns"
             Method to use to add suffixes to columns. Options are:
@@ -1151,7 +1151,7 @@ class Catalog(HealpixDataset):
             )
 
         if output_catalog_name is None:
-            output_catalog_name = self.hc_structure.catalog_info.catalog_name
+            output_catalog_name = f"{self.name}_x_{other.name}"
 
         new_catalog_info = create_merged_catalog_info(
             self,
@@ -1202,7 +1202,7 @@ class Catalog(HealpixDataset):
         nested_column_name : str
             The name of the nested column in the resulting dataframe storing the
             joined columns in the right catalog. (Default: name of right catalog)
-        output_catalog_name : str
+        output_catalog_name : str, default {left_name}_x_{right_name}
             The name of the resulting catalog to be stored in metadata
         how : str, {'inner', 'left'}, default 'inner'
             How to handle the alignment
@@ -1229,7 +1229,7 @@ class Catalog(HealpixDataset):
         )
 
         if output_catalog_name is None:
-            output_catalog_name = self.hc_structure.catalog_info.catalog_name
+            output_catalog_name = f"{self.name}_x_{other.name}"
 
         new_catalog_info = self.hc_structure.catalog_info.copy_and_update(
             catalog_name=output_catalog_name, total_rows=None

--- a/tests/lsdb/catalog/test_join.py
+++ b/tests/lsdb/catalog/test_join.py
@@ -61,6 +61,21 @@ def test_small_sky_join_small_sky_order1(small_sky_catalog, small_sky_order1_cat
     assert joined.est_size() is None
 
 
+def test_small_sky_join_default_output_catalog_name(small_sky_catalog, small_sky_order1_catalog):
+    # The default output catalog name should combine both catalog names, like crossmatch's `a_x_b`,
+    # rather than silently keeping only the left catalog's name.
+    with pytest.warns(match="margin"):
+        joined = small_sky_catalog.join(small_sky_order1_catalog, left_on="id", right_on="id")
+    assert joined.name == f"{small_sky_catalog.name}_x_{small_sky_order1_catalog.name}"
+    assert joined.hc_structure.catalog_name == f"{small_sky_catalog.name}_x_{small_sky_order1_catalog.name}"
+
+    with pytest.warns(match="margin"):
+        joined_explicit = small_sky_catalog.join(
+            small_sky_order1_catalog, left_on="id", right_on="id", output_catalog_name="my_custom_name"
+        )
+    assert joined_explicit.name == "my_custom_name"
+
+
 def test_small_sky_join_overlapping_suffix(small_sky_catalog, small_sky_order1_catalog, helpers):
     suffixes = ("_a", "_b")
     with pytest.warns(match="margin"):
@@ -382,6 +397,29 @@ def test_join_nested(small_sky_catalog, small_sky_order1_source_with_margin):
             check_column_type=False,
             check_index_type=False,
         )
+
+
+def test_join_nested_default_output_catalog_name(small_sky_catalog, small_sky_order1_source_with_margin):
+    # The default output catalog name should combine both catalog names, like crossmatch's `a_x_b`,
+    # rather than silently keeping only the left catalog's name.
+    joined = small_sky_catalog.join_nested(
+        small_sky_order1_source_with_margin,
+        left_on="id",
+        right_on="object_id",
+        nested_column_name="sources",
+    )
+    expected_name = f"{small_sky_catalog.name}_x_{small_sky_order1_source_with_margin.name}"
+    assert joined.name == expected_name
+    assert joined.hc_structure.catalog_name == expected_name
+
+    joined_explicit = small_sky_catalog.join_nested(
+        small_sky_order1_source_with_margin,
+        left_on="id",
+        right_on="object_id",
+        nested_column_name="sources",
+        output_catalog_name="my_custom_name",
+    )
+    assert joined_explicit.name == "my_custom_name"
 
 
 def test_join_nested_how_left(small_sky_order1_catalog, small_sky_order1_source_with_margin, helpers):


### PR DESCRIPTION
## Summary

Fixes #397.

`Catalog.join()` and `Catalog.join_nested()` defaulted `output_catalog_name` to just the left catalog's name (`self.hc_structure.catalog_info.catalog_name`) when `output_catalog_name` was not explicitly provided. This silently drops the right catalog's name from the result, unlike `crossmatch()`/`crossmatch_nested()` and `merge_asof()`, which already combine both catalog names into the default name (crossmatch uses `"{left_name}_x_{right_name}"`, as documented in its own docstring).

## Fix

- Changed the default `output_catalog_name` in `join()` and `join_nested()` (`src/lsdb/catalog/catalog.py`) to `f"{self.name}_x_{other.name}"`, matching the existing crossmatch convention.
- Updated the docstrings for both methods to document the new default (`str, default {left_name}_x_{right_name}`), matching how crossmatch's docstring already documents its default.

## Tests

Added `test_small_sky_join_default_output_catalog_name` and `test_join_nested_default_output_catalog_name` in `tests/lsdb/catalog/test_join.py`, which check both the new default name and that an explicitly passed `output_catalog_name` is still respected.

## Verification

- Ran the two new tests — pass with the fix.
- Reverted the fix locally (restoring the old left-only-name default) and reran the same two tests: both fail, reproducing the exact bug reported in the issue (e.g. `assert 'small_sky' == 'small_sky_x_small_sky_order1'`).
- Reran the surrounding join/join_nested/association-join tests in `tests/lsdb/catalog/test_join.py` (`test_join_wrong_columns`, `test_join_wrong_suffixes`, `test_small_sky_join_small_sky_order1`, `test_small_sky_join_overlapping_suffix`, `test_join_nested`, `test_join_nested_how_left`, `test_join_nested_invalid_how`, `test_join_association`, `test_join_association_overlapping_suffix`) to confirm no other behavior changed.

Signed-off-by: agu2347 <agu2347@users.noreply.github.com>