### PR TITLE
Support local schedulers and efficient per-pixel graphs

### DIFF
--- a/LSDB_GUIDE.md
+++ b/LSDB_GUIDE.md
@@ -359,6 +359,10 @@ from lsdb.streams import CatalogStream
 stream = CatalogStream(cat, partitions_per_chunk=10)
 for chunk in stream:
     process(chunk)
+
+# Compute a single partition in the current process, without a Dask client
+(partition,) = cat.to_delayed(pixels=[pixel])
+df = partition.compute(scheduler="synchronous")
 ```
 
 ### Compute and write results

--- a/LSDB_GUIDE.md
+++ b/LSDB_GUIDE.md
@@ -381,6 +381,9 @@ with Client(
   
   # Compute to memory (use only for small results)
   df = cat.compute()
+
+# `compute()` and `write_catalog()` also run without a client, on the scheduler set in the Dask
+# configuration or passed explicitly, e.g. `cat.compute(scheduler="synchronous")`.
 ```
 
 #### CRITICAL

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -20,7 +20,7 @@ from dask import threaded
 from dask.base import get_scheduler
 from dask.delayed import Delayed
 from deprecated import deprecated  # type: ignore
-from distributed import as_completed
+from distributed import Client, as_completed
 from hats.catalog.healpix_dataset.healpix_dataset import HealpixDataset as HCHealpixDataset
 from hats.pixel_math import HealpixPixel
 from hats.pixel_math.healpix_pixel_function import get_pixel_argsort
@@ -479,8 +479,13 @@ class HealpixDataset:
         """
         return self.meta.nested_columns
 
-    def compute(self, progress_bar=True, tqdm_kwargs=None) -> npd.NestedFrame:
-        """Compute dask distributed dataframe to pandas dataframe.
+    def compute(
+        self,
+        progress_bar: bool = True,
+        tqdm_kwargs: dict | None = None,
+        scheduler: str | Callable | Client | None = None,
+    ) -> npd.NestedFrame:
+        """Compute the catalog into a single in-memory NestedFrame.
 
         Note:
             This method materializes the computation result in memory. If the
@@ -488,6 +493,33 @@ class HealpixDataset:
             using ``Catalog.write_catalog`` instead. It supports automatic resumption
             via ``resume=True``, which allows recovery from both interruptions and
             late-breaking errors in long-running computations.
+
+        Parameters
+        ----------
+        progress_bar : bool, default True
+            Whether to display a progress bar while the partitions are computed.
+        tqdm_kwargs : dict or None, default None
+            Additional keyword arguments for the tqdm progress bar (for example ``desc``).
+        scheduler : str, Callable, dask.distributed.Client or None, default None
+            The scheduler that runs the task graph, with the same meaning as the ``scheduler``
+            argument of ``dask.compute``: the name of a local scheduler (``"synchronous"``,
+            ``"threads"`` or ``"processes"``), ``"distributed"``, a ``dask.distributed.Client``
+            or a scheduler ``get`` function. If None, the scheduler is resolved the way Dask
+            does: the ``scheduler`` key of the Dask configuration if set, else the default
+            ``dask.distributed.Client`` if one exists, else the threaded scheduler.
+
+        Returns
+        -------
+        npd.NestedFrame
+            The computed catalog, with the rows of all partitions concatenated.
+
+        Examples
+        --------
+        >>> import lsdb
+        >>> catalog = lsdb.generate_catalog(500, 10, seed=1)
+        >>> df = catalog.compute(progress_bar=False, scheduler="synchronous")
+        >>> len(df)
+        500
         """
         est_size = self.est_size()
         if est_size is not None and est_size > COMPUTE_SIZE_WARNING_THRESHOLD_KiB:
@@ -502,11 +534,8 @@ class HealpixDataset:
 
         desc = tqdm_kwargs.pop("desc", "Computing Catalog") if tqdm_kwargs else "Computing Catalog"
         healpix_graph = self._operation.build()
-        schedule = get_scheduler()
-        if schedule is None:
-            with TqdmCallback(desc=desc, disable=not progress_bar, **(tqdm_kwargs or {})):
-                result = threaded.get(healpix_graph.graph, healpix_graph.keys, sync=False)
-        else:
+        schedule = get_scheduler(scheduler=scheduler) or threaded.get
+        if isinstance(getattr(schedule, "__self__", None), Client):
             futures = schedule(healpix_graph.graph, healpix_graph.keys, sync=False)
             result_map = {}
             with tqdm(total=len(futures), desc=desc, disable=not progress_bar, **(tqdm_kwargs or {})) as pbar:
@@ -516,6 +545,9 @@ class HealpixDataset:
             result = [
                 result_map[healpix_graph.pixel_to_key_map[p]] for p in self.get_ordered_healpix_pixels()
             ]
+        else:
+            with TqdmCallback(desc=desc, disable=not progress_bar, **(tqdm_kwargs or {})):
+                result = schedule(healpix_graph.graph, healpix_graph.keys)
 
         # If no partitions, return an empty dataframe with the correct schema
         # This can happen through partition pruning operations

--- a/src/lsdb/catalog/dataset/healpix_dataset.py
+++ b/src/lsdb/catalog/dataset/healpix_dataset.py
@@ -22,7 +22,7 @@ from dask.delayed import Delayed
 from deprecated import deprecated  # type: ignore
 from distributed import Client, as_completed
 from hats.catalog.healpix_dataset.healpix_dataset import HealpixDataset as HCHealpixDataset
-from hats.pixel_math import HealpixPixel
+from hats.pixel_math import HealpixPixel, get_healpix_pixel
 from hats.pixel_math.healpix_pixel_function import get_pixel_argsort
 from human_readable import file_size, int_comma
 from mocpy import MOC
@@ -570,25 +570,52 @@ class HealpixDataset:
 
         return df
 
-    def to_delayed(self) -> list[Delayed]:
-        """Get a list of Dask Delayed objects for each partition in the dataset
+    def to_delayed(self, pixels: Sequence[HealpixPixel | tuple[int, int]] | None = None) -> list[Delayed]:
+        """Get a list of Dask Delayed objects, one for each partition in the dataset
 
         Used for more advanced custom operations, but to use again with LSDB, the delayed objects
         must be converted to a Dask DataFrame and used with extra metadata to construct an
         LSDB Dataset.
 
+        Parameters
+        ----------
+        pixels : sequence of HealpixPixel or (order, pixel) tuples, or None, default None
+            If given, only the task graph of these partitions is built, and one Delayed object
+            is returned per requested pixel, in the same order. This is much cheaper than
+            building the whole catalog when only a few partitions are needed at a time, for
+            example when streaming them. If None, every partition of the dataset is returned.
+
         Returns
         -------
         list[Delayed]
             A list of Dask delayed partitions.
+
+        Raises
+        ------
+        ValueError
+            If any of the requested pixels is not a partition of the dataset.
+
+        Examples
+        --------
+        Compute a single partition in the current process, without a Dask client:
+
+        >>> import lsdb
+        >>> catalog = lsdb.generate_catalog(500, 10, seed=1)
+        >>> pixel = catalog.get_healpix_pixels()[0]
+        >>> (partition,) = catalog.to_delayed(pixels=[pixel])
+        >>> df = partition.compute(scheduler="synchronous")
+        >>> len(df) == len(catalog.get_partition(pixel.order, pixel.pixel).compute(progress_bar=False))
+        True
         """
-        build = self._operation.build()
-        graph = build.graph
-        keys = build.keys
-
-        graph_delayed = [Delayed(key, graph) for key in keys]
-
-        return graph_delayed
+        if pixels is None:
+            build = self._operation.build()
+            return [Delayed(key, build.graph) for key in build.keys]
+        requested = [get_healpix_pixel(pixel) for pixel in pixels]
+        build = self._operation.build(pixels=requested)
+        missing = [pixel for pixel in requested if pixel not in build.pixel_to_key_map]
+        if missing:
+            raise ValueError(f"No data exists for pixels {missing}")
+        return [Delayed(build.pixel_to_key_map[pixel], build.graph) for pixel in requested]
 
     def _check_unloaded_columns(self, column_names: Sequence[str | None] | None):
         """Check the list of given column names for any that are valid

--- a/src/lsdb/operations/lsdb_ops.py
+++ b/src/lsdb/operations/lsdb_ops.py
@@ -406,11 +406,11 @@ class SelectPixels(Operation):
 
     def build(self, pixels: list[HealpixPixel] | None = None) -> HealpixGraph:
         """Build the HealpixGraph from the Operation."""
-        # intersect the caller's requested subset with a provided pixel filter
+        # intersect the caller's requested subset with a provided pixel filter, and only ask
+        # the base operation for those pixels instead of building its full graph and culling it
         pixel_set = set(pixels) if pixels is not None else None
-        effective = [p for p in self.pixels if pixel_set is None or p in pixel_set]
-        previous = self.base.build(pixels=effective if pixels is not None else None)
-        selected_pixels = effective if pixels is not None else self.pixels
+        selected_pixels = [p for p in self.pixels if pixel_set is None or p in pixel_set]
+        previous = self.base.build(pixels=selected_pixels)
         for p in selected_pixels:
             if p not in previous.pixel_to_key_map:
                 raise ValueError(f"Selected Pixel {p} not found in operation")

--- a/src/lsdb/operations/lsdb_ops.py
+++ b/src/lsdb/operations/lsdb_ops.py
@@ -102,12 +102,10 @@ class FromHealpixMap(Operation):
         return self.pixels
 
     def build(self, pixels: list[HealpixPixel] | None = None) -> HealpixGraph:
-        target = set(pixels) if pixels is not None else None
         graph = {}
         pixel_keys = {}
-        for i, pixel in enumerate(self.pixels):
-            if target is not None and pixel not in target:
-                continue
+        for i in self._get_build_indices(pixels):
+            pixel = self.pixels[i]
             key = (self.key_name, i)
             map_kwargs = {k: v[i] for k, v in self.map_kwargs.items()} if self.map_kwargs is not None else {}
             func = _verified(self.func, self.meta) if self.verify_meta else self.func
@@ -314,12 +312,16 @@ class MapPartitions(Operation):
     def healpix_pixels(self) -> list[HealpixPixel]:
         return self.base.healpix_pixels
 
+    @functools.cached_property
+    def _pixel_to_index(self) -> dict[HealpixPixel, int]:
+        """Share the base lookup because mapping preserves the pixel layout."""
+        return self.base._pixel_to_index  # pylint: disable=protected-access
+
     def build(self, pixels: list[HealpixPixel] | None = None) -> HealpixGraph:
         """Build the HealpixGraph from the Operation"""
         previous = self.base.build(pixels=pixels)
         graph = previous.graph
         pixel_keys = {}
-        pixel_to_index = {pixel: i for i, pixel in enumerate(self.healpix_pixels)}
         func = self.func
         include_pixel = self.include_pixel
         meta = self.meta
@@ -338,7 +340,7 @@ class MapPartitions(Operation):
                 ) from e
 
         for pixel, prev_key in previous.pixel_to_key_map.items():
-            i = pixel_to_index[pixel]
+            i = self._pixel_to_index[pixel]
             args = self.args
             if self.include_pixel:
                 args = (HealpixPixel(*pixel),) + args
@@ -408,8 +410,7 @@ class SelectPixels(Operation):
         """Build the HealpixGraph from the Operation."""
         # intersect the caller's requested subset with a provided pixel filter, and only ask
         # the base operation for those pixels instead of building its full graph and culling it
-        pixel_set = set(pixels) if pixels is not None else None
-        selected_pixels = [p for p in self.pixels if pixel_set is None or p in pixel_set]
+        selected_pixels = [self.pixels[i] for i in self._get_build_indices(pixels)]
         previous = self.base.build(pixels=selected_pixels)
         for p in selected_pixels:
             if p not in previous.pixel_to_key_map:
@@ -501,12 +502,11 @@ class AlignAndApply(Operation):
 
     def _resolve_build_subsets(
         self, pixels: list[HealpixPixel] | None
-    ) -> tuple[list[int], list[list[HealpixPixel] | None]]:
+    ) -> tuple[range | list[int], list[list[HealpixPixel] | None]]:
         """Resolve the output indices to build and the pixel subset to request from each input"""
         if pixels is None:
-            return list(range(len(self.output_pixels))), [None] * len(self.input_cats)
-        requested = set(pixels)
-        output_indices = [i for i, p in enumerate(self.output_pixels) if p in requested]
+            return range(len(self.output_pixels)), [None] * len(self.input_cats)
+        output_indices = self._get_build_indices(pixels)
         input_pixel_subsets: list[list[HealpixPixel] | None] = [
             [p for i in output_indices if (p := pixel_list[i]) is not None] for pixel_list in self.pixel_lists
         ]

--- a/src/lsdb/operations/operation.py
+++ b/src/lsdb/operations/operation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 from abc import ABC, abstractmethod
 from typing import Self
 
@@ -65,6 +66,24 @@ class Operation(ABC):
     def healpix_pixels(self) -> list[HealpixPixel]:  # pragma: no cover
         """Returns the list of HEALPix pixels that this operation's partitions correspond to"""
         pass
+
+    @functools.cached_property
+    def _pixel_to_index(self) -> dict[HealpixPixel, int]:
+        """Index the fixed pixel layout once for repeated subset builds.
+
+        Catalog transformations create new operations rather than changing an
+        existing operation's pixel layout, so this lookup can be reused.
+        """
+        return {pixel: i for i, pixel in enumerate(self.healpix_pixels)}
+
+    def _get_build_indices(self, pixels: list[HealpixPixel] | None) -> range | list[int]:
+        """Resolve a subset in operation order, retaining the original task indices."""
+        if pixels is None:
+            return range(len(self.healpix_pixels))
+        if not pixels:
+            return []
+        pixel_to_index = self._pixel_to_index
+        return sorted({pixel_to_index[pixel] for pixel in pixels if pixel in pixel_to_index})
 
     def optimize(self) -> Self:  # pragma: no cover
         """Returns an optimized version of the operation."""

--- a/src/lsdb/streams/catalog_streams.py
+++ b/src/lsdb/streams/catalog_streams.py
@@ -4,7 +4,6 @@ from typing import Optional
 import dask
 import numpy as np
 import pandas as pd
-from dask.delayed import Delayed
 from dask.distributed import Client, Future
 
 from lsdb import Catalog
@@ -87,8 +86,7 @@ class CatalogStream:
         if not isinstance(catalog, Catalog):
             raise ValueError(f"The provided catalog input type {type(catalog)} is not a lsdb.Catalog object.")
 
-        self.operation = catalog._operation  # pylint: disable=protected-access
-        self._pixels = catalog._operation.healpix_pixels  # pylint: disable=protected-access
+        self._pixels = catalog.get_healpix_pixels()
 
         self.client = client
         self.partitions_per_chunk = min(partitions_per_chunk, self.catalog.npartitions)
@@ -112,15 +110,7 @@ class CatalogStream:
 
     def submit_next_partitions(self, partitions: np.ndarray) -> Future | _FakeFuture:
         """Submit the next set of partitions for computation."""
-
-        # Intended to be used with single partition builds
-        def _to_delayed(operation, pixel):
-            build = operation.build(pixels=[pixel])
-            graph = build.graph
-            key = build.pixel_to_key_map[pixel]
-            return Delayed(key, graph)
-
-        selected = [_to_delayed(self.operation, self._pixels[i]) for i in partitions]
+        selected = self.catalog.to_delayed(pixels=[self._pixels[i] for i in partitions])
 
         if len(selected) == 1:
             if self.client is None:

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -2,7 +2,9 @@
 from pathlib import Path
 
 import astropy.units as u
+import dask
 import dask.dataframe as dd
+import dask.local
 import hats as hc
 import hats.io.file_io
 import hats.pixel_math.healpix_shim as hp
@@ -131,6 +133,63 @@ def test_catalog_compute_with_distributed_client_progress_bar_kwargs(small_sky_o
 
     n_partitions = len(small_sky_order1_catalog.get_healpix_pixels())
     tqdm_mock.assert_called_once_with(total=n_partitions, desc="Custom Desc", disable=False, ascii=True)
+
+
+@pytest.mark.parametrize("scheduler", ["synchronous", "threads"])
+def test_catalog_compute_with_configured_local_scheduler(small_sky_order1_catalog, scheduler):
+    expected = small_sky_order1_catalog.compute(progress_bar=False)
+    with dask.config.set(scheduler=scheduler):
+        result = small_sky_order1_catalog.compute(progress_bar=False)
+    pd.testing.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("scheduler", ["synchronous", "threads"])
+def test_catalog_compute_with_scheduler_argument(small_sky_order1_catalog, scheduler, mocker):
+    tqdm_callback = mocker.patch("lsdb.catalog.dataset.healpix_dataset.TqdmCallback")
+    expected = small_sky_order1_catalog.compute(progress_bar=False)
+    tqdm_callback.reset_mock()
+
+    result = small_sky_order1_catalog.compute(scheduler=scheduler)
+
+    pd.testing.assert_frame_equal(result, expected)
+    tqdm_callback.assert_called_once_with(desc="Computing Catalog", disable=False)
+
+
+def test_catalog_compute_with_scheduler_callable(small_sky_order1_catalog):
+    calls = []
+
+    def get(dsk, keys, **kwargs):
+        calls.append(keys)
+        return dask.local.get_sync(dsk, keys, **kwargs)
+
+    result = small_sky_order1_catalog.compute(progress_bar=False, scheduler=get)
+
+    assert len(calls) == 1
+    pd.testing.assert_frame_equal(result, small_sky_order1_catalog.compute(progress_bar=False))
+
+
+def test_catalog_compute_scheduler_argument_beats_default_client(small_sky_order1_catalog, mocker):
+    expected = small_sky_order1_catalog.compute(progress_bar=False)
+    with local_client() as client:
+        client_get = mocker.spy(client, "get")
+        result = small_sky_order1_catalog.compute(progress_bar=False, scheduler="synchronous")
+    assert client_get.call_count == 0
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_catalog_compute_with_client_argument(small_sky_order1_catalog, mocker):
+    tqdm_mock = mocker.patch("lsdb.catalog.dataset.healpix_dataset.tqdm")
+    expected = small_sky_order1_catalog.compute(progress_bar=False)
+    with local_client() as client:
+        result = small_sky_order1_catalog.compute(progress_bar=False, scheduler=client)
+    pd.testing.assert_frame_equal(result, expected)
+    n_partitions = len(small_sky_order1_catalog.get_healpix_pixels())
+    tqdm_mock.assert_called_once_with(total=n_partitions, desc="Computing Catalog", disable=True)
+
+
+def test_catalog_compute_with_unknown_scheduler_raises(small_sky_order1_catalog):
+    with pytest.raises(ValueError, match="Expected one of"):
+        small_sky_order1_catalog.compute(progress_bar=False, scheduler="not-a-scheduler")
 
 
 def test_catalog_compute_empty_with_distributed_client(small_sky_order1_catalog):

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -1272,3 +1272,46 @@ def test_filter_empty_catalog_and(small_sky_order1_catalog):
     assert isinstance(computed, npd.NestedFrame)
     assert len(computed) == 0
     assert computed.columns.tolist() == empty_catalog.columns.tolist()
+
+
+def test_to_delayed_returns_all_partitions(small_sky_order1_catalog):
+    delayed = small_sky_order1_catalog.to_delayed()
+    assert len(delayed) == small_sky_order1_catalog.npartitions
+    result = npd.NestedFrame(pd.concat(dask.compute(*delayed, scheduler="synchronous")))
+    pd.testing.assert_frame_equal(result, small_sky_order1_catalog.compute(progress_bar=False))
+
+
+def test_to_delayed_pixels(small_sky_order1_catalog):
+    pixels = small_sky_order1_catalog.get_healpix_pixels()
+    requested = [pixels[2], pixels[0]]
+
+    delayed = small_sky_order1_catalog.to_delayed(pixels=requested)
+
+    assert len(delayed) == 2
+    for partition, pixel in zip(delayed, requested):
+        # only the requested partitions are in the graph, and no scheduler configuration is needed
+        assert len(dict(partition.dask)) == 2
+        expected = small_sky_order1_catalog.get_partition(pixel.order, pixel.pixel).compute(
+            progress_bar=False
+        )
+        pd.testing.assert_frame_equal(partition.compute(scheduler="synchronous"), expected)
+
+
+def test_to_delayed_pixels_accepts_order_pixel_tuples(small_sky_order1_catalog):
+    pixel = small_sky_order1_catalog.get_healpix_pixels()[1]
+    (partition,) = small_sky_order1_catalog.to_delayed(pixels=[(pixel.order, pixel.pixel)])
+    expected = small_sky_order1_catalog.get_partition(pixel.order, pixel.pixel).compute(progress_bar=False)
+    pd.testing.assert_frame_equal(partition.compute(scheduler="synchronous"), expected)
+
+
+def test_to_delayed_pixels_on_crossmatch(small_sky_catalog, small_sky_xmatch_catalog):
+    xmatch = small_sky_catalog.crossmatch(small_sky_xmatch_catalog, radius_arcsec=0.01 * 3600)
+    pixel = xmatch.get_healpix_pixels()[0]
+    (partition,) = xmatch.to_delayed(pixels=[pixel])
+    expected = xmatch.get_partition(pixel.order, pixel.pixel).compute(progress_bar=False)
+    pd.testing.assert_frame_equal(partition.compute(scheduler="synchronous"), expected)
+
+
+def test_to_delayed_unknown_pixel_raises(small_sky_order1_catalog):
+    with pytest.raises(ValueError, match="No data exists for pixels"):
+        small_sky_order1_catalog.to_delayed(pixels=[HealpixPixel(5, 5)])

--- a/tests/lsdb/catalog/test_catalog.py
+++ b/tests/lsdb/catalog/test_catalog.py
@@ -1304,6 +1304,28 @@ def test_to_delayed_pixels_accepts_order_pixel_tuples(small_sky_order1_catalog):
     pd.testing.assert_frame_equal(partition.compute(scheduler="synchronous"), expected)
 
 
+def test_to_delayed_pixels_preserves_duplicate_requests(small_sky_order1_catalog):
+    pixels = small_sky_order1_catalog.get_healpix_pixels()
+    requested = [pixels[1], pixels[0], pixels[1]]
+
+    delayed = small_sky_order1_catalog.to_delayed(pixels=requested)
+
+    assert len(delayed) == 3
+    assert delayed[0].key == delayed[2].key
+    assert delayed[0].key != delayed[1].key
+    assert len(dict(delayed[0].dask)) == 2
+    results = dask.compute(*delayed, scheduler="synchronous")
+    for pixel, result in zip(requested, results):
+        expected = small_sky_order1_catalog.get_partition(pixel.order, pixel.pixel).compute(
+            progress_bar=False
+        )
+        pd.testing.assert_frame_equal(result, expected)
+
+
+def test_to_delayed_explicit_empty_subset(small_sky_order1_catalog):
+    assert small_sky_order1_catalog.to_delayed(pixels=[]) == []
+
+
 def test_to_delayed_pixels_on_crossmatch(small_sky_catalog, small_sky_xmatch_catalog):
     xmatch = small_sky_catalog.crossmatch(small_sky_xmatch_catalog, radius_arcsec=0.01 * 3600)
     pixel = xmatch.get_healpix_pixels()[0]
@@ -1312,6 +1334,10 @@ def test_to_delayed_pixels_on_crossmatch(small_sky_catalog, small_sky_xmatch_cat
     pd.testing.assert_frame_equal(partition.compute(scheduler="synchronous"), expected)
 
 
-def test_to_delayed_unknown_pixel_raises(small_sky_order1_catalog):
+@pytest.mark.parametrize("include_known", [False, True])
+def test_to_delayed_unknown_pixel_raises(small_sky_order1_catalog, include_known):
+    pixels = [HealpixPixel(5, 5)]
+    if include_known:
+        pixels.extend(small_sky_order1_catalog.get_healpix_pixels()[:1])
     with pytest.raises(ValueError, match="No data exists for pixels"):
-        small_sky_order1_catalog.to_delayed(pixels=[HealpixPixel(5, 5)])
+        small_sky_order1_catalog.to_delayed(pixels=pixels)

--- a/tests/lsdb/io/test_to_hats.py
+++ b/tests/lsdb/io/test_to_hats.py
@@ -2,6 +2,7 @@ import shutil
 from importlib.metadata import version
 from pathlib import Path
 
+import dask
 import hats as hc
 import numpy as np
 import numpy.testing as npt
@@ -588,3 +589,13 @@ def test_save_catalog_no_summary_by_default(small_sky_order1_catalog, tmp_path):
     base_catalog_path = tmp_path / "small_sky"
     small_sky_order1_catalog.write_catalog(base_catalog_path, as_collection=False)
     assert not (base_catalog_path / "README.md").exists()
+
+
+def test_write_catalog_with_configured_local_scheduler(small_sky_order1_catalog, tmp_path):
+    base_catalog_path = tmp_path / "small_sky_order1"
+    with dask.config.set(scheduler="synchronous"):
+        small_sky_order1_catalog.write_catalog(base_catalog_path, catalog_name="small_sky_order1")
+    written = lsdb.open_catalog(base_catalog_path)
+    pd.testing.assert_frame_equal(
+        written.compute(progress_bar=False), small_sky_order1_catalog.compute(progress_bar=False)
+    )

--- a/tests/lsdb/operations/test_ops.py
+++ b/tests/lsdb/operations/test_ops.py
@@ -1,3 +1,4 @@
+import dask
 import nested_pandas as npd
 import pandas as pd
 import pytest
@@ -44,6 +45,77 @@ def test_meta_inferred_with_map_kwargs_raises_type_error():
     # inferring meta, so the first pixel's func call is missing `scale`.
     with pytest.raises(TypeError):
         _ = op.meta
+
+
+def test_from_healpix_map_subset_preserves_positions_and_map_kwargs():
+    def scaled_frame(pixel, scale):
+        frame = _make_frame(pixel)
+        frame["a"] *= scale
+        return frame
+
+    pixels = [HealpixPixel(0, i) for i in [2, 0, 3, 1]]
+    scales = [10, 20, 30, 40]
+    op = FromHealpixMap(scaled_frame, pixels, meta=_base_meta(), map_kwargs={"scale": scales})
+    graph = op.build(pixels=[pixels[3], pixels[1], pixels[3], HealpixPixel(5, 5)])
+
+    assert list(graph.pixel_to_key_map) == [pixels[1], pixels[3]]
+    assert graph.keys == [(op.key_name, 1), (op.key_name, 3)]
+    assert len(graph.graph) == 2
+    for index, result in zip([1, 3], dask.get(graph.graph, graph.keys)):
+        expected = npd.NestedFrame(scaled_frame(pixels[index], scales[index]))
+        pd.testing.assert_frame_equal(result, expected)
+
+
+class _CountingPixels(list):
+    """Track full pixel-list traversal without relying on wall-clock timings."""
+
+    def __init__(self, pixels):
+        super().__init__(pixels)
+        self.iterations = 0
+
+    def __iter__(self):
+        self.iterations += 1
+        return super().__iter__()
+
+
+def test_mapping_chain_indexes_pixel_layout_only_once():
+    pixels = _CountingPixels([HealpixPixel(0, i) for i in range(8)])
+    op = FromHealpixMap(_make_frame, pixels, meta=_base_meta())
+    for _ in range(3):
+        op = MapPartitions(op, _func, meta=_base_meta())
+
+    op.build(pixels=[pixels[3]])
+
+    assert pixels.iterations == 1
+
+
+@pytest.mark.parametrize("kind", ["source", "mapped", "selected", "aligned"])
+def test_repeated_subset_builds_do_not_rescan_all_pixels(kind):
+    pixels = _CountingPixels([HealpixPixel(0, i) for i in range(8)])
+    base = FromHealpixMap(_make_frame, pixels, meta=_base_meta())
+    if kind == "mapped":
+        op = MapPartitions(base, _func, meta=_base_meta())
+    elif kind == "selected":
+        op = MapPartitions(SelectPixels(base, pixels), _func, meta=_base_meta())
+    elif kind == "aligned":
+        op = AlignAndApply([], [], _func_aa, _meta_aa(), pixels)
+    else:
+        op = base
+
+    op.build(pixels=[pixels[3]])
+    initial_iterations = pixels.iterations
+    for index in [5, 1, 7]:
+        graph = op.build(pixels=[pixels[index]])
+        assert list(graph.pixel_to_key_map) == [pixels[index]]
+        assert graph.keys == [(op.key_name, index)]
+        assert len(graph.graph) <= 2
+    assert pixels.iterations == initial_iterations
+
+    empty = op.build(pixels=[])
+    missing = op.build(pixels=[HealpixPixel(5, 5)])
+    assert empty.graph == missing.graph == {}
+    assert empty.pixel_to_key_map == missing.pixel_to_key_map == {}
+    assert pixels.iterations == initial_iterations
 
 
 @pytest.mark.parametrize(
@@ -320,6 +392,22 @@ def test_select_pixels_build_intersects_requested_pixels():
     assert len(graph.graph) == 1
 
 
+def test_select_pixels_chain_preserves_local_partition_indices():
+    pixels = [HealpixPixel(0, i) for i in range(4)]
+    base = FromHealpixMap(_make_frame, pixels, meta=_base_meta())
+    selected = SelectPixels(base, [pixels[2], pixels[0], pixels[3]])
+    mapped = MapPartitions(selected, _func, meta=_base_meta())
+    op = SelectPixels(mapped, [pixels[3], pixels[2]])
+
+    graph = op.build(pixels=[pixels[2], pixels[3], pixels[2], HealpixPixel(5, 5)])
+
+    assert list(graph.pixel_to_key_map) == [pixels[3], pixels[2]]
+    assert graph.keys == [(mapped.key_name, 2), (mapped.key_name, 0)]
+    assert len(graph.graph) == 4
+    for pixel, result in zip([pixels[3], pixels[2]], dask.get(graph.graph, graph.keys)):
+        pd.testing.assert_frame_equal(result, npd.NestedFrame(_make_frame(pixel)))
+
+
 def _meta_aa():
     return npd.NestedFrame({"a": pd.Series(dtype="int64")})
 
@@ -362,3 +450,31 @@ def test_align_and_apply_name_includes_func_and_input_op_names_or_none():
     )
 
     assert aa.name == f"AlignAndApply({funcname(_func_aa)}, {op1.name}, None, {op2.name})"
+
+
+def test_align_and_apply_subset_preserves_alignment_and_shared_inputs(mocker):
+    def take_input(frame, absent, _pixel, absent_pixel, info, absent_info):
+        assert absent is absent_pixel is info is absent_info is None
+        return frame
+
+    pixels = [HealpixPixel(0, i) for i in range(4)]
+    base = FromHealpixMap(_make_frame, pixels[:1], meta=_base_meta())
+    catalog = mocker.Mock(_operation=base, hc_structure=mocker.Mock(catalog_info=None))
+    op = AlignAndApply(
+        [catalog, None],
+        [[None, pixels[0], pixels[0], pixels[3]], [None] * 4],
+        take_input,
+        _base_meta(),
+        pixels,
+    )
+
+    graph = op.build(pixels=[pixels[2], pixels[0], pixels[1], pixels[2], pixels[3]])
+
+    assert list(graph.pixel_to_key_map) == pixels
+    assert graph.keys == [(op.key_name, i) for i in range(4)]
+    # Two outputs share one input task; explicit None and unavailable inputs receive empty metadata.
+    assert len(graph.graph) == 5
+    results = dask.get(graph.graph, graph.keys)
+    for index, result in enumerate(results):
+        expected = _base_meta() if index in [0, 3] else npd.NestedFrame(_make_frame(pixels[0]))
+        pd.testing.assert_frame_equal(result, expected)

--- a/tests/lsdb/operations/test_ops.py
+++ b/tests/lsdb/operations/test_ops.py
@@ -297,6 +297,29 @@ def test_select_pixels_build_raises_for_pixel_not_in_base():
         op.build()
 
 
+def test_select_pixels_build_requests_only_selected_pixels_from_base(mocker):
+    base = _base_select()
+    selected = base.healpix_pixels[:1]
+    op = SelectPixels(base, selected)
+    base_build = mocker.spy(base, "build")
+
+    graph = op.build()
+
+    base_build.assert_called_once_with(pixels=selected)
+    assert list(graph.pixel_to_key_map) == selected
+    assert len(graph.graph) == 1
+
+
+def test_select_pixels_build_intersects_requested_pixels():
+    base = _base_select()
+    op = SelectPixels(base, base.healpix_pixels)
+
+    graph = op.build(pixels=[HealpixPixel(0, 1), HealpixPixel(5, 5)])
+
+    assert list(graph.pixel_to_key_map) == [HealpixPixel(0, 1)]
+    assert len(graph.graph) == 1
+
+
 def _meta_aa():
     return npd.NestedFrame({"a": pd.Series(dtype="int64")})
 


### PR DESCRIPTION
Requesting a few catalog partitions could construct or repeatedly scan catalog-wide graphs, and `compute()` treated configured local schedulers as distributed clients. This PR supports efficient partition requests and local execution through public APIs.

- Add `HealpixDataset.to_delayed(pixels=...)`, accepting HEALPix pixels or `(order, pixel)` tuples. Results preserve request order and duplicates; unknown pixels raise `ValueError`, an empty selection returns no partitions, and omitting `pixels` retains full-catalog behavior.
- Route `CatalogStream` through `to_delayed()` and `get_healpix_pixels()`, and make `SelectPixels.build()` request only its selected pixels from dependencies.
- Cache original pixel indices for repeated subset builds in `FromHealpixMap`, `MapPartitions`, `SelectPixels`, and `AlignAndApply`. Mapping and column-selection chains share their base lookup. Original task indices, positional arguments, internal ordering, and shared alignment dependencies are preserved.
- Add `HealpixDataset.compute(scheduler=...)` with normal Dask scheduler resolution. Fix computation and catalog writes under configured local schedulers while retaining distributed futures and progress reporting.

For example, a consumer can compute one partition in its own process without a distributed client:

```python
(partition,) = catalog.to_delayed(pixels=[pixel])
df = partition.compute(scheduler="synchronous")
```

Native subset builds construct each pixel lookup once, then resolve only the requested pixels on subsequent calls. Sorting selected indices preserves operation order. Dask-expression-backed operations still construct their underlying graph before culling; this change does not optimize that separate path.

Validation:

- `PYTHONPATH=src python -m pytest tests/lsdb/operations/test_ops.py tests/lsdb/catalog/test_catalog.py tests/lsdb/catalog/test_crossmatch.py -q`: **200 passed, 1 skipped**.
- Black, isort, pylint, and mypy pass for the four files changed by the subset-index optimization.
- Structural regression tests fail against the previous implementation when repeated subset requests traverse full pixel lists. Additional coverage verifies that mapping chains construct their shared index once, alongside scheduler selection, output equivalence, reordered/duplicate/empty/missing requests, stable task indices, and shared or absent alignment inputs.

Broader local validation also exposed an existing `test_resume_catalog_write` assertion that compares unsorted filesystem listings. The same failure was reproduced on the unmodified baseline; its catalog-content checks pass.
