### PR TITLE
Fix join() output catalog name to combine both catalog names

### DIFF
--- a/src/lsdb/catalog/catalog.py
+++ b/src/lsdb/catalog/catalog.py
@@ -1073,7 +1073,7 @@ class Catalog(HealpixDataset):
             between pixels and individual rows.
         suffixes : tuple[str,str]
             Suffixes to apply to the columns of each table
-        output_catalog_name : str
+        output_catalog_name : str, default {left_name}_join_{right_name}
             The name of the resulting catalog to be stored in metadata
         suffix_method : str, default "all_columns"
             Method to use to add suffixes to columns. Options are:
@@ -1151,7 +1151,7 @@ class Catalog(HealpixDataset):
             )
 
         if output_catalog_name is None:
-            output_catalog_name = self.hc_structure.catalog_info.catalog_name
+            output_catalog_name = f"{self.name}_join_{other.name}"
 
         new_catalog_info = create_merged_catalog_info(
             self,
@@ -1202,7 +1202,7 @@ class Catalog(HealpixDataset):
         nested_column_name : str
             The name of the nested column in the resulting dataframe storing the
             joined columns in the right catalog. (Default: name of right catalog)
-        output_catalog_name : str
+        output_catalog_name : str, default {left_name}_join_{right_name}
             The name of the resulting catalog to be stored in metadata
         how : str, {'inner', 'left'}, default 'inner'
             How to handle the alignment
@@ -1229,7 +1229,7 @@ class Catalog(HealpixDataset):
         )
 
         if output_catalog_name is None:
-            output_catalog_name = self.hc_structure.catalog_info.catalog_name
+            output_catalog_name = f"{self.name}_join_{other.name}"
 
         new_catalog_info = self.hc_structure.catalog_info.copy_and_update(
             catalog_name=output_catalog_name, total_rows=None

--- a/tests/lsdb/catalog/test_join.py
+++ b/tests/lsdb/catalog/test_join.py
@@ -175,6 +175,37 @@ def test_small_sky_join_default_columns(
     helpers.assert_default_columns_in_columns(joined)
 
 
+def test_join_default_output_catalog_name(small_sky_catalog, small_sky_order1_catalog):
+    """The joined catalog's name should combine both input names, mirroring the
+    `{left}_x_{right}` convention used by `crossmatch`, instead of only keeping the
+    left catalog's name (see GitHub issue #397)."""
+    with pytest.warns(match="margin"):
+        joined = small_sky_catalog.join(small_sky_order1_catalog, left_on="id", right_on="id")
+    assert joined.name == f"{small_sky_catalog.name}_join_{small_sky_order1_catalog.name}"
+    assert joined.name != small_sky_catalog.name
+    assert joined.hc_structure.catalog_info.catalog_name == joined.name
+
+
+def test_join_explicit_output_catalog_name(small_sky_catalog, small_sky_order1_catalog):
+    """An explicitly provided `output_catalog_name` should still take precedence."""
+    with pytest.warns(match="margin"):
+        joined = small_sky_catalog.join(
+            small_sky_order1_catalog, left_on="id", right_on="id", output_catalog_name="my_custom_name"
+        )
+    assert joined.name == "my_custom_name"
+
+
+def test_join_association_default_output_catalog_name(
+    small_sky_catalog, small_sky_order1_source_collection_catalog, small_sky_to_o1source_catalog
+):
+    """The `through` (association-based) join path should also combine both catalog names."""
+    joined = small_sky_catalog.join(
+        small_sky_order1_source_collection_catalog, through=small_sky_to_o1source_catalog
+    )
+    assert joined.name == f"{small_sky_catalog.name}_join_{small_sky_order1_source_collection_catalog.name}"
+    assert joined.name != small_sky_catalog.name
+
+
 def test_join_wrong_columns(small_sky_catalog, small_sky_order1_catalog):
     with pytest.raises(ValueError):
         small_sky_catalog.join(small_sky_order1_catalog, left_on="bad", right_on="id")
@@ -382,6 +413,20 @@ def test_join_nested(small_sky_catalog, small_sky_order1_source_with_margin):
             check_column_type=False,
             check_index_type=False,
         )
+
+
+def test_join_nested_default_output_catalog_name(small_sky_catalog, small_sky_order1_source_with_margin):
+    """The joined catalog's name should combine both input names rather than only keeping
+    the left catalog's name (see GitHub issue #397)."""
+    joined = small_sky_catalog.join_nested(
+        small_sky_order1_source_with_margin,
+        left_on="id",
+        right_on="object_id",
+        nested_column_name="sources",
+    )
+    assert joined.name == f"{small_sky_catalog.name}_join_{small_sky_order1_source_with_margin.name}"
+    assert joined.name != small_sky_catalog.name
+    assert joined.hc_structure.catalog_info.catalog_name == joined.name
 
 
 def test_join_nested_how_left(small_sky_order1_catalog, small_sky_order1_source_with_margin, helpers):


### PR DESCRIPTION
Fixes #397.

`Catalog.join()` and `Catalog.join_nested()` defaulted `output_catalog_name` to the left catalog's name only, so a join result carried no trace of the right catalog. This changes the default to `f"{left}_join_{right}"`, following the convention already used by `crossmatch` (`_x_`) and `merge_asof` (`_merge_asof_`).

Covers the plain join path, the association (`through=`) path, and `join_nested()`. An explicit `output_catalog_name=` still takes precedence.

## Testing

`tests/lsdb/catalog/test_join.py`: 25 passed, including 4 new tests. I confirmed the new tests actually catch the bug by reverting the source change — 3 of the 4 fail with the old left-only name.

## Notes

- I used `_join_` spelled out rather than reusing crossmatch's `_x_` infix, so join results stay visually distinct from crossmatch results. Easy to switch if you'd rather be consistent with `_x_`.
- This changes the default output name, which is the behavior change #397 asks for.
- `merge_map()` has the same left-only-name pattern, but I left it alone as out of scope here. Glad to follow up separately if you want it changed too.

## Disclosure

This change was prepared with AI assistance (Claude Code). The tests above were run locally.
