### PR TITLE
Pass storage options on catalog open.

### DIFF
--- a/src/lsdb/loaders/hats/read_hats.py
+++ b/src/lsdb/loaders/hats/read_hats.py
@@ -39,7 +39,7 @@ def open_catalog(
     filters: list[tuple[str]] | None = None,
     path_generator: Callable[[UPath, HealpixPixel, dict | None, str], UPath] = hc.io.pixel_catalog_file,
     show_statistics: bool = False,
-    storage_options: dict|None = None,
+    storage_options: dict | None = None,
     **kwargs,
 ) -> Catalog:
     """Open a catalog from a HATS path.
@@ -146,7 +146,7 @@ def read_hats(
     error_empty_filter: bool = True,
     filters: list[tuple[str]] | None = None,
     path_generator: Callable[[UPath, HealpixPixel, dict | None, str], UPath] = hc.io.pixel_catalog_file,
-    storage_options: dict|None = None,
+    storage_options: dict | None = None,
     **kwargs,
 ) -> HealpixDataset:
     """Load dataset from a HATS path.

--- a/src/lsdb/loaders/hats/read_hats.py
+++ b/src/lsdb/loaders/hats/read_hats.py
@@ -31,6 +31,7 @@ MAX_PYARROW_FILTERS = 10
 
 def open_catalog(
     path: str | Path | UPath,
+    *,
     search_filter: AbstractSearch | None = None,
     columns: list[str] | str | None = None,
     margin_cache: str | Path | UPath | None = None,
@@ -38,6 +39,7 @@ def open_catalog(
     filters: list[tuple[str]] | None = None,
     path_generator: Callable[[UPath, HealpixPixel, dict | None, str], UPath] = hc.io.pixel_catalog_file,
     show_statistics: bool = False,
+    storage_options: dict|None = None,
     **kwargs,
 ) -> Catalog:
     """Open a catalog from a HATS path.
@@ -110,6 +112,8 @@ def open_catalog(
         Defaults to `hats.io.pixel_catalog_file`.
     show_statistics : bool, default False
         If True, the catalog's repr displays a per-column statistics table (min/max values).
+    storage_options: dict or None, default None
+        additional options for connecting to the catalog, or a collection's affiliated tables.
     **kwargs
         Arguments to pass to the pandas parquet file reader
 
@@ -118,7 +122,7 @@ def open_catalog(
     HealpixDataset
         The catalog loaded according to the specified arguments.
     """
-    hc_catalog = hc.read_hats(path)
+    hc_catalog = hc.read_hats(path, storage_options=storage_options)
     if not isinstance(hc_catalog, (hc.catalog.CatalogCollection, hc.catalog.Catalog)):
         raise TypeError("To load auxiliary datasets please use `lsdb.read_hats()`")
     return _read_dataset(
@@ -142,6 +146,7 @@ def read_hats(
     error_empty_filter: bool = True,
     filters: list[tuple[str]] | None = None,
     path_generator: Callable[[UPath, HealpixPixel, dict | None, str], UPath] = hc.io.pixel_catalog_file,
+    storage_options: dict|None = None,
     **kwargs,
 ) -> HealpixDataset:
     """Load dataset from a HATS path.
@@ -173,6 +178,8 @@ def read_hats(
           - npix_suffix: str - "/" for leaf directory, filename suffix like ".parquet" for leaf file
         The catalog metadata files need to live where the HATS standard expects them.
         Defaults to `hats.io.pixel_catalog_file`.
+    storage_options: dict or None, default None
+        additional options for connecting to the catalog, or a collection's affiliated tables.
     **kwargs
         Arguments to pass to the pandas parquet file reader
 
@@ -181,7 +188,7 @@ def read_hats(
     HealpixDataset
         A valid HATS dataset.
     """
-    hc_catalog = hc.read_hats(path)
+    hc_catalog = hc.read_hats(path, storage_options=storage_options)
     return _read_dataset(
         hc_catalog,
         search_filter=search_filter,


### PR DESCRIPTION
Part of addressing https://github.com/astronomy-commons/hats/pull/673

Requires https://github.com/astronomy-commons/hats/pull/714

Just passes storage options through to `hats.read_hats` calls, so the options can be used in read, and for subsequent path construction on catalog collections.